### PR TITLE
M4 一键全量多平台编译（Docker 内）

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,38 @@
 
 ## 编译方式
 
+### 一键全量多平台 release（推荐）
+
+本仓库已接入统一构建工程（M1~M4）：16 个子项目全部提供统一接口 `release.sh`，由
+Docker 统一镜像 `sophon-tools-build` 在容器内完成全部多平台编译。**一条命令全量出包**：
+
+```bash
+# 前置：统一构建镜像（首次）
+bash docker/build.sh --with-dfss-toolchains   # 完整镜像（含 dfss 私有 sw_64/loongarch64 工具链）
+
+# 一键全量 release（所有子项目多平台，Docker 内编译）
+bash release.sh
+
+# 常用变体
+bash release.sh --project pbmssm            # 单项目快速构建
+bash release.sh --version 2.1.0             # 全量 + 统一版本号
+bash release.sh --project pqt_memory_edit   # 宿主执行（pqt 系列需 docker-in-docker）
+```
+
+构建结束后：
+
+- 全部产物汇聚到 `output/<子项目>/`（保持既有 output 约定）
+- `output/MANIFEST.txt`：完整产物清单（子项目 / 文件名 / 架构 / 版本 / md5）
+- `output/git_hash.txt`：构建时仓库 HEAD
+- `output/.build-status.txt`：各子项目 PASS/FAIL/SKIP 状态
+
+**失败隔离**：单个子项目失败不阻塞整体，其余照常出包；构建结束列出失败项，
+`release.sh` 存在失败时以非零退出码结束（失败项见 `.build-status.txt` 与终端汇总）。
+
+详细文档见 [`docker/README.md`](./docker/README.md)。
+
+### 传统方式（单子项目）
+
 1. 支持一键编译的子项目在本目录下执行 `release.sh` 后会将成果输出到 `output` 目录
 2. 不支持一键编译的子项目请参考源码目录中的 `readme.md` 自行准备环境编译
 
@@ -42,3 +74,4 @@
 * 7z/zip
 * dpkg-deb
 * pandoc
+* docker（统一构建镜像 `sophon-tools-build:m2`）

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # sophon-tools-build —— sophon-tools 统一编译镜像
 
-`docker/` 目录是 sophon-tools 17 子项目的统一构建镜像交付物。镜像预装全部子项目所需工具链，
+`docker/` 目录是 sophon-tools 各子项目的统一构建镜像交付物。镜像预装全部子项目所需工具链，
 子项目构建只需基于此镜像，不再依赖构建机预装环境。
 
 ## 一条命令构建镜像
@@ -82,7 +82,7 @@ cd /workspace/sophon-tools/source/pbmssm
 bash build/build-deb-bmssm.sh   # 需以非 root 用户运行，或改输出目录为可写路径
 ```
 
-## 统一构建入口（M3）：全部 17 子项目一键编译
+## 统一构建入口（M3/M4）：全部子项目一键全量多平台编译
 
 每个子项目都提供统一接口的 `release.sh`（M1 规范 v0.1）：
 
@@ -96,16 +96,45 @@ bash release.sh [ARCH] [VERSION]
 `docker/build-all.sh` 在镜像内依次驱动全部子项目的 `release.sh`，产物汇聚到仓库根 `output/<子项目>/`：
 
 ```bash
-# 构建全部 17 子项目（默认平台）
+# 构建全部子项目（默认平台；失败隔离：单项目失败不影响整体）
 bash docker/build-all.sh
 
-# 只构建指定子项目 / 架构
+# 只构建指定子项目 / 架构 / 版本
 bash docker/build-all.sh --project pbmssm
 bash docker/build-all.sh --arch arm64
+bash docker/build-all.sh --version 2.1.0
 
 # 查看构建清单（子项目 + 平台 + 使用镜像）
 bash docker/build-all.sh --list
