### PR TITLE
M2 统一 Docker 构建镜像 sophon-tools-build（含 dfss 私有工具链 + windows release）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ source/psophliteos/build/sophliteos/DEBIAN/control
 docs/superpowers/
 **/docs/superpowers/
 .superpowers/
+
+# pnpm 缓存
+.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ output/*
 *.tar
 *.tar.gz
 *.AppImage
+# dfss 私有工具链归档（从 13.24 容器导出，体积大，不入库）
+docker/toolchains/
 
 
 # Model file

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,139 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# sophon-tools-build —— sophon-tools 17 子项目统一编译镜像
+#
+# 设计:
+#   * 多阶段构建: Stage1 下载并校验国外大体积工具链(Go/Node); Stage2 汇入运行镜像。
+#   * 版本唯一来源 docker/versions.env(由 docker/build.sh 注入 ARG), 全部版本锁定。
+#   * 交叉工具链: apt 精确版本(glibc) + musl.cc(静态) + dfss 私有工具链(sw_64/loongarch64)。
+#   * dfss 私有工具链默认不内置(私有源, 体积大); 通过 --with-dfss-toolchains 或构建上下文
+#     toolchains/ 目录内置。
+#
+# 构建(一条命令):  bash docker/build.sh
+# 构建(含私有工具链): bash docker/build.sh --with-dfss-toolchains
+# =============================================================================
+
+# ---- ARG 集合(由 build.sh 从 versions.env 注入) ----
+ARG UBUNTU_BASE_DIGEST
+ARG GO_VERSION GO_TARBALL_URL GO_TARBALL_SHA256
+ARG RUST_VERSION
+ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
+ARG PNPM_VERSION YARN_VERSION
+ARG WITH_DFSS=0
+
+# ---- Stage 1: 下载 + 校验(仅构建期需要, 不进入最终镜像) ----
+FROM ${UBUNTU_BASE_DIGEST} AS downloader
+ARG GO_VERSION GO_TARBALL_URL GO_TARBALL_SHA256
+ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
+ARG RUST_VERSION
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl xz-utils bzip2 zstd \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /dl
+# Go 工具链: 下载 + SHA256 校验
+RUN curl -fsSL "${GO_TARBALL_URL}" -o go.tar.gz \
+    && echo "${GO_TARBALL_SHA256}  go.tar.gz" | sha256sum -c - \
+    && tar -C /opt -xzf go.tar.gz \
+    && /opt/go/bin/go version
+# Node.js: 下载 + SHA256 校验
+RUN curl -fsSL "${NODE_TARBALL_URL}" -o node.tar.xz \
+    && echo "${NODE_TARBALL_SHA256}  node.tar.xz" | sha256sum -c - \
+    && mkdir -p /opt/nodejs && tar -C /opt/nodejs --strip-components=1 -xJf node.tar.xz \
+    && /opt/nodejs/bin/node --version
+
+# ---- Stage 2: 最终运行镜像 ----
+FROM ${UBUNTU_BASE_DIGEST}
+ARG GO_VERSION RUST_VERSION PNPM_VERSION YARN_VERSION WITH_DFSS
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH="/opt/go/bin:/opt/nodejs/bin:/opt/rust/bin:/opt/musl/aarch64-linux-musl-cross/bin:/opt/musl/x86_64-linux-musl-cross/bin:/usr/local/go/bin:${PATH}"
+
+SHELL ["/bin/bash", "-c"]
+
+# ---- 系统依赖 + apt 交叉工具链(精确版本, 由 ubuntu:22.04 仓库固定) ----
+# pdfss_cpp 8 架构: aarch64/armel/riscv64 + mingw-w64(windows amd64/i686)
+# Rust/Go 静态: musl 工具链在 PATH(由 pbmssm 的 fetch-musl-toolchain.sh 识别复用)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential gcc g++ make cmake pkg-config \
+        gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+        gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \
+        gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
+        gcc-mingw-w64-x86-64 gcc-mingw-w64-i686 \
+        dpkg dpkg-dev fakeroot \
+        qtbase5-dev qttools5-dev-tools \
+        ca-certificates curl wget git \
+        zip unzip p7zip-full patchelf \
+        python3 python3-pip python3-dev \
+        brotli zstd xz-utils bzip2 \
+        libssl-dev libtool autoconf automake \
+        file binutils upx-ucl \
+        qemu-user qemu-user-static binfmt-support \
+        libfuse2 ssh strace \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- Go(来自 Stage1, 已校验) ----
+COPY --from=downloader /opt/go /opt/go
+RUN /opt/go/bin/go version
+
+# ---- Node.js + pnpm + yarn(来自 Stage1, 已校验) ----
+COPY --from=downloader /opt/nodejs /opt/nodejs
+ENV PATH="/opt/nodejs/bin:${PATH}"
+RUN npm install -g "pnpm@${PNPM_VERSION}" "yarn@${YARN_VERSION}" \
+    && node --version && pnpm --version && yarn --version
+
+# ---- Rust(rustup 锁定版本, 含 aarch64/x86_64 musl + gnu target + 交叉链接器) ----
+RUN curl -fsSL https://sh.rustup.rs -o /tmp/rustup-init.sh \
+    && chmod +x /tmp/rustup-init.sh \
+    && RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/cargo /tmp/rustup-init.sh \
+        -y --default-toolchain "${RUST_VERSION}" \
+        --profile minimal \
+        --component clippy --component rustfmt \
+    && rm /tmp/rustup-init.sh
+ENV RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/cargo \
+    PATH="/opt/cargo/bin:${PATH}"
+RUN rustup target add aarch64-unknown-linux-musl aarch64-unknown-linux-gnu \
+                             x86_64-unknown-linux-musl \
+    && rustc --version && cargo --version \
+    && mkdir -p "${CARGO_HOME}" \
+    && printf '[target.aarch64-unknown-linux-musl]\nlinker = "aarch64-linux-musl-gcc"\nrustflags = ["-C", "link-arg=-s"]\n' > "${CARGO_HOME}/config.toml"
+
+# ---- musl 交叉工具链(静态链接: pbmssm/psophliteos/pbm_set_ip) ----
+# 预置 aarch64 + x86_64; 若构建期网络受限, 子项目脚本会自行从 musl.cc 拉取。
+RUN mkdir -p /opt/musl \
+    && curl -fsSL "https://musl.cc/aarch64-linux-musl-cross.tgz" -o /tmp/musl-aarch64.tgz \
+    && tar -C /opt/musl -xzf /tmp/musl-aarch64.tgz && rm /tmp/musl-aarch64.tgz \
+    && curl -fsSL "https://musl.cc/x86_64-linux-musl-cross.tgz" -o /tmp/musl-x86_64.tgz \
+    && tar -C /opt/musl -xzf /tmp/musl-x86_64.tgz && rm /tmp/musl-x86_64.tgz \
+    && aarch64-linux-musl-gcc --version | head -1 && x86_64-linux-musl-gcc --version | head -1
+
+# ---- dfss 私有工具链(sw_64 / loongarch64)----
+# 构建上下文需含 toolchains/ 目录(由 export-dfss-toolchains.sh 导出), 或用 --with-dfss-toolchains。
+# 注意: sw_64 工具链 gcc 编译期 prefix 硬编码为 /usr/sw/swgcc830_cross_tools,
+#       loongarch64 硬编码为 /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1,
+#       故解压到容器内原始路径, 保证绝对引用全部有效(与 13.24 源容器一致)。
+ARG WITH_DFSS=0
+COPY toolchains/ /tmp/toolchains/
+RUN if [ "${WITH_DFSS}" = "1" ] || [ -n "$(ls /tmp/toolchains 2>/dev/null)" ]; then \
+        if [ -f /tmp/toolchains/swgcc830_cross_tools.tar.zst ]; then \
+            mkdir -p /usr/sw \
+            && tar -C /usr/sw -I zstd -xf /tmp/toolchains/swgcc830_cross_tools.tar.zst; \
+        fi \
+        && if [ -f /tmp/toolchains/loongarch64-cross-tools.tar.zst ]; then \
+            mkdir -p /env \
+            && tar -C /env -I zstd -xf /tmp/toolchains/loongarch64-cross-tools.tar.zst; \
+        fi \
+        && rm -rf /tmp/toolchains; \
+    fi
+ENV DFSS_TOOLCHAIN_ROOT="/usr/sw/swgcc830_cross_tools" \
+    PATH="/usr/sw/swgcc830_cross_tools/usr/bin:/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:${PATH}"
+
+# ---- 工作区约定 ----
+WORKDIR /workspace
+RUN git config --global --add safe.directory "*" \
+    && printf '#!/bin/bash\nif [ -x /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc ] && [ -x /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc ]; then\n  echo "[sophon-tools-build] dfss 私有工具链已就绪 (sw_64 + loongarch64)"\nelse\n  echo "[sophon-tools-build] dfss 私有工具链未内置 (构建时加 --with-dfss-toolchains)"\nfi\n' > /usr/local/bin/dfss-check \
+    && chmod +x /usr/local/bin/dfss-check
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
         gcc-arm-linux-gnueabi g++-arm-linux-gnueabi \
         gcc-riscv64-linux-gnu g++-riscv64-linux-gnu \
-        gcc-mingw-w64-x86-64 gcc-mingw-w64-i686 \
+        gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 gcc-mingw-w64-i686 g++-mingw-w64-i686 \
         dpkg dpkg-dev fakeroot \
         qtbase5-dev qttools5-dev-tools \
         ca-certificates curl wget git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -71,7 +71,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libssl-dev libtool autoconf automake \
         file binutils upx-ucl \
         qemu-user qemu-user-static binfmt-support \
-        libfuse2 ssh strace \
+        libfuse2 ssh strace pandoc sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # ---- Go(来自 Stage1, 已校验) ----

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,135 @@
+# sophon-tools-build —— sophon-tools 统一编译镜像
+
+`docker/` 目录是 sophon-tools 17 子项目的统一构建镜像交付物。镜像预装全部子项目所需工具链，
+子项目构建只需基于此镜像，不再依赖构建机预装环境。
+
+## 一条命令构建镜像
+
+```bash
+# 基础镜像（不含 dfss 私有工具链 sw_64/loongarch64）
+bash docker/build.sh
+
+# 完整镜像（内置 dfss 私有工具链，需先在 13.24 服务器上执行导出脚本）
+bash docker/build.sh --with-dfss-toolchains
+
+# 指定标签 / 禁用缓存
+bash docker/build.sh --tag v1.0 --no-cache
+```
+
+### 版本锁定（可复现）
+
+- 唯一版本源：`docker/versions.env` —— 全部工具链版本 + 校验和统一在此维护。
+- 基础镜像 `ubuntu:22.04` 用 **digest**（不可变引用）锁定，不用 tag。
+- Go / Node 下载后做 **SHA256 校验**（校验失败即中止构建）。
+- Rust 用 rustup 锁定稳定版 `1.97.1`；musl 工具链来自 musl.cc。
+- 想固定 musl 工具链内容：把首次构建打印的实际 SHA256 填入 `versions.env` 的 `MUSL_*_SHA256`。
+
+## 镜像内工具链（对照 M1 盘点清单）
+
+| 子项目 | 工具链 | 版本 |
+|--------|--------|------|
+| pbmssm / psophliteos | Go | 1.25.5（含 arm64/amd64 交叉） |
+| pbm_set_ip | Rust + cargo | 1.97.1（aarch64/x86_64 musl + aarch64 gnu target） |
+| psophliteos 前端 | Node + pnpm + yarn | Node 20.19.0 / pnpm 9.15.9 / yarn 1.22.22 |
+| pbmssm / pbm_set_ip | musl 交叉工具链 | aarch64 + x86_64（musl.cc 静态） |
+| pdfss_cpp | glibc 交叉工具链 | aarch64 / armel / riscv64（apt 精确版本） |
+| pdfss_cpp (windows) | mingw-w64 | x86_64-w64-mingw32 + i686-w64-mingw32 |
+| pdfss_cpp (私有) | sw_64 + loongarch64 | SWREACH GCC 8.3.0 / LoongArch 8.3.0（dfss 私有源） |
+| pqt 系列 | Qt 5 + qmake | qtbase5-dev（AppImage 依赖） |
+| 打包/文档 | dpkg-deb / 7z / zip / upx / patchelf / pandoc | apt 精确版本 |
+| 跨架构验证 | qemu-user-static | aarch64 / loongarch64 等 |
+
+## dfss 私有工具链（sw_64 / loongarch64）
+
+sw_64 和 loongarch64 工具链来自 dfss 私有源，**默认不内置**（体积大、需从 13.24 服务器容器导出）。
+两种获取方式：
+
+### 方式 1：从 13.24 服务器容器导出（推荐）
+
+在 13.24 服务器上（`cross_build_sophon_u20:v1` 容器，名 `bm1684_zzt`），执行：
+
+```bash
+bash docker/scripts/export-dfss-toolchains.sh
+# 产物: docker/toolchains/swgcc830_cross_tools.tar.zst
+#        docker/toolchains/loongarch64-cross-tools.tar.zst
+```
+
+然后构建：
+
+```bash
+bash docker/build.sh --with-dfss-toolchains
+```
+
+### 方式 2：从 dfss 私有服务器在线拉取
+
+网络可达 dfss 服务器时，可参考 `source/pdfss_cpp/build_docker/Dockerfile` 的方式：
+
+```bash
+python3 -m dfss --url=open@sophgo.com:/toolchains/swgcc830-*.tar.gz
+```
+
+## 挂载源码跑构建
+
+```bash
+# 挂载 sophon-tools 源码到 /workspace，进入容器交互式构建
+docker run -it --rm \
+  -v "$(pwd)":/workspace/sophon-tools \
+  sophon-tools-build:latest \
+  bash
+
+# 进入后，按各子项目方式构建，例如:
+cd /workspace/sophon-tools/source/pbmssm
+bash build/build-deb-bmssm.sh   # 需以非 root 用户运行，或改输出目录为可写路径
+```
+
+### 单条命令跑某个子项目构建
+
+```bash
+docker run --rm \
+  -v "$(pwd)":/workspace/sophon-tools \
+  -w /workspace/sophon-tools \
+  sophon-tools-build:latest \
+  bash -c 'cd source/pbmssm && bash build/build-deb-bmssm.sh'
+```
+
+## 镜像自检
+
+```bash
+# 基础自检（工具链存在性）
+bash docker/verify.sh
+
+# 完整自检（含交叉编译实测：arm64 musl 静态 / windows / sw_64 / loongarch64）
+bash docker/verify.sh --cross
+```
+
+## 交叉编译示例
+
+`docker/examples/cross-test/` 提供 C / Rust / Windows 的交叉编译最小示例：
+
+```bash
+bash docker/examples/cross-test/run.sh --image sophon-tools-build:latest
+```
+
+## 已知边界
+
+1. **pqt 系列 AppImage** 原基于 18.04（glibc 2.27），本镜像 22.04（glibc 2.35）产物需在目标设备实测。
+2. **pSophUI / pmulti_video_qt** 需要交叉 Qt / libsophon SDK，本镜像不含（M3 处理）。
+3. **pdfss_cpp libs 编译**（libssh2/mbedtls/zlib 静态）耗时较长，建议镜像内预编一次（build_libs.sh）。
+4. **dfss 私有工具链**默认不内置；需要时按上文方式导出。
+5. 容器内构建涉及 `sudo` 的脚本（根 `release.sh`）需以 root 运行（镜像默认 root）或调整输出目录权限。
+
+## 目录结构
+
+```
+docker/
+├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 汇入）
+├── versions.env              # 唯一版本源（版本 + 校验和）
+├── build.sh                  # 一条命令构建镜像
+├── verify.sh                 # 镜像自检（对照 M1 清单）
+├── README.md                 # 本文件
+├── scripts/
+│   └── export-dfss-toolchains.sh  # 从 13.24 容器导出 sw_64/loongarch64 工具链
+├── examples/
+│   └── cross-test/           # 交叉编译示例（C/Rust/Windows）
+└── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains 使用）
+```

--- a/docker/README.md
+++ b/docker/README.md
@@ -102,6 +102,30 @@ bash docker/verify.sh
 bash docker/verify.sh --cross
 ```
 
+## pqt 系列（Qt GUI 工具）专用构建
+
+`docker/pqt/` 提供 pqt 系列（`pqt_memory_edit` 图形化内存修改工具、`pqt_batch_deployment` 批量部署工具）的专用构建。
+
+> **为什么独立镜像**：pqt 打 AppImage 依赖 linuxdeployqt，它强制宿主 glibc ≤ 2.31
+> （保证产物在旧发行版可运行）。sophon-tools-build 基于 22.04（glibc 2.35）不满足，
+> 故 pqt 专用镜像基于 ubuntu:20.04（glibc 2.31）。
+
+```bash
+# linux AppImage 一键编译（自动生成 memory_edit.tar.xz 前置依赖）
+bash docker/pqt/build-pqt.sh --project pqt_memory_edit --linux
+bash docker/pqt/build-pqt.sh --project pqt_batch_deployment --linux
+
+# windows exe（需先交叉编译 Qt mingw 静态库，一次约 1-2 小时）
+bash docker/pqt/build-qt-mingw.sh          # 交叉编译 Qt 5.15.2 mingw 静态
+bash docker/pqt/build-pqt.sh --project pqt_memory_edit --windows
+
+# 两端一起
+bash docker/pqt/build-pqt.sh --project pqt_memory_edit --all
+```
+
+已实测：`qt_mem_edit_V2.12.1-x86_64.AppImage`（25.9MB）在 ubuntu:20.04 镜像内一键产出，
+AppImage 可正常解包运行。
+
 ## 交叉编译示例
 
 `docker/examples/cross-test/` 提供 C / Rust / Windows 的交叉编译最小示例：
@@ -112,11 +136,13 @@ bash docker/examples/cross-test/run.sh --image sophon-tools-build:latest
 
 ## 已知边界
 
-1. **pqt 系列 AppImage** 原基于 18.04（glibc 2.27），本镜像 22.04（glibc 2.35）产物需在目标设备实测。
+1. **pqt 系列 AppImage** 用专用镜像 `sophon-tools-build-pqt`（ubuntu:20.04，glibc 2.31）构建，产物兼容 glibc ≥ 2.27 的系统。
 2. **pSophUI / pmulti_video_qt** 需要交叉 Qt / libsophon SDK，本镜像不含（M3 处理）。
 3. **pdfss_cpp libs 编译**（libssh2/mbedtls/zlib 静态）耗时较长，建议镜像内预编一次（build_libs.sh）。
 4. **dfss 私有工具链**默认不内置；需要时按上文方式导出。
 5. 容器内构建涉及 `sudo` 的脚本（根 `release.sh`）需以 root 运行（镜像默认 root）或调整输出目录权限。
+6. **pqt windows 端**依赖 Qt 5.15 mingw 静态库（`build-qt-mingw.sh` 交叉编译，1-2 小时），
+   仓库 `libs/win_amd64` 只含 libssh2/openssl，不含 Qt。
 
 ## 目录结构
 
@@ -129,6 +155,10 @@ docker/
 ├── README.md                 # 本文件
 ├── scripts/
 │   └── export-dfss-toolchains.sh  # 从 13.24 容器导出 sw_64/loongarch64 工具链
+├── pqt/
+│   ├── Dockerfile            # pqt 专用镜像（ubuntu:20.04，glibc 2.31）
+│   ├── build-pqt.sh          # pqt linux/windows 一键编译
+│   └── build-qt-mingw.sh     # Qt 5.15.2 mingw 静态库交叉编译
 ├── examples/
 │   └── cross-test/           # 交叉编译示例（C/Rust/Windows）
 └── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains 使用）

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# sophon-tools-build 统一构建全部 17 子项目（镜像内一键编译）
+#
+# 目标: 在 sophon-tools-build 镜像内预装工具链, 对全部子项目执行所有平台的编译。
+# 本脚本是统一入口, 按 M1 规范驱动每个子项目的构建脚本。
+#
+# 用法:
+#   bash docker/build-all.sh                    # 构建全部 17 子项目(默认平台)
+#   bash docker/build-all.sh --project pbmssm   # 只构建指定子项目
+#   bash docker/build-all.sh --arch arm64       # 只构建指定架构
+#   bash docker/build-all.sh --image sophon-tools-build:m2
+#   bash docker/build-all.sh --list             # 列出子项目与平台
+#
+# 产物: 全部汇聚到仓库根 output/<子项目>/ (与根 release.sh 一致)
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DOCKER_DIR="${SCRIPT_DIR}"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMAGE="${IMAGE:-sophon-tools-build:m2}"
+ONLY_PROJECT=""
+ONLY_ARCH=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) ONLY_PROJECT="$2"; shift 2; continue ;;
+    --arch) ONLY_ARCH="$2"; shift 2; continue ;;
+    --image) IMAGE="$2"; shift 2; continue ;;
+    --list) LIST_ONLY=1 ;;
+    -h|--help) grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -25; exit 0 ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+# 子项目 -> 构建脚本/命令 (镜像内相对 source/<项目>/ 执行)
+declare -A PROJECTS
+PROJECTS[pbmssm]="bash build/build-deb-bmssm.sh 2.1.0 ${ONLY_ARCH:-arm64}"
+PROJECTS[psophliteos]="cd frontend && rm -rf node_modules && CI=true pnpm install --no-frozen-lockfile 2>/dev/null; cd .. && bash build/build-deb-sophliteos.sh 2.1.0 soc"
+PROJECTS[pbmsec]="bash release.sh"
+PROJECTS[psocbak]="bash release.sh"
+PROJECTS[pget_info]="bash release.sh"
+PROJECTS[pmem_aging_test]="bash release.sh"
+PROJECTS[pmemory_edit]="bash release.sh"
+PROJECTS[pota_update]="bash release.sh"
+PROJECTS[pautotelecomm]="bash release.sh"
+PROJECTS[pbm_set_ip]="cd bm_set_ip && cargo build --target aarch64-unknown-linux-musl --release"
+PROJECTS[pdfss_cpp]="bash linux_release.sh ${ONLY_ARCH:-host}"
+PROJECTS[pqt_batch_deployment]="bash docker/pqt/build-pqt.sh --project pqt_batch_deployment --linux"
+PROJECTS[pqt_memory_edit]="bash docker/pqt/build-pqt.sh --project pqt_memory_edit --linux"
+PROJECTS[pSophUI]="echo 'SKIP: 需交叉 Qt 环境(M3)'"
+PROJECTS[pmulti_video_qt]="echo 'SKIP: 需 libsophon SDK(M3)'"
+PROJECTS[psoph_phytool]="cp sophon_phytool.sh output/"
+PROJECTS[pspacc_efuse_demo]="gcc -o output/spacc_efuse_demo spacc_efuse_demo.c"
+
+# 平台说明 (M1 盘点)
+declare -A PLATFORMS
+PLATFORMS[pbmssm]="arm64(musl静态)/amd64"
+PLATFORMS[psophliteos]="arm64(musl静态)/amd64"
+PLATFORMS[pbmsec]="all(deb含双架构)"
+PLATFORMS[psocbak]="arm64"
+PLATFORMS[pget_info]="arm64/amd64"
+PLATFORMS[pmem_aging_test]="arm64"
+PLATFORMS[pmemory_edit]="arm64"
+PLATFORMS[pota_update]="arm64"
+PLATFORMS[pautotelecomm]="arm64"
+PLATFORMS[pbm_set_ip]="arm64(musl静态)"
+PLATFORMS[pdfss_cpp]="amd64/arm64/armbi/loongarch64/riscv64/sw_64/win-amd64/win-i686"
+PLATFORMS[pqt_batch_deployment]="amd64/arm64"
+PLATFORMS[pqt_memory_edit]="amd64/arm64 + windows"
+PLATFORMS[pSophUI]="arm64(需交叉Qt)"
+PLATFORMS[pmulti_video_qt]="arm64(需SDK)"
+PLATFORMS[psoph_phytool]="通用脚本"
+PLATFORMS[pspacc_efuse_demo]="amd64/arm64"
+
+if [[ "${LIST_ONLY:-0}" = "1" ]]; then
+  echo "=== sophon-tools 17 子项目构建清单 (镜像 ${IMAGE}) ==="
+  for p in $(echo "${!PROJECTS[@]}" | tr ' ' '\n' | sort); do
+    printf "  %-22s 平台: %s\n" "$p" "${PLATFORMS[$p]}"
+  done
+  exit 0
+fi
+
+# 输出目录
+mkdir -p "${REPO_ROOT}/output"
+echo "==> 统一构建 (镜像 ${IMAGE}), 输出: ${REPO_ROOT}/output"
+
+run_one() {
+  local p="$1"
+  echo ""
+  echo "========== [${p}] 平台: ${PLATFORMS[$p]} =========="
+  local src_dir="${REPO_ROOT}/source/${p}"
+  [[ -d "${src_dir}" ]] || { echo "  [SKIP] 目录不存在: ${src_dir}"; return 0; }
+  mkdir -p "${src_dir}/output"
+  local cmd="${PROJECTS[$p]}"
+  docker run --rm --privileged \
+    -v /dev:/dev \
+    -v "${REPO_ROOT}":/workspace/sophon-tools \
+    -w "/workspace/sophon-tools/source/${p}" \
+    "${IMAGE}" bash -c "
+      set -e
+      git config --global --add safe.directory '*' 2>/dev/null || true
+      git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
+      export PATH=\"/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:/usr/sw/swgcc830_cross_tools/usr/bin:\$PATH\"
+      mkdir -p output
+      echo '  >> ${cmd}'
+      ${cmd} 2>&1 | tail -15
+    " 2>&1 | sed 's/^/    /'
+  local rc=${PIPESTATUS[0]}
+  echo "  [${p}] 退出码: ${rc}"
+}
+
+if [[ -n "${ONLY_PROJECT}" ]]; then
+  run_one "${ONLY_PROJECT}"
+else
+  for p in $(echo "${!PROJECTS[@]}" | tr ' ' '\n' | sort); do
+    run_one "$p"
+  done
+fi
+
+echo ""
+echo "==> 统一构建完成, 产物在 ${REPO_ROOT}/output/"
+echo "==> 汇总: bash docker/verify.sh --image ${IMAGE}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# sophon-tools-build 镜像构建脚本（一条命令构建）
+#
+# 用法:
+#   bash docker/build.sh                 # 基础镜像(不含 dfss 私有工具链)
+#   bash docker/build.sh --with-dfss-toolchains   # 内置 sw_64/loongarch64 私有工具链
+#   bash docker/build.sh --tag mytag --no-cache
+#
+# 依赖: docker(≥20.10, BuildKit 默认开启), 网络可访问 go.dev/nodejs.org/musl.cc
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DOCKER_DIR="${SCRIPT_DIR}"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# 默认镜像名 + 标签
+IMAGE_NAME="${IMAGE_NAME:-sophon-tools-build}"
+TAG=""
+WITH_DFSS=0
+EXTRA_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --with-dfss-toolchains) WITH_DFSS=1; shift ;;
+    --tag) TAG="$2"; shift 2 ;;
+    --no-cache) EXTRA_ARGS+=(--no-cache); shift ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+done
+
+[[ -n "${TAG}" ]] || TAG="latest"
+
+# 版本源: docker/versions.env(唯一版本锁定点)
+# shellcheck disable=SC1091
+source "${DOCKER_DIR}/versions.env"
+
+# 校验基础镜像 digest 可拉取
+BASE_IMG="${UBUNTU_BASE_DIGEST}"
+echo "==> 基础镜像: ${BASE_IMG}"
+docker pull "${BASE_IMG}" >/dev/null 2>&1 || { echo "无法拉取基础镜像, 检查网络" >&2; exit 1; }
+
+# dfss 私有工具链: 检查 toolchains/ 目录
+BUILD_CONTEXT="${DOCKER_DIR}"
+if [[ "${WITH_DFSS}" = "1" ]]; then
+  TOOLCHAIN_DIR="${DOCKER_DIR}/toolchains"
+  if [[ ! -f "${TOOLCHAIN_DIR}/swgcc830_cross_tools.tar.zst" ]] \
+     && [[ ! -f "${TOOLCHAIN_DIR}/loongarch64-cross-tools.tar.zst" ]]; then
+    echo "==> toolchains/ 为空, 先从 13.24 容器导出(需要 docker 容器 bm1684_zzt 或 cross_build_sophon_u20:v1)..." >&2
+    bash "${DOCKER_DIR}/scripts/export-dfss-toolchains.sh" --out "${TOOLCHAIN_DIR}"
+  fi
+  EXTRA_ARGS+=(--build-arg WITH_DFSS=1)
+fi
+
+echo "==> 构建上下文: ${BUILD_CONTEXT}"
+echo "==> 版本: Go ${GO_VERSION} / Rust ${RUST_VERSION} / Node ${NODE_VERSION} / pnpm ${PNPM_VERSION}"
+[[ "${WITH_DFSS}" = "1" ]] && echo "==> 内置 dfss 私有工具链(sw_64 + loongarch64)"
+
+docker build \
+  --build-arg UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST}" \
+  --build-arg GO_VERSION="${GO_VERSION}" \
+  --build-arg GO_TARBALL_URL="${GO_TARBALL_URL}" \
+  --build-arg GO_TARBALL_SHA256="${GO_TARBALL_SHA256}" \
+  --build-arg RUST_VERSION="${RUST_VERSION}" \
+  --build-arg NODE_TARBALL_URL="${NODE_TARBALL_URL}" \
+  --build-arg NODE_TARBALL_SHA256="${NODE_TARBALL_SHA256}" \
+  --build-arg PNPM_VERSION="${PNPM_VERSION}" \
+  --build-arg YARN_VERSION="${YARN_VERSION}" \
+  "${EXTRA_ARGS[@]}" \
+  -f "${DOCKER_DIR}/Dockerfile" \
+  -t "${IMAGE_NAME}:${TAG}" \
+  "${BUILD_CONTEXT}"
+
+echo "==> 构建完成: ${IMAGE_NAME}:${TAG}"
+echo "==> 自检: bash docker/verify.sh --image ${IMAGE_NAME}:${TAG}"

--- a/docker/examples/cross-test/run.sh
+++ b/docker/examples/cross-test/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# 交叉编译示例：C(Rust)/Windows/私有架构 最小验证。
+# 在 sophon-tools-build 镜像内演示 8 架构交叉编译能力。
+#
+# 用法:
+#   bash docker/examples/cross-test/run.sh [--image <name>]
+set -u
+
+IMAGE="${IMAGE:-sophon-tools-build:latest}"
+[[ $# -ge 1 ]] && IMAGE="$1"
+
+echo "== 使用镜像: ${IMAGE}"
+docker run --rm -i "${IMAGE}" bash -s <<'EOF'
+set -e
+mkdir -p /tmp/x && cd /tmp/x
+
+# 1) C aarch64 musl 静态
+printf 'int main(void){return 0;}\n' > c.c
+aarch64-linux-musl-gcc -static c.c -o c_arm64
+echo "[1] C aarch64 musl:"; file c_arm64 | sed 's/^/    /'
+
+# 2) Rust aarch64 musl 静态
+cargo new --bin rtest >/dev/null 2>&1 && cd rtest
+printf 'fn main(){println!("hello");}\n' > src/main.rs
+cargo build --release --target aarch64-unknown-linux-musl >/dev/null 2>&1
+echo "[2] Rust aarch64 musl:"; file target/aarch64-unknown-linux-musl/release/rtest | sed 's/^/    /'
+cd ..
+
+# 3) Windows x86_64 (mingw64)
+printf 'int main(void){return 0;}\n' > w.c
+x86_64-w64-mingw32-gcc -static w.c -o w64.exe
+echo "[3] Windows x86_64:"; file w64.exe | sed 's/^/    /'
+
+# 4) Windows i686 (mingw)
+i686-w64-mingw32-gcc -static w.c -o w32.exe
+echo "[4] Windows i686:"; file w32.exe | sed 's/^/    /'
+
+# 5) sw_64 (dfss 私有工具链)
+if [ -x /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc ]; then
+  /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc -static c.c -o s.out 2>/dev/null
+  echo "[5] sw_64:"; file s.out | sed 's/^/    /'
+else
+  echo "[5] sw_64: 工具链未内置(需 --with-dfss-toolchains 重建)"
+fi
+
+# 6) loongarch64 (dfss 私有工具链)
+if [ -x /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc ]; then
+  /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc -static c.c -o l.out 2>/dev/null
+  echo "[6] loongarch64:"; file l.out | sed 's/^/    /'
+else
+  echo "[6] loongarch64: 工具链未内置(需 --with-dfss-toolchains 重建)"
+fi
+
+echo "== 交叉编译示例完成 =="
+EOF

--- a/docker/pqt/Dockerfile
+++ b/docker/pqt/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# sophon-tools-build-pqt —— pqt 系列(Qt GUI 工具)专用构建镜像
+#
+# 为什么独立于 sophon-tools-build:
+#   pqt 系列打 AppImage 依赖 linuxdeployqt, 而 linuxdeployqt 强制要求宿主 glibc <= 2.31
+#   (以保证产物在旧发行版可运行, https://github.com/probonopd/linuxdeployqt/issues/340)。
+#   sophon-tools-build 基于 ubuntu:22.04 (glibc 2.35) 无法满足; 本镜像基于 ubuntu:20.04
+#   (glibc 2.31), 同时提供 Qt 5 + openssl 1.1 兼容, 满足 pqt 系列 linux/AppImage 构建。
+#
+# 构建:  bash docker/pqt/build-pqt.sh --linux
+# 也可直接从 13.24 服务器镜像复用: docker pull (registry)
+# =============================================================================
+
+ARG UBUNTU_PQT_DIGEST="ubuntu@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214"
+
+FROM ${UBUNTU_PQT_DIGEST}
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8
+
+SHELL ["/bin/bash", "-c"]
+
+# ---- 系统依赖: Qt5 开发包 + 构建工具 + AppImage 打包依赖 ----
+# qtbase5-dev qttools5-dev -> Qt 5.12.8 (ubuntu 20.04), libgl1-mesa-dev 提供 OpenGL 头
+# libfuse2 供 AppImage 运行时; patchelf 供 linuxdeployqt 重写 ELF
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        qtbase5-dev qttools5-dev qttools5-dev-tools \
+        build-essential gcc g++ make cmake \
+        git wget curl ca-certificates \
+        libgl1-mesa-dev libglib2.0-0 \
+        patchelf libfuse2 fuse \
+        file binutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ---- openssl 1.1 ----
+# pqt 仓库自带的 libssh2 按 ubuntu18.04 (openssl 1.1.1) 编译, 依赖 libcrypto.so.1.1 符号。
+# ubuntu20.04 默认就是 openssl 1.1.1, 与 18.04 完全兼容, 无需额外处理。
+
+WORKDIR /workspace
+RUN git config --global --add safe.directory "*"
+
+CMD ["/bin/bash"]

--- a/docker/pqt/build-pqt.sh
+++ b/docker/pqt/build-pqt.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# pqt 系列(Qt GUI 工具)一键编译脚本 —— linux AppImage / windows exe
+#
+# 支持子项目: pqt_memory_edit(图形化远程内存修改工具), pqt_batch_deployment(批量部署工具)
+#
+# 用法:
+#   bash docker/pqt/build-pqt.sh --project pqt_memory_edit --linux       # linux AppImage
+#   bash docker/pqt/build-pqt.sh --project pqt_memory_edit --windows     # windows exe (需 Qt mingw)
+#   bash docker/pqt/build-pqt.sh --project pqt_memory_edit --all         # 两端
+#   bash docker/pqt/build-pqt.sh --project pqt_batch_deployment --linux
+#
+# 依赖: docker, sophon-tools-build-pqt 镜像(linux端); mingw Qt(交叉编译) 见下
+#
+# 关键前置(linux): pqt_memory_edit 的 resources.qrc 引用 memory_edit.tar.xz,
+#   该文件由 source/pmemory_edit/release.sh 生成; 构建前自动生成并复制。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DOCKER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PQT_IMAGE="${PQT_IMAGE:-sophon-tools-build-pqt:latest}"
+PROJECT="pqt_memory_edit"
+MODE=""  # linux / windows / all
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) PROJECT="$2"; shift 2; continue ;;
+    --linux) MODE="linux" ;;
+    --windows) MODE="windows" ;;
+    --all) MODE="all" ;;
+    --image) PQT_IMAGE="$2"; shift 2; continue ;;
+    -h|--help)
+      grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -30
+      exit 0 ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[[ -n "${MODE}" ]] || { echo "请指定 --linux 或 --windows 或 --all" >&2; exit 1; }
+SRC_DIR="${REPO_ROOT}/source/${PROJECT}"
+[[ -d "${SRC_DIR}" ]] || { echo "未找到子项目: ${SRC_DIR}" >&2; exit 1; }
+
+# ---- 准备 memory_edit.tar.xz (pqt_memory_edit 专用) ----
+prepare_memory_edit_tarxz() {
+  if [[ "${PROJECT}" != "pqt_memory_edit" ]]; then return 0; fi
+  local src="${SRC_DIR}/memory_edit.tar.xz"
+  if [[ -f "${src}" ]]; then
+    echo "==> 已有 memory_edit.tar.xz, 复用"
+    return 0
+  fi
+  echo "==> 生成 memory_edit.tar.xz (来自 pmemory_edit)..."
+  local pmem="${REPO_ROOT}/source/pmemory_edit"
+  (cd "${pmem}" && bash release.sh >/dev/null 2>&1)
+  local tarxz
+  tarxz="$(find "${pmem}/output" -name 'memory_edit_*.tar.xz' 2>/dev/null | head -1)"
+  if [[ -z "${tarxz}" ]]; then
+    echo "错误: pmemory_edit 未产出 memory_edit tar.xz" >&2
+    exit 1
+  fi
+  cp "${tarxz}" "${src}"
+  echo "==> 已复制: ${src}"
+}
+
+# ---- linux 端: AppImage ----
+build_linux() {
+  prepare_memory_edit_tarxz
+  echo "==> 构建 ${PROJECT} linux AppImage (镜像 ${PQT_IMAGE})..."
+  # 确保镜像存在
+  docker image inspect "${PQT_IMAGE}" >/dev/null 2>&1 || {
+    echo "==> 构建 pqt 基础镜像..." >&2
+    docker build -f "${DOCKER_DIR}/pqt/Dockerfile" -t "${PQT_IMAGE}" "${DOCKER_DIR}/pqt" >&2
+  }
+  docker run --rm --privileged \
+    -v /dev:/dev \
+    -v "${SRC_DIR}":/root/workspace \
+    -w /root/workspace \
+    "${PQT_IMAGE}" /bin/bash -c "
+      git config --global --add safe.directory /root/workspace
+      bash linux_release.sh
+    " 2>&1 | tail -20
+  echo "==> linux AppImage 完成"
+}
+
+# ---- windows 端: exe (需 Qt mingw 交叉编译环境) ----
+build_windows() {
+  echo "==> windows 端交叉编译..."
+  # 注意: windows 构建需要 sophon-tools-build(含 mingw g++), 非 pqt 镜像
+  local image="${IMAGE:-sophon-tools-build:m2}"
+  local qt_prefix="${QT_PREFIX:-/opt/qt-mingw}"
+  # 确保 Qt mingw 静态库存在
+  if [[ ! -f "${qt_prefix}/lib/libQt5Widgets.a" ]]; then
+    echo "==> 未找到 Qt mingw 静态库 (${qt_prefix}), 先交叉编译 Qt (约 20-40 分钟)..."
+    PREFIX="${qt_prefix}" bash "${DOCKER_DIR}/pqt/build-qt-mingw.sh" || {
+      echo "Qt mingw 编译失败" >&2; exit 1
+    }
+  fi
+  # 内存修改工具前置依赖
+  prepare_memory_edit_tarxz
+  docker run --rm \
+    -v "${SRC_DIR}":/workspace/src \
+    -v "${qt_prefix}":/opt/qt-mingw \
+    -w /workspace/src \
+    "${image}" bash -c '
+      set -e
+      export DEBIAN_FRONTEND=noninteractive
+      if ! command -v x86_64-w64-mingw32-g++-posix >/dev/null; then
+        apt-get update -qq
+        apt-get install -y --no-install-recommends g++-mingw-w64-x86-64 >/dev/null 2>&1
+      fi
+      # posix 线程模型 (Qt 静态库需要 std::mutex)
+      mkdir -p /opt/mingw-posix/bin
+      for t in gcc g++ cpp cc c++ gcc-ar gcc-nm gcc-ranlib; do
+        [ -x /usr/bin/x86_64-w64-mingw32-${t}-posix ] && ln -sf /usr/bin/x86_64-w64-mingw32-${t}-posix /opt/mingw-posix/bin/x86_64-w64-mingw32-${t}
+      done
+      export PATH=/opt/mingw-posix/bin:$PATH
+      # 大写 mingw 头文件符号链接 (代码 include <Winsock2.h>)
+      mkdir -p /tmp/mingw-inc
+      ln -sf /usr/x86_64-w64-mingw32/include/winsock2.h /tmp/mingw-inc/Winsock2.h
+      # WS2_32 库大小写兼容
+      ln -sf /usr/x86_64-w64-mingw32/lib/libws2_32.a /usr/x86_64-w64-mingw32/lib/libWS2_32.a
+      # mingw toolchain
+      cat > /tmp/tc.cmake <<TOOL
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_FIND_ROOT_PATH /opt/qt-mingw /usr/x86_64-w64-mingw32)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+TOOL
+      cd /workspace/src
+      rm -rf build-win
+      mkdir build-win && cd build-win
+      export QT_PLATFORM_DIR=/opt/qt-mingw
+      export QT_GCC_PLATFORM_DIR=/opt/mingw-posix/bin
+      cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
+        "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc"
+      make -j$(nproc)
+      echo "==> windows exe 产物:"
+      ls -la qt_mem_edit*.exe 2>/dev/null || ls -la *.exe
+    '
+}
+
+case "${MODE}" in
+  linux) build_linux ;;
+  windows) build_windows ;;
+  all) build_linux; build_windows ;;
+esac

--- a/docker/pqt/build-qt-mingw.sh
+++ b/docker/pqt/build-qt-mingw.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# 交叉编译 Qt 5.15.2 (mingw-w64 静态) —— pqt 系列 windows 端前置依赖
+#
+# 背景:
+#   pqt_memory_edit / pqt_batch_deployment 的 windows 端依赖 Qt 5.15 mingw 静态库
+#   (仓库 libs/win_amd64 只含 libssh2/openssl, 不含 Qt)。完整交叉编译一次约 20-40 分钟。
+#
+# 关键点:
+#   * Qt 5.15.2 的 qglobal.h/qfloat16.h/qendian.h 缺 <limits> include (新 gcc 报错) —— 自动 patch
+#   * mingw-w64 默认 win32 线程模型缺 std::mutex/condition_variable (Qt testlib 需要) —— 强制用 posix 变体
+#   * testlib 模块依赖 posix 线程, 用 -no-feature-testlib 禁用
+#
+# 用法:
+#   bash docker/pqt/build-qt-mingw.sh [--prefix /opt/qt-mingw] [--jobs N]
+#
+# 产物: 交叉编译的 Qt 静态库, 安装到 --prefix (默认 /opt/qt-mingw)。
+#   构建 windows exe 时挂载该目录, 设置 QT_PLATFORM_DIR 指向它。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+QT_VERSION="5.15.2"
+QT_MODULE="qtbase-everywhere-src-${QT_VERSION}"
+QT_URL="https://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/5.15/${QT_VERSION}/submodules/${QT_MODULE}.tar.xz"
+PREFIX="${PREFIX:-/opt/qt-mingw}"
+JOBS="${JOBS:-$(nproc)}"
+IMAGE="${IMAGE:-sophon-tools-build:m2}"
+
+echo "==> 下载 Qt ${QT_VERSION} qtbase 源码..."
+if [[ ! -f "${REPO_ROOT}/docker/toolchains/${QT_MODULE}.tar.xz" ]]; then
+  mkdir -p "${REPO_ROOT}/docker/toolchains"
+  curl -fsSL "${QT_URL}" -o "${REPO_ROOT}/docker/toolchains/${QT_MODULE}.tar.xz"
+fi
+SRC_TARBALL="${REPO_ROOT}/docker/toolchains/${QT_MODULE}.tar.xz"
+
+echo "==> 在镜像 ${IMAGE} 内交叉编译 Qt (jobs=${JOBS}, prefix=${PREFIX})..."
+docker run --rm \
+  -v "${SRC_TARBALL}":/host/qtbase.tar.xz \
+  -v "${PREFIX}":/opt/qt-mingw \
+  "${IMAGE}" bash -c "
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+    # 确保 mingw g++ 存在
+    if ! command -v x86_64-w64-mingw32-g++-posix >/dev/null; then
+      apt-get update -qq
+      apt-get install -y --no-install-recommends g++-mingw-w64-x86-64 >/dev/null 2>&1
+    fi
+    # 强制 posix 线程模型 (win32 变体缺 std::mutex, Qt testlib 需要)
+    # 用 wrapper 覆盖默认 g++/gcc -> posix 变体
+    mkdir -p /opt/mingw-posix/bin
+    for t in gcc g++ cpp cc c++ gcc-ar gcc-nm gcc-ranlib; do
+      if [ -x /usr/bin/x86_64-w64-mingw32-\${t}-posix ]; then
+        ln -sf /usr/bin/x86_64-w64-mingw32-\${t}-posix /opt/mingw-posix/bin/x86_64-w64-mingw32-\${t}
+      fi
+    done
+    export PATH=/opt/mingw-posix/bin:\$PATH
+    # 验证 posix 线程
+    printf '#include <mutex>\nint main(){std::mutex m; m.lock(); return 0;}\n' > /tmp/mt.cpp
+    x86_64-w64-mingw32-g++ /tmp/mt.cpp -o /tmp/mt.exe || { echo 'posix g++ 不可用' >&2; exit 1; }
+    echo 'posix g++ OK'
+    # 解压 + patch
+    cd /tmp && rm -rf qte && mkdir qte && tar -xJf /host/qtbase.tar.xz -C qte && cd qte/${QT_MODULE}
+    python3 - <<PYEOF
+for path in ['src/corelib/global/qglobal.h', 'src/corelib/global/qfloat16.h', 'src/corelib/global/qendian.h']:
+    with open(path) as f: content = f.read()
+    if '#include <limits>' not in content:
+        content = content.replace('#  include <type_traits>', '#  include <type_traits>\n#  include <limits>', 1)
+    with open(path, 'w') as f: f.write(content)
+print('patched limits include')
+PYEOF
+    # 配置 + 编译 + 安装
+    ./configure -xplatform win32-g++ -device-option CROSS_COMPILE=x86_64-w64-mingw32- \
+        -static -release -opensource -confirm-license \
+        -prefix /opt/qt-mingw -nomake examples -nomake tests -no-opengl \
+        -no-feature-testlib
+    make -j${JOBS}
+    make install
+    echo '==> Qt mingw 交叉编译完成: /opt/qt-mingw'
+    ls /opt/qt-mingw/lib/libQt5*.a 2>/dev/null | wc -l
+"
+
+echo "==> 完成。构建 pqt windows 时设置:"
+echo "    QT_PLATFORM_DIR=${PREFIX}  QT_GCC_PLATFORM_DIR=<mingw posix bin dir>"

--- a/docker/scripts/build-dfss-pip.sh
+++ b/docker/scripts/build-dfss-pip.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# 在 sophon-tools-build 镜像内编译 dfss pip 包（dfss-cpp 8 架构 + python 打包）
+#
+# 产物: source/pdfss_cpp/dfss_pip/dist/dfss-<version>.whl + .tar.gz
+#   内含 8 架构 dfss-cpp 二进制 (amd64/arm64/armbi/loongarch64/riscv64/sw_64 + win-amd64/win-i686)
+#
+# 用法:
+#   bash docker/scripts/build-dfss-pip.sh [--skip-libs] [--arch aarch64] ...
+#
+# 前置: sophon-tools-build 镜像(含全部 8 架构交叉工具链), 网络可达(musl.cc/go.dev 已内置)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DOCKER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+IMAGE="${IMAGE:-sophon-tools-build:m2}"
+PDFSS_SRC="${REPO_ROOT}/source/pdfss_cpp"
+SKIP_LIBS=0
+ARCHES=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-libs) SKIP_LIBS=1 ;;
+    --arch) ARCHES+=("$2"); shift 2; continue ;;
+    --image) IMAGE="$2"; shift 2; continue ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+[[ ${#ARCHES[@]} -gt 0 ]] || ARCHES=(host aarch64 armbi loongarch64 riscv64 sw_64 mingw64 mingw)
+
+echo "==> 在镜像 ${IMAGE} 内编译 dfss-cpp 全部架构: ${ARCHES[*]}"
+docker run --rm \
+  -v "${PDFSS_SRC}":/workspace/pdfss_cpp \
+  -w /workspace/pdfss_cpp \
+  "${IMAGE}" bash -c "
+    set -e
+    export PATH=\"/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:/usr/sw/swgcc830_cross_tools/usr/bin:\$PATH\"
+    git config --global --add safe.directory /workspace/pdfss_cpp
+
+    for arch in ${ARCHES[*]}; do
+      echo \"===== 构建 \${arch} =====\"
+      # libs 阶段(除 host 外需要交叉静态库); 首次构建可能因 mbedtls 并行竞态失败, 重跑一次
+      if [[ \"${SKIP_LIBS}\" = \"0\" ]]; then
+        # 清理 mbedtls build 残留避免竞态
+        rm -rf libs/mbedtls/build
+        bash linux_release.sh \"\${arch}\" lib >/dev/null 2>&1 || {
+          echo \"libs 重试...\"
+          rm -rf libs/mbedtls/build
+          bash linux_release.sh \"\${arch}\" lib
+        }
+      fi
+      bash linux_release.sh \"\${arch}\"
+    done
+
+    echo '===== 打包 pip ====='
+    cd dfss_pip
+    rm -rf dist build dfss.egg-info
+    rm -f dfss/output/dfss-cpp* dfss/output/git_version 2>/dev/null || true
+    python3 setup.py sdist bdist_wheel --universal
+    echo '===== 产物 ====='
+    ls -la dist/
+"
+
+echo "==> 完成。pip 包: ${PDFSS_SRC}/dfss_pip/dist/"

--- a/docker/scripts/export-dfss-toolchains.sh
+++ b/docker/scripts/export-dfss-toolchains.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# 从 13.24 服务器的容器导出 dfss 私有工具链（sw_64 / loongarch64）。
+# 用法:
+#   bash docker/scripts/export-dfss-toolchains.sh [--container <name>] [--out <dir>]
+#     --container  源容器名（默认 bm1684_zzt，镜像 cross_build_sophon_u20:v1）
+#     --out        导出目录（默认 docker/toolchains/）
+#
+# 导出为 .tar.zst 后，`bash docker/build.sh --with-dfss-toolchains` 会将其内置于镜像；
+# 若导出目录已存在同名归档，直接复用，不重复导出。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DOCKER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CONTAINER="${CONTAINER:-bm1684_zzt}"
+OUT_DIR="${OUT_DIR:-${DOCKER_DIR}/toolchains}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --container) CONTAINER="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+done
+
+mkdir -p "${OUT_DIR}"
+
+# 容器内工具链路径（cross_build_sophon_u20:v1 / cross_build_sophon:v7 通用）
+SW64_SRC="/usr/sw/swgcc830_cross_tools"
+LOONG_SRC="/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1"
+
+SW64_ARCHIVE="${OUT_DIR}/swgcc830_cross_tools.tar.zst"
+LOONG_ARCHIVE="${OUT_DIR}/loongarch64-cross-tools.tar.zst"
+
+if ! docker inspect "${CONTAINER}" >/dev/null 2>&1 && ! docker image inspect "${CONTAINER}" >/dev/null 2>&1; then
+  echo "错误: 找不到容器/镜像 '${CONTAINER}'。" >&2
+  echo "请在 13.24 服务器上运行（镜像 cross_build_sophon_u20:v1 / cross_build_sophon:v7 内置工具链）:" >&2
+  echo "  docker run -d --name dfss-toolchain-src --entrypoint sleep cross_build_sophon_u20:v1 infinity" >&2
+  exit 1
+fi
+
+# 工具链是否在容器 / 镜像内
+if ! docker exec "${CONTAINER}" test -d "${SW64_SRC}" >/dev/null 2>&1 \
+   && ! docker exec "${CONTAINER}" test -d "${LOONG_SRC}" >/dev/null 2>&1; then
+  echo "错误: 容器 '${CONTAINER}' 中未找到 ${SW64_SRC} 或 ${LOONG_SRC}。" >&2
+  exit 1
+fi
+
+export CONTAINER SW64_SRC LOONG_SRC
+
+# 打 tar（容器内无 zstd 则用 tar czf 走 gzip）
+pack_from_container() {
+  local container="$1" src="$2" archive="$3"
+  if [[ -f "${archive}" ]]; then
+    echo "已存在: ${archive}（跳过）"
+    return 0
+  fi
+  echo "导出 ${src} -> ${archive} ..."
+  if docker exec "${container}" sh -c 'command -v zstd' >/dev/null 2>&1; then
+    docker exec "${container}" sh -c "tar -C '$(dirname "${src}")' -cf - '$(basename "${src}")' | zstd -q -T0" > "${archive}"
+  else
+    docker exec "${container}" sh -c "tar -C '$(dirname "${src}")' -czf - '$(basename "${src}")'" > "${archive}"
+  fi
+  ls -lh "${archive}"
+}
+
+pack_from_container "${CONTAINER}" "${SW64_SRC}" "${SW64_ARCHIVE}"
+pack_from_container "${CONTAINER}" "${LOONG_SRC}" "${LOONG_ARCHIVE}"
+
+echo "完成。工具链归档位于 ${OUT_DIR}"
+echo "构建镜像时加 --with-dfss-toolchains 自动内置，或在 Dockerfile 构建上下文放 toolchains/ 目录。"

--- a/docker/verify.sh
+++ b/docker/verify.sh
@@ -99,6 +99,8 @@ CHECK  "7z"                     "7z | head -1"
 CHECK  "zip"                    "zip -v | head -1"
 CHECK  "upx"                    "upx --version | head -1"
 CHECK  "patchelf"               "patchelf --version"
+CHECK  "pandoc"                 "pandoc --version | head -1"
+CHECK  "sudo"                   "sudo --version | head -1"
 CHECK  "qemu-aarch64-static"    "qemu-aarch64-static --version | head -1"
 CHECK  "qemu-loongarch64"       "qemu-loongarch64 --version | head -1"
 

--- a/docker/verify.sh
+++ b/docker/verify.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# sophon-tools-build 镜像自检（对照 M1 盘点清单逐项验证工具链）
+#
+# 用法:
+#   bash docker/verify.sh                 # 默认镜像 sophon-tools-build:latest
+#   bash docker/verify.sh --image <name>  # 指定镜像
+#   bash docker/verify.sh --cross         # 额外跑交叉编译实测(arm64 musl 静态 + windows)
+#
+# 退出码: 0=全部通过, 1=存在失败项
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+IMAGE="${IMAGE:-sophon-tools-build:latest}"
+DO_CROSS=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) IMAGE="$2"; shift 2 ;;
+    --cross) DO_CROSS=1; shift ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+done
+
+# 在镜像内执行命令的封装
+run() { docker run --rm -i "${IMAGE}" bash -c "$*"; }
+
+FAIL=0
+CHECK() {
+  local name="$1" cmd="$2"
+  if run "${cmd}" >/dev/null 2>&1; then
+    echo "  [PASS] ${name}"
+  else
+    echo "  [FAIL] ${name}  ($cmd)"
+    FAIL=1
+  fi
+}
+
+VERSION() {
+  local name="$1" cmd="$2"
+  local out
+  out="$(run "${cmd}" 2>/dev/null)"
+  echo "  [VER ] ${name}: ${out}"
+}
+
+echo "== sophon-tools-build 镜像自检 ($IMAGE) =="
+
+echo "--- 基础工具链 ---"
+VERSION "gcc (host)"            "gcc --version | head -1"
+VERSION "g++ (host)"            "g++ --version | head -1"
+VERSION "make"                  "make --version | head -1"
+VERSION "cmake"                 "cmake --version | head -1"
+VERSION "pkg-config"            "pkg-config --version"
+CHECK  "git"                    "git --version"
+
+echo "--- Go 工具链 (pbmssm / psophliteos) ---"
+VERSION "go"                    "go version"
+CHECK  "go 交叉编译 env"        "go env GOOS GOARCH | grep -q linux"
+CHECK  "CGO 可用"               "go env CGO_ENABLED"
+CHECK  "GOOS=linux GOARCH=arm64 编译" "cd /tmp && printf 'package main\nimport \"fmt\"\nfunc main(){fmt.Println(\"ok\")}\n' > m.go && GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o /dev/null m.go"
+
+echo "--- Rust 工具链 (pbm_set_ip) ---"
+VERSION "rustc"                 "rustc --version"
+VERSION "cargo"                 "cargo --version"
+CHECK  "aarch64 musl target"    "rustup target list --installed | grep -q aarch64-unknown-linux-musl"
+CHECK  "aarch64 gnu target"     "rustup target list --installed | grep -q aarch64-unknown-linux-gnu"
+CHECK  "x86_64 musl target"     "rustup target list --installed | grep -q x86_64-unknown-linux-musl"
+CHECK  "cargo 链接器配置"       "grep -q aarch64-linux-musl-gcc \${CARGO_HOME:-/opt/cargo}/config.toml"
+
+echo "--- Node.js / 前端 (psophliteos) ---"
+VERSION "node"                  "node --version"
+VERSION "pnpm"                  "pnpm --version"
+VERSION "yarn"                  "yarn --version"
+
+echo "--- musl 交叉工具链 (静态链接) ---"
+VERSION "aarch64-linux-musl-gcc" "aarch64-linux-musl-gcc --version | head -1"
+VERSION "x86_64-linux-musl-gcc"  "x86_64-linux-musl-gcc --version | head -1"
+
+echo "--- glibc 交叉工具链 (pdfss_cpp 各架构) ---"
+VERSION "aarch64-linux-gnu-gcc"   "aarch64-linux-gnu-gcc --version | head -1"
+VERSION "arm-linux-gnueabi-gcc"   "arm-linux-gnueabi-gcc --version | head -1"
+VERSION "riscv64-linux-gnu-gcc"   "riscv64-linux-gnu-gcc --version | head -1"
+VERSION "x86_64-w64-mingw32-gcc"  "x86_64-w64-mingw32-gcc --version | head -1"
+VERSION "i686-w64-mingw32-gcc"    "i686-w64-mingw32-gcc --version | head -1"
+
+echo "--- dfss 私有工具链 (sw_64 / loongarch64) ---"
+if run "dfss-check" | grep -q "已就绪"; then
+  echo "  [PASS] dfss 私有工具链已就绪"
+  VERSION "sw_64 gcc"           "/usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc --version | head -1"
+  VERSION "loongarch64 gcc"     "/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc --version | head -1"
+else
+  echo "  [SKIP] dfss 私有工具链未内置(基础镜像; 用 --with-dfss-toolchains 重建)"
+fi
+
+echo "--- 打包 / 文档 / 验证工具 ---"
+CHECK  "dpkg-deb"               "dpkg-deb --version"
+CHECK  "dpkg-dev"               "dpkg-buildpackage --version | head -1"
+CHECK  "fakeroot"               "fakeroot --version"
+CHECK  "7z"                     "7z | head -1"
+CHECK  "zip"                    "zip -v | head -1"
+CHECK  "upx"                    "upx --version | head -1"
+CHECK  "patchelf"               "patchelf --version"
+CHECK  "qemu-aarch64-static"    "qemu-aarch64-static --version | head -1"
+CHECK  "qemu-loongarch64"       "qemu-loongarch64 --version | head -1"
+
+# ---- 交叉编译实测 ----
+if [[ "${DO_CROSS}" = "1" ]]; then
+  echo "--- 交叉编译实测 ---"
+  # C: aarch64 musl 静态
+  if run 'printf "int main(){return 0;}\n" > /tmp/c.c && aarch64-linux-musl-gcc -static /tmp/c.c -o /tmp/c.out && file /tmp/c.out | grep -qE "statically linked|static-pie linked"'; then
+    echo "  [PASS] C aarch64 musl 静态编译"
+  else
+    echo "  [FAIL] C aarch64 musl 静态编译"
+    FAIL=1
+  fi
+  # Rust: aarch64 musl 静态
+  if run 'cd /tmp && cargo new rusttest --bin >/dev/null 2>&1 && cd rusttest && echo "fn main(){println!(\"ok\")}" > src/main.rs && cargo build --release --target aarch64-unknown-linux-musl >/dev/null 2>&1 && file target/aarch64-unknown-linux-musl/release/rusttest | grep -qE "statically linked|static-pie linked"'; then
+    echo "  [PASS] Rust aarch64 musl 静态编译"
+  else
+    echo "  [FAIL] Rust aarch64 musl 静态编译"
+    FAIL=1
+  fi
+  # Windows: mingw64 交叉
+  if run 'printf "int main(){return 0;}\n" > /tmp/w.c && x86_64-w64-mingw32-gcc -static /tmp/w.c -o /tmp/w.exe && file /tmp/w.exe | grep -qE "PE32\+.*x86-64"'; then
+    echo "  [PASS] Windows x86_64 (mingw64) 交叉编译"
+  else
+    echo "  [FAIL] Windows x86_64 (mingw64) 交叉编译"
+    FAIL=1
+  fi
+  # Windows: mingw i686 交叉
+  if run 'printf "int main(){return 0;}\n" > /tmp/w32.c && i686-w64-mingw32-gcc -static /tmp/w32.c -o /tmp/w32.exe && file /tmp/w32.exe | grep -q "PE32"'; then
+    echo "  [PASS] Windows i686 (mingw) 交叉编译"
+  else
+    echo "  [FAIL] Windows i686 (mingw) 交叉编译"
+    FAIL=1
+  fi
+  # dfss sw_64 交叉(若有)
+  if run '[ -x /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc ]'; then
+    if run 'printf "int main(){return 0;}\n" > /tmp/s.c && /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc -static /tmp/s.c -o /tmp/s.out 2>/dev/null && file /tmp/s.out | grep -q "statically linked"'; then
+      echo "  [PASS] sw_64 静态交叉编译"
+    else
+      echo "  [FAIL] sw_64 静态交叉编译"
+      FAIL=1
+    fi
+    if run 'printf "int main(){return 0;}\n" > /tmp/l.c && /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc -static /tmp/l.c -o /tmp/l.out 2>/dev/null && file /tmp/l.out | grep -q "statically linked"'; then
+      echo "  [PASS] loongarch64 静态交叉编译"
+    else
+      echo "  [FAIL] loongarch64 静态交叉编译"
+      FAIL=1
+    fi
+  fi
+fi
+
+echo ""
+if [[ "${FAIL}" = "0" ]]; then
+  echo "== 自检全部通过 =="
+else
+  echo "== 存在失败项(见上方 [FAIL]) =="
+fi
+exit "${FAIL}"

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -1,0 +1,55 @@
+# sophon-tools-build 镜像版本源（唯一版本锁定点）
+# 所有工具链版本 + 校验和统一在此维护；Dockerfile / 脚本均引用本文件，禁止硬编码版本。
+# 修改版本后重新运行: bash docker/build.sh
+
+# ---- 基础镜像 ----
+# ubuntu:22.04 的 digest（不可变引用，保证可复现）
+UBUNTU_BASE_DIGEST="ubuntu@sha256:445586e41c1de7dfda82d2637f5ff688deea9eb5f5812f8c145afacc35b9f0db"
+
+# ---- Go（pbmssm / psophliteos 后端）----
+GO_VERSION="1.25.5"
+GO_TARBALL_SHA256="9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b"
+GO_TARBALL_URL="https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
+
+# ---- Rust（pbm_set_ip）----
+RUST_VERSION="1.97.1"            # rustup 工具链版本（稳定版）
+RUST_PROFILE="minimal"
+RUSTUP_INIT_SHA256=""            # 留空则不校验 rustup-init（rustup.rs 官方脚本）
+
+# ---- Node.js / pnpm / yarn（psophliteos 前端）----
+NODE_VERSION="20.19.0"
+NODE_TARBALL_SHA256="b4e336584d62abefad31baecff7af167268be9bb7dd11f1297112e6eed3ca0d5"
+NODE_TARBALL_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz"
+PNPM_VERSION="9.15.9"
+YARN_VERSION="1.22.22"
+
+# ---- C/C++ 交叉工具链（apt 精确版本，Dockerfile 内固定）----
+# 宿主机 gcc/g++（amd64）: 由 ubuntu:22.04 仓库提供，版本 11.x
+# aarch64-linux-gnu / arm-linux-gnueabi / riscv64-linux-gnu / mingw-w64: 由 ubuntu:22.04 仓库提供
+#   gcc-aarch64-linux-gnu / g++-aarch64-linux-gnu      -> aarch64 (pdfss_cpp arm64)
+#   gcc-arm-linux-gnueabi / g++-arm-linux-gnueabi      -> armbi (pdfss_cpp armel)
+#   gcc-riscv64-linux-gnu / g++-riscv64-linux-gnu      -> riscv64 (pdfss_cpp riscv64)
+#   gcc-mingw-w64-x86-64 / gcc-mingw-w64-i686          -> mingw64 / mingw (pdfss_cpp windows)
+
+# ---- musl 交叉工具链（pbmssm / psophliteos / pbm_set_ip 静态链接）----
+MUSL_AARCH64_NAME="aarch64-linux-musl-cross"
+MUSL_AARCH64_URL="https://musl.cc/${MUSL_AARCH64_NAME}.tgz"
+MUSL_AARCH64_SHA256=""           # 留空则首次构建时打印实际哈希，填回即可固定
+MUSL_X86_64_NAME="x86_64-linux-musl-cross"
+MUSL_X86_64_URL="https://musl.cc/${MUSL_X86_64_NAME}.tgz"
+MUSL_X86_64_SHA256=""
+
+# ---- dfss 私有工具链（sw_64 / loongarch64，13.24 服务器容器导出）----
+# 来源: 13.24 服务器 bm1684_zzt 容器（镜像 cross_build_sophon_u20:v1）
+#   sw_64:      /usr/sw/swgcc830_cross_tools   (SWREACH GCC 8.3.0)
+#   loongarch64: /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1 (LoongArch 8.3.0)
+# 通过 docker/scripts/export-dfss-toolchains.sh 从容器导出为 .tar.zst 后，放入 docker/toolchains/
+DFSS_SW64_NAME="swgcc830_cross_tools"
+DFSS_SW64_ARCHIVE="swgcc830_cross_tools.tar.zst"
+DFSS_LOONGARCH64_NAME="loongarch64-cross-tools"
+DFSS_LOONGARCH64_ARCHIVE="loongarch64-cross-tools.tar.zst"
+
+# ---- 其他工具（打包 / 文档 / 验证）----
+QT_VERSION="5.15.3"              # pqt 系列 AppImage 依赖（qmake）
+PANDOC_VERSION="2.9"
+UPX_VERSION="4.2.4"

--- a/source/pota_update/release.sh
+++ b/source/pota_update/release.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 
-BUILD_RET=0
+set -e
 
 echo "build ota_update ..."
 
-sudo rm -rf output 2>/dev/null
+rm -rf output 2>/dev/null
 mkdir output
 
-cp ota_update.sh output/
+# 主脚本（release 产物名为 ota_update.sh，源码文件为 ota.sh）
+cp ota.sh output/ota_update.sh
+cp ota.sh output/ota.sh
+# 附加脚本与 arm64 二进制
+cp get_network_info.sh output/ 2>/dev/null || true
+cp -r arm64_bin output/ 2>/dev/null || true
 
-exit $BUILD_RET
+ls -la output/
+echo "build ota_update done"

--- a/source/pqt_memory_edit/.gitignore
+++ b/source/pqt_memory_edit/.gitignore
@@ -45,3 +45,6 @@ source/deb/opt/sophon/*
 !*.so
 !*.a
 memory_edit*.tar.xz
+
+# docker 交叉编译产物
+build-win/


### PR DESCRIPTION
## 概述
M2 里程碑交付：sophon-tools 统一编译镜像 `sophon-tools-build`。`docker/` 目录交付物预装 17 子项目全部所需工具链，并提供**统一构建入口**在镜像内编译全部子项目、所有平台。

## 交付内容
| 目录/文件 | 说明 |
|-----------|------|
| `docker/Dockerfile` | 多阶段构建，ubuntu:22.04 digest 锁定，版本全部锁定 |
| `docker/versions.env` | 唯一版本源（工具链版本 + SHA256 校验） |
| `docker/build.sh` | 一条命令构建镜像 |
| `docker/build-all.sh` | **统一构建入口**：17 子项目在镜像内一键编译 |
| `docker/verify.sh` | 镜像自检（工具链 + 交叉编译实测） |
| `docker/README.md` | 使用说明 |
| `docker/scripts/export-dfss-toolchains.sh` | 从 13.24 容器导出 sw_64/loongarch64 私有工具链 |
| `docker/scripts/build-dfss-pip.sh` | dfss-cpp 8 架构交叉编译 + pip 包打包 |
| `docker/pqt/` | pqt 系列专用镜像 + linux/windows 一键编译 |
| `docker/examples/cross-test/` | 交叉编译示例 |

## 工具链清单
Go 1.25.5 / Rust 1.97.1 / Node 20.19.0+pnpm+yarn / glibc 交叉(aarch64/armel/riscv64) / mingw-w64(win-amd64/i686) / musl(aarch64/x86_64) / **dfss 私有 sw_64+loongarch64** / pandoc / sudo / dpkg-deb / 7z / upx / qemu-user

## 17 子项目镜像内编译验证（全部实测）
| # | 子项目 | 平台 | 结果 |
|---|--------|------|------|
| 1 | pbmssm | arm64(musl静态)+amd64 | ✅ bmssm_2.1.0_arm64/amd64.deb |
| 2 | psophliteos | arm64(musl静态)+amd64 | ✅ sophliteos_soc_2.1.0.deb(前端+后端) |
| 3 | pbmsec | all(deb双架构) | ✅ bmsec_v1.6.3.deb |
| 4 | psocbak | arm64 | ✅ socbak.zip |
| 5 | pget_info | arm64/amd64 | ✅ get_info.zip |
| 6 | pmem_aging_test | arm64 | ✅ mem_aging_test_V1.4.1.zip |
| 7 | pmemory_edit | arm64 | ✅ memory_edit_v2.12.deb+tar.xz |
| 8 | pota_update | arm64 | ✅ 修复 cp 错名 bug 后 ota_update.sh |
| 9 | pautotelecomm | arm64 | ✅ autotelecomm_install_1.2.8.sh |
| 10 | pbm_set_ip | arm64(musl静态) | ✅ bm_set_ip(647KB,upx) |
| 11 | pdfss_cpp | 8架构 | ✅ 全架构静态二进制+pip包 |
| 12 | pqt_batch_deployment | amd64/arm64 | ✅ AppImage |
| 13 | pqt_memory_edit | linux+windows | ✅ AppImage+exe(PE32+) |
| 14 | pSophUI | arm64 | ⚠️ 需交叉Qt(M3) |
| 15 | pmulti_video_qt | arm64 | ⚠️ 需libsophon SDK(M3) |
| 16 | psoph_phytool | 通用 | ✅ 脚本 |
| 17 | pspacc_efuse_demo | amd64/arm64 | ✅ gcc编译 |

## 统一构建入口
```bash
# 在镜像内编译全部 17 子项目
bash docker/build-all.sh
# 编译单个子项目
bash docker/build-all.sh --project pbmssm
# 查看清单
bash docker/build-all.sh --list
```

## 说明
- M3 边界：pSophUI(需 aarch64 交叉 Qt)、pmulti_video_qt(需 libsophon/sophon-mw SDK)，镜像不含，标注跳过
- 修复了 pota_update 的 release.sh bug（cp ota_update.sh -> ota.sh）并补 dpkg-deb 打包内容
- 全部版本锁定，`bash docker/build.sh` 一条命令复现