+
+# 生成产物清单（文件名/架构/版本/md5）
+bash docker/gen-manifest.sh          # -> output/MANIFEST.txt
 ```
+
+### M4：一条命令全量 release（推荐入口）
+
+仓库根 `release.sh` 是 M4 的一键全量入口，内部依次完成：镜像前置检查 → 驱动
+`build-all.sh` 全量构建 → 生成 `MANIFEST.txt` + `git_hash.txt` + `.build-status.txt`。
+
+```bash
+bash release.sh                      # 一键全量多平台 release
+bash release.sh --project pbmssm     # 单项目
+bash release.sh --version 2.1.0      # 统一版本号
+```
+
+**失败隔离语义**：单子项目失败（如某平台工具链缺失）不阻塞其他项目，其余照常出包。
+结束时打印汇总表并写 `output/.build-status.txt`（每行 `<子项目> PASS|FAIL:<rc>|SKIP`）；
+存在失败项时 `release.sh` 以退出码 1 结束，失败项在终端与状态文件中明确列出。
+
+**产物清单**：`output/MANIFEST.txt` 为固定格式文本：
+
+```
+子项目                | 文件名                                            | 架构           | 版本      | md5
+pbmssm               | bmssm_2.1.0_arm64.deb                             | arm64          | 2.1.0     | db83...
+pdfss_cpp            | dfss-cpp-linux-loongarch64                        | loongarch64    | 1.10.5    | ...
+```
+
+架构判定优先级：文件名关键字 → `.deb` 包 `Architecture` 字段 → `file` ELF/PE 探测。
 
 ### 各子项目使用的镜像
 
@@ -178,6 +207,8 @@ docker/
 ├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 汇入）
 ├── versions.env              # 唯一版本源（版本 + 校验和）
 ├── build.sh                  # 一条命令构建镜像
+├── build-all.sh              # 统一构建入口（M3/M4，驱动全部子项目 release.sh）
+├── gen-manifest.sh           # 生成产物清单 MANIFEST.txt（文件名/架构/版本/md5）
 ├── verify.sh                 # 镜像自检（对照 M1 清单）
 ├── README.md                 # 本文件
 ├── scripts/

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -181,6 +181,34 @@ else
   done
 fi
 
+# ---- 构建后清理：pSophUI 的 qmake 会在源码树内重生成 Makefile 并留下编译产物 ----
+# Makefile 是 qmake 生成物（仓库内为旧版 /env/qt_fl2000 路径），构建时被重写。
+# 为避免每次全量 release 弄脏工作区，构建后恢复仓库内 Makefile 并移除编译产物。
+# 产物由容器内 root 创建，清理时优先 sudo（与根 release.sh 旧版一致），无 sudo 则尽力而为。
+if [[ -z "${ONLY_PROJECT}" || "${ONLY_PROJECT}" = "pSophUI" ]]; then
+  pui="${REPO_ROOT}/source/pSophUI/SophUI"
+  if [[ -d "${pui}" ]]; then
+    git -C "${REPO_ROOT}" checkout -- "source/pSophUI/SophUI/Makefile" 2>/dev/null || true
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      sudo rm -rf "${pui}"/.qmake.stash \
+                  "${pui}"/Makefile.Debug \
+                  "${pui}"/Makefile.Release \
+                  "${pui}"/release \
+                  "${pui}"/ui_mainwindow.h 2>/dev/null || true
+      sudo rm -f "${pui}/SophUI" 2>/dev/null || true
+      sudo rm -rf "${pui}/deb/opt" 2>/dev/null || true
+    else
+      rm -rf "${pui}"/.qmake.stash \
+             "${pui}"/Makefile.Debug \
+             "${pui}"/Makefile.Release \
+             "${pui}"/release \
+             "${pui}"/ui_mainwindow.h 2>/dev/null || true
+      rm -f "${pui}/SophUI" 2>/dev/null || true
+      rm -rf "${pui}/deb/opt" 2>/dev/null || true
+    fi
+  fi
+fi
+
 echo ""
 echo "=========================================================="
 echo "==> 统一构建完成, 产物在 ${REPO_ROOT}/output/"

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# sophon-tools-build 统一构建全部 17 子项目（镜像内一键编译）
+# sophon-tools-build 统一构建全部子项目（镜像内一键编译）
 #
 # 目标: 在 sophon-tools-build 镜像内预装工具链, 对全部子项目执行所有平台的编译。
 # 本脚本是统一入口, 按 M1 规范驱动每个子项目的 release.sh（统一接口）。
@@ -10,14 +10,18 @@
 #     VERSION: 显式版本号（缺省用子项目版本来源）
 #     env OUTPUT_DIR: 覆盖产物目录（默认 <repo>/output/<子项目>/）
 #
+# 范围: 16 个子项目（pmulti_video_qt 已按 MYSWY 决定排除）
+#
 # 用法:
-#   bash docker/build-all.sh                    # 构建全部 17 子项目(默认平台)
+#   bash docker/build-all.sh                    # 构建全部子项目(默认平台)
 #   bash docker/build-all.sh --project pbmssm   # 只构建指定子项目
 #   bash docker/build-all.sh --arch arm64       # 只构建指定架构
 #   bash docker/build-all.sh --image sophon-tools-build:m2
+#   bash docker/build-all.sh --version 2.1.0    # 统一显式版本号（透传给所有 release.sh）
 #   bash docker/build-all.sh --list             # 列出子项目与平台
 #
 # 产物: 全部汇聚到仓库根 output/<子项目>/ (与根 release.sh 一致)
+# 失败隔离: 单子项目失败不影响其他项目，结束后汇总 PASS/FAIL，非零退出码。
 set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -27,14 +31,16 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 IMAGE="${IMAGE:-sophon-tools-build:m2}"
 ONLY_PROJECT=""
 ONLY_ARCH=""
+BUILD_VERSION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) ONLY_PROJECT="$2"; shift 2; continue ;;
     --arch) ONLY_ARCH="$2"; shift 2; continue ;;
     --image) IMAGE="$2"; shift 2; continue ;;
+    --version) BUILD_VERSION="$2"; shift 2; continue ;;
     --list) LIST_ONLY=1 ;;
-    -h|--help) grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -30; exit 0 ;;
+    -h|--help) grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -40; exit 0 ;;
     *) echo "未知参数: $1" >&2; exit 1 ;;
   esac
   shift
@@ -103,7 +109,7 @@ EXTRA_ENV[pdfss_cpp]="export PATH=/env/loongson-gnu-toolchain-8.3-x86_64-loongar
 EXTRA_ENV[pSophUI]="export PATH=/env/qt_5.12.8_nosysroot/bin:/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin:\$PATH; export QMAKESPEC=/env/qt_5.12.8_nosysroot/mkspecs/linux-aarch64-gnu-g++"
 
 if [[ "${LIST_ONLY:-0}" = "1" ]]; then
-  echo "=== sophon-tools 17 子项目构建清单 ==="
+  echo "=== sophon-tools 16 子项目构建清单（pmulti_video_qt 已排除） ==="
   for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
     img="${IMAGE_OVERRIDES[$p]:-$IMAGE}"
     printf "  %-22s 平台: %-40s 镜像: %s\n" "$p" "${PLATFORMS[$p]}" "$img"
@@ -115,6 +121,9 @@ fi
 mkdir -p "${REPO_ROOT}/output"
 echo "==> 统一构建, 输出: ${REPO_ROOT}/output"
 
+# 各子项目构建结果（失败隔离汇总）: "<项目>|<退出码>"
+RESULTS=()
+
 run_one() {
   local p="$1"
   local arch="${ONLY_ARCH:-${DEFAULT_ARCH[$p]}}"
@@ -122,36 +131,46 @@ run_one() {
   echo ""
   echo "========== [${p}] 平台: ${PLATFORMS[$p]} arch=${arch} 镜像: ${img} =========="
   local src_dir="${REPO_ROOT}/source/${p}"
-  [[ -d "${src_dir}" ]] || { echo "  [SKIP] 目录不存在: ${src_dir}"; return 0; }
+  if [[ ! -d "${src_dir}" ]]; then
+    echo "  [SKIP] 目录不存在: ${src_dir}"
+    RESULTS+=("${p}|skip")
+    return 0
+  fi
 
+  local rc=0
   # pqt 系列在宿主直接执行 release.sh（内部需要 docker 起专用容器）
   if [[ "${HOST_RUN[$p]:-0}" = "1" ]]; then
     (
       cd "${src_dir}"
-      echo "  >> (宿主) bash release.sh ${arch}"
-      OUTPUT_DIR="${REPO_ROOT}/output/${p}" bash release.sh "${arch}" 2>&1 | tail -20
+      echo "  >> (宿主) bash release.sh ${arch} ${BUILD_VERSION}"
+      OUTPUT_DIR="${REPO_ROOT}/output/${p}" bash release.sh "${arch}" ${BUILD_VERSION} 2>&1 | tail -20
     ) | sed 's/^/    /'
-    local rc=${PIPESTATUS[0]}
+    rc=${PIPESTATUS[0]}
     echo "  [${p}] 退出码: ${rc}"
-    return 0
+  else
+    local extra_env="${EXTRA_ENV[$p]:-}"
+    docker run --rm --privileged \
+      -v /dev:/dev \
+      -v "${REPO_ROOT}":/workspace/sophon-tools \
+      -w "/workspace/sophon-tools/source/${p}" \
+      -e OUTPUT_DIR="/workspace/sophon-tools/output/${p}" \
+      "${img}" bash -c "
+        set -euo pipefail
+        git config --global --add safe.directory '*' 2>/dev/null || true
+        git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
+        ${extra_env}
+        echo '  >> bash release.sh ${arch} ${BUILD_VERSION}'
+        bash release.sh ${arch} ${BUILD_VERSION} 2>&1 | tail -20
+      " 2>&1 | sed 's/^/    /'
+    rc=${PIPESTATUS[0]}
+    echo "  [${p}] 退出码: ${rc}"
   fi
 
-  local extra_env="${EXTRA_ENV[$p]:-}"
-  docker run --rm --privileged \
-    -v /dev:/dev \
-    -v "${REPO_ROOT}":/workspace/sophon-tools \
-    -w "/workspace/sophon-tools/source/${p}" \
-    -e OUTPUT_DIR="/workspace/sophon-tools/output/${p}" \
-    "${img}" bash -c "
-      set -e
-      git config --global --add safe.directory '*' 2>/dev/null || true
-      git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
-      ${extra_env}
-      echo '  >> bash release.sh ${arch}'
-      bash release.sh ${arch} 2>&1 | tail -20
-    " 2>&1 | sed 's/^/    /'
-  local rc=${PIPESTATUS[0]}
-  echo "  [${p}] 退出码: ${rc}"
+  if [[ "${rc}" = "0" ]]; then
+    RESULTS+=("${p}|ok")
+  else
+    RESULTS+=("${p}|fail:${rc}")
+  fi
 }
 
 if [[ -n "${ONLY_PROJECT}" ]]; then
@@ -163,5 +182,25 @@ else
 fi
 
 echo ""
+echo "=========================================================="
 echo "==> 统一构建完成, 产物在 ${REPO_ROOT}/output/"
-echo "==> 汇总: bash docker/verify.sh --image ${IMAGE}"
+echo "==> 构建汇总:"
+PASS_N=0; FAIL_N=0; SKIP_N=0
+STATUS_FILE="${REPO_ROOT}/output/.build-status.txt"
+: > "${STATUS_FILE}"
+for r in "${RESULTS[@]:-}"; do
+  p="${r%%|*}"; st="${r#*|}"
+  printf "    %-24s %s\n" "$p" "$st"
+  printf "%-24s %s\n" "$p" "$st" >> "${STATUS_FILE}"
+  case "$st" in
+    ok) PASS_N=$((PASS_N+1)) ;;
+    skip) SKIP_N=$((SKIP_N+1)) ;;
+    *) FAIL_N=$((FAIL_N+1)) ;;
+  esac
+done
+echo "==> 通过: ${PASS_N}  失败: ${FAIL_N}  跳过: ${SKIP_N}"
+echo "==> 状态文件: ${STATUS_FILE}"
+echo "=========================================================="
+echo "==> 产物清单: bash docker/gen-manifest.sh"
+[[ "${FAIL_N}" = "0" ]] || { echo "==> 存在失败项, 请查看上方 [xxx] 退出码" >&2; exit 1; }
+echo "==> 镜像自检: bash docker/verify.sh --image ${IMAGE}"

--- a/docker/gen-manifest.sh
+++ b/docker/gen-manifest.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# 生成统一产物清单 MANIFEST.txt（文件名 / 架构 / 版本 / md5）
+#
+# 用法:
+#   bash docker/gen-manifest.sh                 # 默认扫描仓库根 output/
+#   bash docker/gen-manifest.sh --output <dir>  # 指定产物目录
+#
+# 输出: <output>/MANIFEST.txt
+# 说明:
+#   - 递归扫描 output/<子项目>/ 下的全部文件（跳过顶层 MANIFEST.txt/git_hash.txt 等元数据）
+#   - 架构: 优先从文件名关键字推断; 否则用 `file` 探测; 无信息记 unknown
+#   - 版本: 从文件名中的 v?<数字>.<数字>.<数字> 提取; 无则 unknown
+#   - md5: 全部计算
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUT_ROOT="${OUTPUT_ROOT:-${REPO_ROOT}/output}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output) OUT_ROOT="$2"; shift 2; continue ;;
+    -h|--help) grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -20; exit 0 ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+MANIFEST="${OUT_ROOT}/MANIFEST.txt"
+: > "${MANIFEST}"
+
+detect_arch() {
+  # $1=文件名 $2=文件路径
+  local name="$1" path="$2"
+  case "$name" in
+    *win*amd64*|*win*x86_64*) echo "win-amd64"; return ;;
+    *win*i686*|*win*32*)      echo "win-i686"; return ;;
+    *\.exe)                   echo "win-amd64"; return ;;
+    *arm64*|*aarch64*|*_arm64*)  echo "arm64"; return ;;
+    *amd64*|*x86_64*|*x86-64*)   echo "amd64"; return ;;
+    *armbi*) echo "armbi"; return ;;
+    *loongarch64*) echo "loongarch64"; return ;;
+    *riscv64*) echo "riscv64"; return ;;
+    *sw_64*) echo "sw_64"; return ;;
+    *i686*) echo "i686"; return ;;
+  esac
+  # .deb 用包元数据（Architecture 字段）
+  if [[ "${name}" == *.deb ]] && command -v dpkg-deb >/dev/null 2>&1; then
+    local a
+    a="$(dpkg-deb -f "$path" Architecture 2>/dev/null)"
+    case "$a" in
+      arm64|amd64|armel|all) echo "${a}"; return ;;
+    esac
+  fi
+  # 探测 ELF/PE
+  local ftype
+  ftype="$(file -b "$path" 2>/dev/null)"
+  case "$ftype" in
+    *aarch64*) echo "arm64"; return ;;
+    *x86-64*) echo "amd64"; return ;;
+    *ARM*) echo "arm"; return ;;
+    *MIPS*) echo "mips"; return ;;
+    *"RISC-V"*) echo "riscv64"; return ;;
+    *PE32+*) echo "win-amd64"; return ;;
+    *PE32*) echo "win-i686"; return ;;
+    *ELF*) echo "elf"; return ;;
+  esac
+  echo "unknown"
+}
+
+detect_ver() {
+  local name="$1"
+  local v
+  v="$(echo "$name" | grep -oE '[0-9]+\.[0-9]+(\.[0-9]+)?' | head -1)"
+  echo "${v:-unknown}"
+}
+
+echo "==> 生成产物清单: ${MANIFEST}"
+printf '%-22s | %-52s | %-14s | %-10s | %s\n' \
+  "子项目" "文件名" "架构" "版本" "md5" | tee -a "${MANIFEST}"
+printf '%s\n' "---------------------+-----------------------------------------------------+----------------+------------+----------------------------------" >> "${MANIFEST}"
+
+TOTAL=0
+for pdir in "${OUT_ROOT}"/*/; do
+  [[ -d "${pdir}" ]] || continue
+  p="$(basename "${pdir}")"
+  [[ "${p}" = "." || "${p}" = ".." ]] && continue
+  # 递归扫描子目录内全部文件（如 pota_update/arm64_bin/bc），跳过顶层元数据文件
+  while IFS= read -r -d '' f; do
+    rel="${f#"${pdir}"}"
+    name="$(basename "${f}")"
+    if [[ "${rel}" != */* ]]; then
+      case "${name}" in
+        MANIFEST.txt|git_hash.txt|.build-status.txt|.gitkeep) continue ;;
+      esac
+    fi
+    md5="$(md5sum "${f}" | awk '{print $1}')"
+    arch="$(detect_arch "${name}" "${f}")"
+    ver="$(detect_ver "${name}")"
+    printf '%-22s | %-52s | %-14s | %-10s | %s\n' \
+      "${p}" "${rel}" "${arch}" "${ver}" "${md5}" | tee -a "${MANIFEST}"
+    TOTAL=$((TOTAL+1))
+  done < <(find "${pdir}" -type f -print0)
+done
+
+echo "==> 清单完成: ${TOTAL} 个文件, 见 ${MANIFEST}"

--- a/release.sh
+++ b/release.sh
@@ -1,27 +1,97 @@
 #!/bin/bash
+# =============================================================================
+# sophon-tools 一键全量多平台 release（M4 统一入口）
+#
+# 用法:
+#   bash release.sh [--project <子项目>] [--version <版本号>] [--no-image-check]
+#
+# 行为:
+#   1. 检查统一构建镜像 sophon-tools-build:m2 是否可用；缺失时提示用
+#      `bash docker/build.sh` 构建（不自动构建，避免长时间阻塞）。
+#   2. 驱动 docker/build-all.sh 对全部子项目做多平台构建（失败隔离：单项目
+#      失败不阻塞整体，结束后列出失败项，非零退出）。
+#   3. 汇聚产物到 output/<子项目>/（保持既有 output 约定），并生成:
+#        - output/MANIFEST.txt   产物清单（子项目/文件名/架构/版本/md5）
+#        - output/git_hash.txt   构建时仓库 HEAD
+#        - output/.build-status.txt  各子项目 PASS/FAIL 状态（供脚本读取）
+#
+# 退出码:
+#   0  全部子项目构建成功
+#   1  存在失败子项目（含镜像缺失等前置检查失败）
+#
+# 向后兼容: 支持 --project 单项目快速构建; 无参数 = 全量。
+# =============================================================================
+set -uo pipefail
 
-script_path="$(dirname "$(readlink -f "$0")")"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "${SCRIPT_DIR}" || exit 1
 
-export CMD_BASH=$(command -v bash)
+IMAGE="${IMAGE:-sophon-tools-build:m2}"
+ARGS=()
 
-echo "release start ..."
-pushd "$script_path"
-	sudo rm output/* -rf
-	for dir in source/*/
-	do
-		echo "release $dir ..."
-		pushd "$dir"
-			if [ -f release.sh ]; then
-				$CMD_BASH release.sh
-				if [ -d output ]; then
-					cp -r output/* "$script_path/output/" 2>/dev/null
-				fi
-			else
-				echo "[$dir] no have release.sh, cannot auto release"
-			fi
-		popd
-	done
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --project) ARGS+=(--project "$2"); shift 2; continue ;;
+    --version) ARGS+=(--version "$2"); shift 2; continue ;;
+    --image) IMAGE="$2"; shift 2; continue ;;
+    --no-image-check) NO_IMAGE_CHECK=1; shift ;;
+    -h|--help)
+      grep -E '^# ' "$0" | sed 's/^# \{0,1\}//' | head -40
+      exit 0 ;;
+    *) echo "未知参数: $1（用 bash release.sh --help 查看）" >&2; exit 1 ;;
+  esac
+  shift
+done
 
-popd
-git rev-parse HEAD | tee output/git_hash.txt
-echo "release end"
+echo "==> sophon-tools 一键全量 release（M4 统一入口）"
+echo "==> 工作目录: ${SCRIPT_DIR}"
+
+# --- 1. 镜像前置检查 --------------------------------------------------------
+if [[ -z "${NO_IMAGE_CHECK:-}" ]]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: 未找到 docker，本构建依赖 Docker 统一镜像。请先安装 docker。" >&2
+    exit 1
+  fi
+  if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+    echo "ERROR: 统一构建镜像 ${IMAGE} 不存在。" >&2
+    echo "       请先构建镜像: bash docker/build.sh [--with-dfss-toolchains]" >&2
+    echo "       或指定已有镜像: bash release.sh --image <镜像名>" >&2
+    exit 1
+  fi
+  echo "==> 镜像就绪: ${IMAGE}"
+fi
+
+# --- 2. 全量构建（失败隔离由 docker/build-all.sh 负责） -----------------------
+bash "${SCRIPT_DIR}/docker/build-all.sh" --image "${IMAGE}" "${ARGS[@]}"
+BUILD_RC=$?
+
+# --- 3. 产物清单 + git_hash + 构建状态 ----------------------------------------
+echo ""
+echo "==> 生成产物清单..."
+bash "${SCRIPT_DIR}/docker/gen-manifest.sh" >/dev/null 2>&1 \
+  && echo "==> 产物清单: output/MANIFEST.txt" \
+  || echo "WARN: 生成产物清单失败" >&2
+
+echo "==> 写入 git_hash.txt ..."
+git rev-parse HEAD 2>/dev/null | tee output/git_hash.txt \
+  || echo "WARN: 无法获取 git HEAD（非 git 仓库？）" >&2
+
+# 构建状态汇总由 docker/build-all.sh 写入 output/.build-status.txt
+# （各子项目 PASS / FAIL:<rc> / SKIP），供脚本与人读取。
+
+if [[ "${BUILD_RC}" = "0" ]]; then
+  echo ""
+  echo "=========================================================="
+  echo "==> ✅ 全部子项目构建成功"
+  echo "==> 产物目录: output/"
+  echo "==> 清单文件: output/MANIFEST.txt"
+  echo "=========================================================="
+  exit 0
+else
+  echo ""
+  echo "=========================================================="
+  echo "==> ⚠️ 存在失败子项目（见上方构建汇总）"
+  echo "==> 其余子项目产物仍已生成，见 output/MANIFEST.txt"
+  echo "=========================================================="
+  exit 1
+fi


### PR DESCRIPTION
## Summary

M4 里程碑：一条命令在 Docker 内完成全部 16 个子项目多平台 release（基于 M3 统一构建）。

- **根 `release.sh` 重写**为 M4 一键全量入口：镜像前置检查 → 驱动 `docker/build-all.sh` 全量构建 → 生成 `MANIFEST.txt` / `git_hash.txt` / `.build-status.txt`
- **`docker/build-all.sh` 增强**：`--version` 透传、逐项目 PASS/FAIL 汇总、失败隔离非零退出；修复容器内管道吞掉子项目退出码（`set -euo pipefail`）；pSophUI 构建后清理 qmake 产物保持工作区干净
- **新增 `docker/gen-manifest.sh`**：产物清单（子项目 / 文件名 / 架构 / 版本 / md5），架构判定优先文件名 → `.deb` Architecture → `file` 探测
- **文档**：根 README 与 `docker/README.md` 补充一键全量用法、失败隔离语义、清单格式

## 验收核对

- [x] 一条命令 `bash release.sh` 在 Docker 内完成 16 子项目多平台构建（真实环境实测，全部 PASS，退出码 0）
- [x] 产物齐全、架构正确（`file` 实测 arm64/amd64/loongarch64/sw_64/riscv64/win 等）、版本统一，附完整清单 `output/MANIFEST.txt`（含 md5）
- [x] 失败隔离生效（实测：人为破坏一子项目 → 其余 15 照常出包，失败项明确列出，非零退出）
- [x] 文档清晰（根 README + docker/README）

## 测试记录

- 全量构建 ×3 次通过（含版本透传、失败注入隔离测试）
- 产物 35 个文件 / 156M，`output/MANIFEST.txt` 逐项 md5
- 工作区在构建后保持干净（pSophUI qmake 产物已清理）

🤖 Generated with [Claude Code](https://claude.com/claude-code)