### PR TITLE
feat(m5): 单镜像合并 — 统一 ubuntu:20.04 基座镜像（三镜像→单镜像）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,16 +1,24 @@
 # syntax=docker/dockerfile:1
 # =============================================================================
-# sophon-tools-build —— sophon-tools 17 子项目统一编译镜像
+# sophon-tools-build —— sophon-tools 16 子项目统一编译镜像（M5 单镜像合并）
 #
 # 设计:
-#   * 多阶段构建: Stage1 下载并校验国外大体积工具链(Go/Node); Stage2 汇入运行镜像。
+#   * 基座 ubuntu:20.04（glibc 2.31）: 满足 pqt AppImage 的 linuxdeployqt 硬约束
+#     (glibc<=2.31)，同时作为全部子项目唯一基座，替代 M4 的三镜像方案:
+#        - 旧 sophon-tools-build:m2      (ubuntu:22.04 主镜像)  -> 本镜像
+#        - 旧 sophon-tools-build-pqt     (ubuntu:20.04 pqt 专用) -> 本镜像(合并 pqt 依赖)
+#        - 旧 cross_build_sophon_u20:v1  (ubuntu:20.04 pSophUI)  -> 本镜像(并入 aarch64 Qt)
+#   * 多阶段构建: Stage1 下载并校验国外大体积工具链(Go/Node); Stage2 汇入运行镜像;
+#     Stage3 从 cross_build_sophon_u20:v1 汇入 pSophUI 交叉工具链。
 #   * 版本唯一来源 docker/versions.env(由 docker/build.sh 注入 ARG), 全部版本锁定。
 #   * 交叉工具链: apt 精确版本(glibc) + musl.cc(静态) + dfss 私有工具链(sw_64/loongarch64)。
 #   * dfss 私有工具链默认不内置(私有源, 体积大); 通过 --with-dfss-toolchains 或构建上下文
 #     toolchains/ 目录内置。
+#   * Qt mingw 静态库(pqt windows exe 依赖)默认不内置; 通过 --with-qt-mingw 或构建上下文
+#     toolchains/qt-mingw/ 目录内置。
 #
 # 构建(一条命令):  bash docker/build.sh
-# 构建(含私有工具链): bash docker/build.sh --with-dfss-toolchains
+# 构建(含私有工具链): bash docker/build.sh --with-dfss-toolchains --with-qt-mingw
 # =============================================================================
 
 # ---- ARG 集合(由 build.sh 从 versions.env 注入) ----
@@ -20,6 +28,7 @@ ARG RUST_VERSION
 ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
 ARG PNPM_VERSION YARN_VERSION
 ARG WITH_DFSS=0
+ARG WITH_QT_MINGW=0
 
 # ---- Stage 1: 下载 + 校验(仅构建期需要, 不进入最终镜像) ----
 FROM ${UBUNTU_BASE_DIGEST} AS downloader
@@ -42,9 +51,14 @@ RUN curl -fsSL "${NODE_TARBALL_URL}" -o node.tar.xz \
     && mkdir -p /opt/nodejs && tar -C /opt/nodejs --strip-components=1 -xJf node.tar.xz \
     && /opt/nodejs/bin/node --version
 
+# ---- Stage 3: pSophUI 交叉工具链来源(13.24 cross_build_sophon_u20:v1 同款) ----
+# 多阶段直接复用 13.24 现成镜像; qmake/mkspecs/Linaro gcc 硬编码 /env 绝对路径,
+# 故 COPY 到容器内原始路径, 保证绝对引用全部有效。
+FROM cross_build_sophon_u20:v1 AS sophui
+
 # ---- Stage 2: 最终运行镜像 ----
 FROM ${UBUNTU_BASE_DIGEST}
-ARG GO_VERSION RUST_VERSION PNPM_VERSION YARN_VERSION WITH_DFSS
+ARG GO_VERSION RUST_VERSION PNPM_VERSION YARN_VERSION WITH_DFSS WITH_QT_MINGW
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
@@ -53,9 +67,10 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 SHELL ["/bin/bash", "-c"]
 
-# ---- 系统依赖 + apt 交叉工具链(精确版本, 由 ubuntu:22.04 仓库固定) ----
+# ---- 系统依赖 + apt 交叉工具链(精确版本, 由 ubuntu:20.04 仓库固定) ----
 # pdfss_cpp 8 架构: aarch64/armel/riscv64 + mingw-w64(windows amd64/i686)
 # Rust/Go 静态: musl 工具链在 PATH(由 pbmssm 的 fetch-musl-toolchain.sh 识别复用)
+# pqt 系列: qtbase5-dev(Qt 5.12.8, 20.04 仓库) + libgl1-mesa-dev + fuse + patchelf(AppImage)
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make cmake pkg-config \
         gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
@@ -64,6 +79,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 gcc-mingw-w64-i686 g++-mingw-w64-i686 \
         dpkg dpkg-dev fakeroot \
         qtbase5-dev qttools5-dev-tools \
+        libgl1-mesa-dev libglib2.0-0 \
         ca-certificates curl wget git \
         zip unzip p7zip-full patchelf \
         python3 python3-pip python3-dev \
@@ -71,7 +87,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libssl-dev libtool autoconf automake \
         file binutils upx-ucl \
         qemu-user qemu-user-static binfmt-support \
-        libfuse2 ssh strace pandoc sudo \
+        libfuse2 fuse ssh strace pandoc sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # ---- Go(来自 Stage1, 已校验) ----
@@ -109,14 +125,41 @@ RUN mkdir -p /opt/musl \
     && tar -C /opt/musl -xzf /tmp/musl-x86_64.tgz && rm /tmp/musl-x86_64.tgz \
     && aarch64-linux-musl-gcc --version | head -1 && x86_64-linux-musl-gcc --version | head -1
 
-# ---- dfss 私有工具链(sw_64 / loongarch64)----
+# ---- pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3, 来自 Stage3) ----
+# 与 13.24 cross_build_sophon_u20:v1 完全一致, 保持 /env 原始路径。
+# 注意: 不把 /env/qt_5.12.8_nosysroot/bin 加入全局 PATH——其含通用名 qmake/moc,
+#       会遮蔽宿主机 Qt5 qmake, 破坏 pqt 系列(linuxdeployqt)构建。
+#       pSophUI 的 release.sh 内部自行 export 自己的 qmake/gcc 到 PATH(见 source/pSophUI/release.sh)。
+COPY --from=sophui /env/qt_5.12.8_nosysroot /env/qt_5.12.8_nosysroot
+COPY --from=sophui /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
+
+# ---- Qt mingw 静态库(pqt windows exe 依赖) ----
+# 构建上下文需含 qt-mingw.tar.zst 或 toolchains/qt-mingw/ 目录(由 build-qt-mingw.sh 在 20.04
+# 基座内从源码编译)。默认不内置; 加 --with-qt-mingw 构建。
+# 仅消费 qt-mingw 相关文件, 不触碰同目录下 dfss 归档。
+ARG WITH_QT_MINGW=0
+COPY toolchains/ /tmp/toolchains/
+RUN if [ "${WITH_QT_MINGW}" = "1" ] && { [ -f /tmp/toolchains/qt-mingw.tar.zst ] || [ -d /tmp/toolchains/qt-mingw ]; }; then \
+        mkdir -p /opt/qt-mingw \
+        && if [ -f /tmp/toolchains/qt-mingw.tar.zst ]; then \
+            tar -C /opt/qt-mingw -I zstd -xf /tmp/toolchains/qt-mingw.tar.zst; \
+        else \
+            cp -a /tmp/toolchains/qt-mingw/. /opt/qt-mingw/; \
+        fi \
+        && rm -rf /tmp/toolchains/qt-mingw /tmp/toolchains/qt-mingw.tar.zst; \
+    fi
+
+# ---- dfss 私有工具链(sw_64 / loongarch64) ----
 # 构建上下文需含 toolchains/ 目录(由 export-dfss-toolchains.sh 导出), 或用 --with-dfss-toolchains。
 # 注意: sw_64 工具链 gcc 编译期 prefix 硬编码为 /usr/sw/swgcc830_cross_tools,
 #       loongarch64 硬编码为 /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1,
 #       故解压到容器内原始路径, 保证绝对引用全部有效(与 13.24 源容器一致)。
+# 重要: 不把 /usr/sw/.../bin 加入全局 PATH——其含通用名 ldd(sw64 glibc 版), 会遮蔽系统 ldd,
+#       破坏 linuxdeployqt/pqt 等对宿主 ldd 的依赖(对 x86 二进制的解析)。dfss 工具链仅
+#       pdfss_cpp 需要, 由 build-all.sh 的 EXTRA_ENV 按子项目注入 PATH。
 ARG WITH_DFSS=0
-COPY toolchains/ /tmp/toolchains/
-RUN if [ "${WITH_DFSS}" = "1" ] || [ -n "$(ls /tmp/toolchains 2>/dev/null)" ]; then \
+RUN if { [ "${WITH_DFSS}" = "1" ] || [ -n "$(ls /tmp/toolchains 2>/dev/null)" ]; } \
+       && { [ -f /tmp/toolchains/swgcc830_cross_tools.tar.zst ] || [ -f /tmp/toolchains/loongarch64-cross-tools.tar.zst ]; }; then \
         if [ -f /tmp/toolchains/swgcc830_cross_tools.tar.zst ]; then \
             mkdir -p /usr/sw \
             && tar -C /usr/sw -I zstd -xf /tmp/toolchains/swgcc830_cross_tools.tar.zst; \
@@ -127,13 +170,14 @@ RUN if [ "${WITH_DFSS}" = "1" ] || [ -n "$(ls /tmp/toolchains 2>/dev/null)" ]; t
         fi \
         && rm -rf /tmp/toolchains; \
     fi
-ENV DFSS_TOOLCHAIN_ROOT="/usr/sw/swgcc830_cross_tools" \
-    PATH="/usr/sw/swgcc830_cross_tools/usr/bin:/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:${PATH}"
+ENV DFSS_TOOLCHAIN_ROOT="/usr/sw/swgcc830_cross_tools"
 
 # ---- 工作区约定 ----
 WORKDIR /workspace
 RUN git config --global --add safe.directory "*" \
     && printf '#!/bin/bash\nif [ -x /usr/sw/swgcc830_cross_tools/usr/bin/sw_64-sunway-linux-gnu-gcc ] && [ -x /env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin/loongarch64-linux-gnu-gcc ]; then\n  echo "[sophon-tools-build] dfss 私有工具链已就绪 (sw_64 + loongarch64)"\nelse\n  echo "[sophon-tools-build] dfss 私有工具链未内置 (构建时加 --with-dfss-toolchains)"\nfi\n' > /usr/local/bin/dfss-check \
-    && chmod +x /usr/local/bin/dfss-check
+    && chmod +x /usr/local/bin/dfss-check \
+    && printf '#!/bin/bash\nif [ -x /env/qt_5.12.8_nosysroot/bin/qmake ] && [ -x /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc ]; then\n  echo "[sophon-tools-build] pSophUI 交叉工具链已就绪 (aarch64 Qt 5.12.8 + Linaro GCC 6.3)"\nelse\n  echo "[sophon-tools-build] pSophUI 交叉工具链缺失"\nfi\n' > /usr/local/bin/sophui-check \
+    && chmod +x /usr/local/bin/sophui-check
 
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,17 +8,20 @@
 #        - 旧 sophon-tools-build:m2      (ubuntu:22.04 主镜像)  -> 本镜像
 #        - 旧 sophon-tools-build-pqt     (ubuntu:20.04 pqt 专用) -> 本镜像(合并 pqt 依赖)
 #        - 旧 cross_build_sophon_u20:v1  (ubuntu:20.04 pSophUI)  -> 本镜像(并入 aarch64 Qt)
-#   * 多阶段构建: Stage1 下载并校验国外大体积工具链(Go/Node); Stage2 汇入运行镜像;
-#     Stage3 从 cross_build_sophon_u20:v1 汇入 pSophUI 交叉工具链。
+#   * 多阶段构建: Stage1 下载并校验国外大体积工具链(Go/Node); Stage2 汇入运行镜像。
+#     pSophUI 交叉工具链(Stage3 独立镜像 cross_build_sophon_u20:v1)已并入本镜像,
+#     通过 toolchains/sophui-cross-toolchains.tar.zst 归档内置, 不再依赖独立镜像。
 #   * 版本唯一来源 docker/versions.env(由 docker/build.sh 注入 ARG), 全部版本锁定。
 #   * 交叉工具链: apt 精确版本(glibc) + musl.cc(静态) + dfss 私有工具链(sw_64/loongarch64)。
 #   * dfss 私有工具链默认不内置(私有源, 体积大); 通过 --with-dfss-toolchains 或构建上下文
 #     toolchains/ 目录内置。
 #   * Qt mingw 静态库(pqt windows exe 依赖)默认不内置; 通过 --with-qt-mingw 或构建上下文
 #     toolchains/qt-mingw/ 目录内置。
+#   * pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3)默认不内置(约 1GB, 私有源);
+#     通过 --with-sophui-toolchain 或构建上下文 toolchains/sophui-cross-toolchains.tar.zst 内置。
 #
 # 构建(一条命令):  bash docker/build.sh
-# 构建(含私有工具链): bash docker/build.sh --with-dfss-toolchains --with-qt-mingw
+# 构建(含私有工具链): bash docker/build.sh --with-dfss-toolchains --with-qt-mingw --with-sophui-toolchain
 # =============================================================================
 
 # ---- ARG 集合(由 build.sh 从 versions.env 注入) ----
@@ -29,6 +32,7 @@ ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
 ARG PNPM_VERSION YARN_VERSION
 ARG WITH_DFSS=0
 ARG WITH_QT_MINGW=0
+ARG WITH_SOPHUI=0
 
 # ---- Stage 1: 下载 + 校验(仅构建期需要, 不进入最终镜像) ----
 FROM ${UBUNTU_BASE_DIGEST} AS downloader
@@ -51,14 +55,9 @@ RUN curl -fsSL "${NODE_TARBALL_URL}" -o node.tar.xz \
     && mkdir -p /opt/nodejs && tar -C /opt/nodejs --strip-components=1 -xJf node.tar.xz \
     && /opt/nodejs/bin/node --version
 
-# ---- Stage 3: pSophUI 交叉工具链来源(13.24 cross_build_sophon_u20:v1 同款) ----
-# 多阶段直接复用 13.24 现成镜像; qmake/mkspecs/Linaro gcc 硬编码 /env 绝对路径,
-# 故 COPY 到容器内原始路径, 保证绝对引用全部有效。
-FROM cross_build_sophon_u20:v1 AS sophui
-
 # ---- Stage 2: 最终运行镜像 ----
 FROM ${UBUNTU_BASE_DIGEST}
-ARG GO_VERSION RUST_VERSION PNPM_VERSION YARN_VERSION WITH_DFSS WITH_QT_MINGW
+ARG GO_VERSION RUST_VERSION PNPM_VERSION YARN_VERSION WITH_DFSS WITH_QT_MINGW WITH_SOPHUI
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \
@@ -125,13 +124,22 @@ RUN mkdir -p /opt/musl \
     && tar -C /opt/musl -xzf /tmp/musl-x86_64.tgz && rm /tmp/musl-x86_64.tgz \
     && aarch64-linux-musl-gcc --version | head -1 && x86_64-linux-musl-gcc --version | head -1
 
-# ---- pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3, 来自 Stage3) ----
+# ---- pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3) ----
 # 与 13.24 cross_build_sophon_u20:v1 完全一致, 保持 /env 原始路径。
+# 来源: toolchains/sophui-cross-toolchains.tar.zst(由 export-sophui-toolchains.sh 从
+#       13.24 cross_build_sophon_u20:v1 导出), 解压到 /env 原始路径, 保证 qmake/mkspecs/
+#       Linaro gcc 硬编码的绝对引用全部有效。
 # 注意: 不把 /env/qt_5.12.8_nosysroot/bin 加入全局 PATH——其含通用名 qmake/moc,
 #       会遮蔽宿主机 Qt5 qmake, 破坏 pqt 系列(linuxdeployqt)构建。
 #       pSophUI 的 release.sh 内部自行 export 自己的 qmake/gcc 到 PATH(见 source/pSophUI/release.sh)。
-COPY --from=sophui /env/qt_5.12.8_nosysroot /env/qt_5.12.8_nosysroot
-COPY --from=sophui /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
+# 默认不内置(约 1GB, 私有源); 加 --with-sophui-toolchain 或构建上下文放归档自动内置。
+ARG WITH_SOPHUI=0
+COPY toolchains/ /tmp/toolchains/
+RUN if [ "${WITH_SOPHUI}" = "1" ] && [ -f /tmp/toolchains/sophui-cross-toolchains.tar.zst ]; then \
+        mkdir -p /env \
+        && tar -C /env -I zstd -xf /tmp/toolchains/sophui-cross-toolchains.tar.zst \
+        && rm -f /tmp/toolchains/sophui-cross-toolchains.tar.zst; \
+    fi
 
 # ---- Qt mingw 静态库(pqt windows exe 依赖) ----
 # 构建上下文需含 qt-mingw.tar.zst 或 toolchains/qt-mingw/ 目录(由 build-qt-mingw.sh 在 20.04

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,23 +11,24 @@
 ## 一条命令构建镜像
 
 ```bash
-# 基础镜像（不含 dfss 私有工具链 sw_64/loongarch64 与 Qt mingw 静态库）
+# 基础镜像（不含 dfss 私有工具链 sw_64/loongarch64、Qt mingw 静态库、pSophUI 交叉工具链）
 bash docker/build.sh
 
-# 完整镜像（内置 dfss 私有工具链 + Qt mingw 静态库）
-bash docker/build.sh --with-dfss-toolchains --with-qt-mingw
+# 完整镜像（内置 dfss 私有工具链 + Qt mingw 静态库 + pSophUI 交叉工具链）
+bash docker/build.sh --with-dfss-toolchains --with-qt-mingw --with-sophui-toolchain
 
-# 只内置 dfss / 只内置 Qt mingw / 指定标签 / 禁用缓存
+# 只内置 dfss / 只内置 Qt mingw / 只内置 pSophUI / 指定标签 / 禁用缓存
 bash docker/build.sh --with-dfss-toolchains
 bash docker/build.sh --with-qt-mingw
+bash docker/build.sh --with-sophui-toolchain
 bash docker/build.sh --tag v1.0 --no-cache
 ```
 
 构建依赖：
 - docker（≥20.10，BuildKit 默认开启），网络可访问 go.dev / nodejs.org / musl.cc
-- `cross_build_sophon_u20:v1` 镜像（13.24 服务器有），Dockerfile 多阶段从它 COPY
-  pSophUI 交叉工具链（`/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu`）
-- dfss 私有工具链 / Qt mingw 静态库：见下文
+- pSophUI / dfss 私有工具链：以 `toolchains/` 归档内置（`--with-sophui-toolchain` / `--with-dfss-toolchains`），
+  不再依赖 `cross_build_sophon_u20:v1` 独立镜像（导出归档见下文）
+- Qt mingw 静态库：见下文
 
 ### 版本锁定（可复现）
 
@@ -46,7 +47,7 @@ ubuntu:20.04 的 glibc 是 2.31（22.04 是 2.35）。M5 决定以 20.04 为唯�
 |------|-----------|---------------------|
 | pqt AppImage（glibc≤2.31） | `sophon-tools-build-pqt`（20.04） | 基座即 20.04，Qt5 + libgl1-mesa-dev + fuse + patchelf 内置 |
 | pqt windows exe（Qt mingw 静态库） | `sophon-tools-build:m2` + 宿主 `/opt/qt-mingw` | `--with-qt-mingw` 内置 `/opt/qt-mingw` |
-| pSophUI（aarch64 Qt 5.12.8 交叉） | `cross_build_sophon_u20:v1`（20.04） | 多阶段 COPY `/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-...` |
+| pSophUI（aarch64 Qt 5.12.8 交叉） | `cross_build_sophon_u20:v1`（20.04） | `--with-sophui-toolchain` 内置 `/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-...` |
 | dfss sw_64 / loongarch64 | `sophon-tools-build:m2` 内置 | `--with-dfss-toolchains` 内置（不变） |
 | 其余 13 子项目 | `sophon-tools-build:m2` | 直接满足 |
 
@@ -117,8 +118,25 @@ bash docker/build.sh --with-qt-mingw
 
 ## pSophUI 交叉工具链（aarch64 Qt 5.12.8 + Linaro GCC 6.3）
 
-与 13.24 `cross_build_sophon_u20:v1` 完全一致，Dockerfile 多阶段直接 COPY（不额外导出）。
-qmake / mkspecs / Linaro gcc 硬编码 `/env` 绝对路径，COPY 后保持原始路径，绝对引用全部有效。
+与 13.24 `cross_build_sophon_u20:v1` 完全一致，**默认不内置**（约 1GB，私有源）。两种获取方式：
+
+### 方式 1：从 13.24 服务器镜像导出（推荐）
+
+在 13.24 服务器上执行：
+
+```bash
+bash docker/scripts/export-sophui-toolchains.sh
+# 产物: docker/toolchains/sophui-cross-toolchains.tar.zst (约 253MB)
+```
+
+然后构建：
+
+```bash
+bash docker/build.sh --with-sophui-toolchain
+```
+
+归档内置后，构建期不再依赖 `cross_build_sophon_u20:v1` 独立镜像（与 M2 处理 dfss 工具链的方式一致）。
+qmake / mkspecs / Linaro gcc 硬编码 `/env` 绝对路径，解压到 `/env` 原始路径，绝对引用全部有效。
 
 ## 挂载源码跑构建
 
@@ -245,7 +263,8 @@ bash docker/examples/cross-test/run.sh --image sophon-tools-build:unified
 1. **pqt 系列 AppImage** 在统一镜像（20.04，glibc 2.31）内构建，产物兼容 glibc ≥ 2.27 的系统。
 2. **pqt 系列 windows exe** 依赖 Qt 5.15 mingw 静态库（`build-qt-mingw.sh` 交叉编译，20-40 分钟）；
    `--with-qt-mingw` 后内置 `/opt/qt-mingw`，全部在统一镜像内完成，无需宿主 `/opt/qt-mingw`。
-3. **pSophUI** 在统一镜像内交叉编译（aarch64 Qt 5.12.8 + Linaro GCC 6.3，来自 cross_build_sophon_u20:v1），
+3. **pSophUI** 在统一镜像内交叉编译（aarch64 Qt 5.12.8 + Linaro GCC 6.3，`--with-sophui-toolchain` 内置，
+   `sophui-cross-toolchains.tar.zst` 归档导出自 cross_build_sophon_u20:v1），
    产出 `sophgo-hdmi_<ver>_arm64.deb` + `SophUI_arm64`（尾部 upx 缺失仅告警，不影响产物）。
 4. **pmulti_video_qt** 已按 MYSWY 决定从统一构建范围排除（不需要做），不再参与构建。
 5. **dfss 私有工具链**默认不内置；需要时按上文方式导出（`--with-dfss-toolchains`）。
@@ -257,7 +276,7 @@ bash docker/examples/cross-test/run.sh --image sophon-tools-build:unified
 
 ```
 docker/
-├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 运行镜像 → Stage3 pSophUI 工具链）
+├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 运行镜像；工具链归档内置）
 ├── versions.env              # 唯一版本源（版本 + 校验和）
 ├── build.sh                  # 一条命令构建镜像
 ├── build-all.sh              # 统一构建入口（M3/M4/M5，驱动全部子项目 release.sh）
@@ -265,12 +284,13 @@ docker/
 ├── verify.sh                 # 镜像自检（对照 M1 清单 + pqt/pSophUI 工具链）
 ├── README.md                 # 本文件
 ├── scripts/
-│   └── export-dfss-toolchains.sh  # 从 13.24 容器导出 sw_64/loongarch64 工具链
+│   ├── export-dfss-toolchains.sh     # 从 13.24 容器导出 sw_64/loongarch64 工具链
+│   └── export-sophui-toolchains.sh   # 从 13.24 镜像导出 pSophUI 交叉工具链
 ├── pqt/
 │   ├── Dockerfile            # [废弃] pqt 专用镜像（M5 已并入统一镜像，保留兼容）
 │   ├── build-pqt.sh          # pqt linux/windows 一键编译（支持 inplace 模式）
 │   └── build-qt-mingw.sh     # Qt 5.15.2 mingw 静态库交叉编译
 ├── examples/
 │   └── cross-test/           # 交叉编译示例（C/Rust/Windows）
-└── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains / --with-qt-mingw 使用）
+└── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains / --with-qt-mingw / --with-sophui-toolchain 使用）
 ```

--- a/docker/README.md
+++ b/docker/README.md
@@ -8,6 +8,10 @@
 合并为**一个 ubuntu:20.04 基座镜像** `sophon-tools-build:unified`，全部 16 个子项目在单镜像内构建，
 不再按子项目切换镜像。
 
+**镜像体积**：完整镜像（内置 dfss sw_64/loongarch64、Qt mingw 静态库、pSophUI aarch64 交叉工具链）
+约 **10GB**（`docker images` 显示 ~10.1GB，实际层内容 ~9.4GB）。体积增大是单镜像方案的预期取舍
+——换取构建期零镜像切换、一键全量。
+
 ## 一条命令构建镜像
 
 ```bash

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,28 +1,54 @@
-# sophon-tools-build —— sophon-tools 统一编译镜像
+# sophon-tools-build —— sophon-tools 统一编译镜像（M5 单镜像合并）
 
 `docker/` 目录是 sophon-tools 各子项目的统一构建镜像交付物。镜像预装全部子项目所需工具链，
 子项目构建只需基于此镜像，不再依赖构建机预装环境。
 
+**M5 起为单镜像方案**：三个镜像（`sophon-tools-build:m2` ubuntu:22.04 主镜像、
+`sophon-tools-build-pqt` ubuntu:20.04 pqt 专用、`cross_build_sophon_u20:v1` ubuntu:20.04 pSophUI 专用）
+合并为**一个 ubuntu:20.04 基座镜像** `sophon-tools-build:unified`，全部 16 个子项目在单镜像内构建，
+不再按子项目切换镜像。
+
 ## 一条命令构建镜像
 
 ```bash
-# 基础镜像（不含 dfss 私有工具链 sw_64/loongarch64）
+# 基础镜像（不含 dfss 私有工具链 sw_64/loongarch64 与 Qt mingw 静态库）
 bash docker/build.sh
 
-# 完整镜像（内置 dfss 私有工具链，需先在 13.24 服务器上执行导出脚本）
-bash docker/build.sh --with-dfss-toolchains
+# 完整镜像（内置 dfss 私有工具链 + Qt mingw 静态库）
+bash docker/build.sh --with-dfss-toolchains --with-qt-mingw
 
-# 指定标签 / 禁用缓存
+# 只内置 dfss / 只内置 Qt mingw / 指定标签 / 禁用缓存
+bash docker/build.sh --with-dfss-toolchains
+bash docker/build.sh --with-qt-mingw
 bash docker/build.sh --tag v1.0 --no-cache
 ```
+
+构建依赖：
+- docker（≥20.10，BuildKit 默认开启），网络可访问 go.dev / nodejs.org / musl.cc
+- `cross_build_sophon_u20:v1` 镜像（13.24 服务器有），Dockerfile 多阶段从它 COPY
+  pSophUI 交叉工具链（`/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu`）
+- dfss 私有工具链 / Qt mingw 静态库：见下文
 
 ### 版本锁定（可复现）
 
 - 唯一版本源：`docker/versions.env` —— 全部工具链版本 + 校验和统一在此维护。
-- 基础镜像 `ubuntu:22.04` 用 **digest**（不可变引用）锁定，不用 tag。
+- 基础镜像 `ubuntu:20.04` 用 **digest**（不可变引用）锁定，不用 tag。
 - Go / Node 下载后做 **SHA256 校验**（校验失败即中止构建）。
 - Rust 用 rustup 锁定稳定版 `1.97.1`；musl 工具链来自 musl.cc。
 - 想固定 musl 工具链内容：把首次构建打印的实际 SHA256 填入 `versions.env` 的 `MUSL_*_SHA256`。
+
+## 为什么基座是 ubuntu:20.04（硬约束）
+
+pqt 系列打 AppImage 依赖 linuxdeployqt，它**强制宿主 glibc ≤ 2.31**（保证产物兼容旧发行版）。
+ubuntu:20.04 的 glibc 是 2.31（22.04 是 2.35）。M5 决定以 20.04 为唯一基座，同时满足：
+
+| 需求 | 原独立镜像 | M5 单镜像内如何满足 |
+|------|-----------|---------------------|
+| pqt AppImage（glibc≤2.31） | `sophon-tools-build-pqt`（20.04） | 基座即 20.04，Qt5 + libgl1-mesa-dev + fuse + patchelf 内置 |
+| pqt windows exe（Qt mingw 静态库） | `sophon-tools-build:m2` + 宿主 `/opt/qt-mingw` | `--with-qt-mingw` 内置 `/opt/qt-mingw` |
+| pSophUI（aarch64 Qt 5.12.8 交叉） | `cross_build_sophon_u20:v1`（20.04） | 多阶段 COPY `/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-...` |
+| dfss sw_64 / loongarch64 | `sophon-tools-build:m2` 内置 | `--with-dfss-toolchains` 内置（不变） |
+| 其余 13 子项目 | `sophon-tools-build:m2` | 直接满足 |
 
 ## 镜像内工具链（对照 M1 盘点清单）
 
@@ -35,7 +61,9 @@ bash docker/build.sh --tag v1.0 --no-cache
 | pdfss_cpp | glibc 交叉工具链 | aarch64 / armel / riscv64（apt 精确版本） |
 | pdfss_cpp (windows) | mingw-w64 | x86_64-w64-mingw32 + i686-w64-mingw32 |
 | pdfss_cpp (私有) | sw_64 + loongarch64 | SWREACH GCC 8.3.0 / LoongArch 8.3.0（dfss 私有源） |
-| pqt 系列 | Qt 5 + qmake | qtbase5-dev（AppImage 依赖） |
+| pqt 系列 (linux AppImage) | Qt 5 + qmake | qtbase5-dev = Qt 5.12.8（20.04 仓库）+ libgl1-mesa-dev + fuse + patchelf |
+| pqt 系列 (windows exe) | Qt 5.15.2 mingw 静态 | `/opt/qt-mingw`（build-qt-mingw.sh 编译，`--with-qt-mingw` 内置） |
+| pSophUI | aarch64 Qt 5.12.8 + Linaro GCC 6.3 | `/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu`（13.24 同款） |
 | 打包/文档 | dpkg-deb / 7z / zip / upx / patchelf / pandoc | apt 精确版本 |
 | 跨架构验证 | qemu-user-static | aarch64 / loongarch64 等 |
 
@@ -68,13 +96,37 @@ bash docker/build.sh --with-dfss-toolchains
 python3 -m dfss --url=open@sophgo.com:/toolchains/swgcc830-*.tar.gz
 ```
 
+## Qt mingw 静态库（pqt windows exe）
+
+pqt 系列 windows 端依赖 Qt 5.15 mingw **静态库**（仓库 `libs/win_amd64` 只含 libssh2/openssl，不含 Qt）。
+**默认不内置**，获取方式：
+
+```bash
+# 在 20.04 基座内从源码交叉编译（约 20-40 分钟）—— 唯一可靠方式
+bash docker/pqt/build-qt-mingw.sh
+# 产物: /opt/qt-mingw（宿主工具 uic/moc 已与 20.04 glibc 兼容）
+tar -C /opt/qt-mingw -cf - . | zstd -q -T0 > docker/toolchains/qt-mingw.tar.zst
+
+# 然后构建镜像
+bash docker/build.sh --with-qt-mingw
+```
+
+> **为什么不能复用 13.24 的 /opt/qt-mingw**：13.24 上的 Qt mingw 是 22.04 基座编译的，
+> 其宿主工具（uic/moc/rcc 等）链接 glibc ≥ 2.33，在 20.04 基座（glibc 2.31）内无法运行。
+> `build.sh --with-qt-mingw` 会先校验/触发从源码重建，保证宿主工具与 20.04 兼容。
+
+## pSophUI 交叉工具链（aarch64 Qt 5.12.8 + Linaro GCC 6.3）
+
+与 13.24 `cross_build_sophon_u20:v1` 完全一致，Dockerfile 多阶段直接 COPY（不额外导出）。
+qmake / mkspecs / Linaro gcc 硬编码 `/env` 绝对路径，COPY 后保持原始路径，绝对引用全部有效。
+
 ## 挂载源码跑构建
 
 ```bash
 # 挂载 sophon-tools 源码到 /workspace，进入容器交互式构建
 docker run -it --rm \
   -v "$(pwd)":/workspace/sophon-tools \
-  sophon-tools-build:latest \
+  sophon-tools-build:unified \
   bash
 
 # 进入后，按各子项目方式构建，例如:
@@ -82,7 +134,7 @@ cd /workspace/sophon-tools/source/pbmssm
 bash build/build-deb-bmssm.sh   # 需以非 root 用户运行，或改输出目录为可写路径
 ```
 
-## 统一构建入口（M3/M4）：全部子项目一键全量多平台编译
+## 统一构建入口（M3/M4/M5）：全部子项目一键全量多平台编译
 
 每个子项目都提供统一接口的 `release.sh`（M1 规范 v0.1）：
 
@@ -111,6 +163,13 @@ bash docker/build-all.sh --list
 bash docker/gen-manifest.sh          # -> output/MANIFEST.txt
 ```
 
+### M5 单镜像说明
+
+- **不再按子项目切换镜像**：pqt 系列（AppImage + exe）与 pSophUI 全部在统一镜像内构建。
+- pqt 系列通过 `PQT_INPLACE=1` 让 `build-pqt.sh` 直接在容器内执行（不嵌套 docker）。
+- pqt 系列 linux AppImage 基座即 20.04（glibc 2.31），linuxdeployqt 约束已满足。
+- pqt 系列 windows exe 依赖 `/opt/qt-mingw`（`--with-qt-mingw` 内置）。
+
 ### M4：一条命令全量 release（推荐入口）
 
 仓库根 `release.sh` 是 M4 的一键全量入口，内部依次完成：镜像前置检查 → 驱动
@@ -136,48 +195,41 @@ pdfss_cpp            | dfss-cpp-linux-loongarch64                        | loong
 
 架构判定优先级：文件名关键字 → `.deb` 包 `Architecture` 字段 → `file` ELF/PE 探测。
 
-### 各子项目使用的镜像
-
-| 子项目 | 镜像 | 说明 |
-|--------|------|------|
-| 大部分（pbmssm/psophliteos/pdfss_cpp/pbm_set_ip/pbmsec 等） | `sophon-tools-build` | 统一镜像 |
-| pqt_batch_deployment / pqt_memory_edit | `sophon-tools-build-pqt` | linux AppImage 需 glibc≤2.31，宿主执行 release.sh（内部调 docker/pqt/build-pqt.sh） |
-| pSophUI | `cross_build_sophon_u20:v1` | aarch64 Qt 5.12.8 交叉工具链（13.24 同款） |
-
-> pmulti_video_qt 已按 MYSWY 决定（2026-08-08）从统一构建范围排除，不再构建。
-
 ## 镜像自检
 
 ```bash
-# 基础自检（工具链存在性）
-bash docker/verify.sh
+# 基础自检（工具链存在性，含基座 glibc 版本 + pqt/pSophUI 工具链）
+bash docker/verify.sh --image sophon-tools-build:unified
 
-# 完整自检（含交叉编译实测：arm64 musl 静态 / windows / sw_64 / loongarch64）
-bash docker/verify.sh --cross
+# 完整自检（含交叉编译实测：arm64 musl 静态 / windows / sw_64 / loongarch64 / pqt Qt5 / pqt mingw / pSophUI）
+bash docker/verify.sh --image sophon-tools-build:unified --cross
 ```
 
 ## pqt 系列（Qt GUI 工具）专用构建
 
 `docker/pqt/` 提供 pqt 系列（`pqt_memory_edit` 图形化内存修改工具、`pqt_batch_deployment` 批量部署工具）的专用构建。
 
-> **为什么独立镜像**：pqt 打 AppImage 依赖 linuxdeployqt，它强制宿主 glibc ≤ 2.31
-> （保证产物在旧发行版可运行）。sophon-tools-build 基于 22.04（glibc 2.35）不满足，
-> 故 pqt 专用镜像基于 ubuntu:20.04（glibc 2.31）。
+> **M5 变更**：pqt 不再用独立镜像。统一镜像基座即 20.04（glibc 2.31），满足 linuxdeployqt 的
+> glibc≤2.31 硬约束；windows exe 的 Qt mingw 静态库由 `--with-qt-mingw` 内置。
 
 ```bash
 # linux AppImage 一键编译（自动生成 memory_edit.tar.xz 前置依赖）
 bash docker/pqt/build-pqt.sh --project pqt_memory_edit --linux
 bash docker/pqt/build-pqt.sh --project pqt_batch_deployment --linux
 
-# windows exe（需先交叉编译 Qt mingw 静态库，一次约 1-2 小时）
-bash docker/pqt/build-qt-mingw.sh          # 交叉编译 Qt 5.15.2 mingw 静态
+# windows exe（需先内置 Qt mingw 静态库，见上文）
+bash docker/pqt/build-qt-mingw.sh          # 交叉编译 Qt 5.15.2 mingw 静态（一次约 20-40 分钟）
 bash docker/pqt/build-pqt.sh --project pqt_memory_edit --windows
 
 # 两端一起
 bash docker/pqt/build-pqt.sh --project pqt_memory_edit --all
+
+# 在统一镜像内直接执行（inplace 模式，不嵌套 docker）
+docker run --rm -v "$(pwd)":/workspace/sophon-tools sophon-tools-build:unified bash -c \
+  'cd /workspace/sophon-tools/source/pqt_memory_edit && PQT_INPLACE=1 bash release.sh amd64'
 ```
 
-已实测：`qt_mem_edit_V2.12.1-x86_64.AppImage`（25.9MB）在 ubuntu:20.04 镜像内一键产出，
+已实测：`qt_mem_edit_V2.12.1-x86_64.AppImage`（25.9MB）在 20.04 镜像内一键产出，
 AppImage 可正常解包运行。
 
 ## 交叉编译示例
@@ -185,39 +237,40 @@ AppImage 可正常解包运行。
 `docker/examples/cross-test/` 提供 C / Rust / Windows 的交叉编译最小示例：
 
 ```bash
-bash docker/examples/cross-test/run.sh --image sophon-tools-build:latest
+bash docker/examples/cross-test/run.sh --image sophon-tools-build:unified
 ```
 
 ## 已知边界
 
-1. **pqt 系列 AppImage** 用专用镜像 `sophon-tools-build-pqt`（ubuntu:20.04，glibc 2.31）构建，产物兼容 glibc ≥ 2.27 的系统。
-2. **pSophUI** 已接入：用 `cross_build_sophon_u20:v1`（aarch64 Qt 5.12.8 + Linaro GCC 6.3）交叉编译，
+1. **pqt 系列 AppImage** 在统一镜像（20.04，glibc 2.31）内构建，产物兼容 glibc ≥ 2.27 的系统。
+2. **pqt 系列 windows exe** 依赖 Qt 5.15 mingw 静态库（`build-qt-mingw.sh` 交叉编译，20-40 分钟）；
+   `--with-qt-mingw` 后内置 `/opt/qt-mingw`，全部在统一镜像内完成，无需宿主 `/opt/qt-mingw`。
+3. **pSophUI** 在统一镜像内交叉编译（aarch64 Qt 5.12.8 + Linaro GCC 6.3，来自 cross_build_sophon_u20:v1），
    产出 `sophgo-hdmi_<ver>_arm64.deb` + `SophUI_arm64`（尾部 upx 缺失仅告警，不影响产物）。
-3. **pmulti_video_qt** 已按 MYSWY 决定从统一构建范围排除（不需要做），不再参与构建。
-4. **pdfss_cpp libs 编译**（libssh2/mbedtls/zlib 静态）耗时较长，建议镜像内预编一次（build_libs.sh）。
-5. **dfss 私有工具链**默认不内置；需要时按上文方式导出。
+4. **pmulti_video_qt** 已按 MYSWY 决定从统一构建范围排除（不需要做），不再参与构建。
+5. **dfss 私有工具链**默认不内置；需要时按上文方式导出（`--with-dfss-toolchains`）。
 6. 容器内构建涉及 `sudo` 的脚本（根 `release.sh`）需以 root 运行（镜像默认 root）或调整输出目录权限。
-7. **pqt windows 端**依赖 Qt 5.15 mingw 静态库（`build-qt-mingw.sh` 交叉编译，1-2 小时），
-   仓库 `libs/win_amd64` 只含 libssh2/openssl，不含 Qt。
+7. 基座由 22.04 降为 20.04 后，宿主 gcc 从 11.x 变为 9.4、Qt 从 5.15.3 变为 5.12.8；
+   各子项目构建回归结果见 M5 交付矩阵（16/16 全绿）。
 
 ## 目录结构
 
 ```
 docker/
-├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 汇入）
+├── Dockerfile                # 多阶段构建（Stage1 下载校验 → Stage2 运行镜像 → Stage3 pSophUI 工具链）
 ├── versions.env              # 唯一版本源（版本 + 校验和）
 ├── build.sh                  # 一条命令构建镜像
-├── build-all.sh              # 统一构建入口（M3/M4，驱动全部子项目 release.sh）
+├── build-all.sh              # 统一构建入口（M3/M4/M5，驱动全部子项目 release.sh）
 ├── gen-manifest.sh           # 生成产物清单 MANIFEST.txt（文件名/架构/版本/md5）
-├── verify.sh                 # 镜像自检（对照 M1 清单）
+├── verify.sh                 # 镜像自检（对照 M1 清单 + pqt/pSophUI 工具链）
 ├── README.md                 # 本文件
 ├── scripts/
 │   └── export-dfss-toolchains.sh  # 从 13.24 容器导出 sw_64/loongarch64 工具链
 ├── pqt/
-│   ├── Dockerfile            # pqt 专用镜像（ubuntu:20.04，glibc 2.31）
-│   ├── build-pqt.sh          # pqt linux/windows 一键编译
+│   ├── Dockerfile            # [废弃] pqt 专用镜像（M5 已并入统一镜像，保留兼容）
+│   ├── build-pqt.sh          # pqt linux/windows 一键编译（支持 inplace 模式）
 │   └── build-qt-mingw.sh     # Qt 5.15.2 mingw 静态库交叉编译
 ├── examples/
 │   └── cross-test/           # 交叉编译示例（C/Rust/Windows）
-└── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains 使用）
+└── toolchains/               # 导出的私有工具链归档（构建时由 --with-dfss-toolchains / --with-qt-mingw 使用）
 ```

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 # sophon-tools-build 统一构建全部子项目（镜像内一键编译）
 #
-# 目标: 在 sophon-tools-build 镜像内预装工具链, 对全部子项目执行所有平台的编译。
+# 目标: 在 sophon-tools-build 统一镜像内预装工具链, 对全部子项目执行所有平台的编译。
 # 本脚本是统一入口, 按 M1 规范驱动每个子项目的 release.sh（统一接口）。
+#
+# M5 变更: 单镜像方案。三镜像(sophon-tools-build:m2 / sophon-tools-build-pqt /
+# cross_build_sophon_u20:v1)合并为单个 ubuntu:20.04 基座镜像 sophon-tools-build:unified,
+# 不再按子项目切换镜像; pqt 系列/pSophUI 全部在统一镜像内构建。
 #
 # 统一接口 (M1 规范 v0.1):
 #   bash release.sh [ARCH] [VERSION]
@@ -16,7 +20,7 @@
 #   bash docker/build-all.sh                    # 构建全部子项目(默认平台)
 #   bash docker/build-all.sh --project pbmssm   # 只构建指定子项目
 #   bash docker/build-all.sh --arch arm64       # 只构建指定架构
-#   bash docker/build-all.sh --image sophon-tools-build:m2
+#   bash docker/build-all.sh --image sophon-tools-build:unified
 #   bash docker/build-all.sh --version 2.1.0    # 统一显式版本号（透传给所有 release.sh）
 #   bash docker/build-all.sh --list             # 列出子项目与平台
 #
@@ -28,7 +32,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 DOCKER_DIR="${SCRIPT_DIR}"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-IMAGE="${IMAGE:-sophon-tools-build:m2}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 ONLY_PROJECT=""
 ONLY_ARCH=""
 BUILD_VERSION=""
@@ -79,47 +83,40 @@ PLATFORMS[pota_update]="arm64"
 PLATFORMS[pautotelecomm]="arm64"
 PLATFORMS[pbm_set_ip]="arm64(musl静态)/amd64"
 PLATFORMS[pdfss_cpp]="amd64/arm64/armbi/loongarch64/riscv64/sw_64/win-amd64/win-i686"
-PLATFORMS[pqt_batch_deployment]="amd64/arm64"
+PLATFORMS[pqt_batch_deployment]="amd64/arm64 + windows"
 PLATFORMS[pqt_memory_edit]="amd64/arm64 + windows"
 PLATFORMS[pSophUI]="arm64(交叉Qt)"
 PLATFORMS[psoph_phytool]="通用脚本"
 PLATFORMS[pspacc_efuse_demo]="amd64/arm64"
 
-# 子项目 -> 专用镜像覆盖（默认用统一镜像 sophon-tools-build）
-#   pqt 系列: linux AppImage 需 glibc<=2.31 -> pqt 专用 20.04 镜像
-#   pSophUI: 需 aarch64 Qt 交叉工具链 -> cross_build_sophon_u20 (13.24 同款)
-declare -A IMAGE_OVERRIDES
-IMAGE_OVERRIDES[pqt_batch_deployment]="${PQT_IMAGE:-sophon-tools-build-pqt:latest}"
-IMAGE_OVERRIDES[pqt_memory_edit]="${PQT_IMAGE:-sophon-tools-build-pqt:latest}"
-IMAGE_OVERRIDES[pSophUI]="${CROSS_QT_IMAGE:-cross_build_sophon_u20:v1}"
-
-# 宿主执行项目（不在容器内跑 release.sh）：
-#   pqt 系列 release.sh 内部调用 docker/pqt/build-pqt.sh，后者用 docker 起 pqt 专用容器，
-#   因此必须在宿主（有 docker）直接执行 release.sh，而非在容器内嵌套 docker。
-declare -A HOST_RUN
-HOST_RUN[pqt_batch_deployment]=1
-HOST_RUN[pqt_memory_edit]=1
+# M5: 全部子项目统一用 sophon-tools-build:unified（20.04 基座）, 不再按子项目切换镜像。
+#   pqt 系列: 统一镜像基座即 20.04(glibc 2.31), AppImage 的 linuxdeployqt 约束已满足,
+#             windows exe 依赖的 Qt mingw 静态库由 --with-qt-mingw 内置。
+#   pSophUI: 统一镜像内置 /env/qt_5.12.8_nosysroot + /env/gcc-linaro-6.3.1-2017.05...。
 
 # 子项目 -> 额外环境 (镜像内 export; 以 ; 分隔)
+# M5: 统一镜像已在 PATH/ENV 预置 Go/Node/Rust/交叉工具链及 pSophUI 工具链,
+#       release.sh 默认即指向 /env 路径, 一般无需额外 export。
+# pqt 系列: build-pqt.sh 以 PQT_INPLACE=1 直接在容器内执行(不再嵌套 docker)。
 declare -A EXTRA_ENV
 EXTRA_ENV[pbm_set_ip]="export PATH=\${HOME}/.cargo/bin:/opt/cargo/bin:\$PATH"
 EXTRA_ENV[psophliteos]="export PATH=/opt/nodejs/bin:/opt/go/bin:\$PATH"
 EXTRA_ENV[pbmssm]="export PATH=/opt/go/bin:\$PATH"
 EXTRA_ENV[pdfss_cpp]="export PATH=/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:/usr/sw/swgcc830_cross_tools/usr/bin:\$PATH"
-EXTRA_ENV[pSophUI]="export PATH=/env/qt_5.12.8_nosysroot/bin:/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin:\$PATH; export QMAKESPEC=/env/qt_5.12.8_nosysroot/mkspecs/linux-aarch64-gnu-g++"
+EXTRA_ENV[pqt_batch_deployment]="export PQT_INPLACE=1"
+EXTRA_ENV[pqt_memory_edit]="export PQT_INPLACE=1"
 
 if [[ "${LIST_ONLY:-0}" = "1" ]]; then
-  echo "=== sophon-tools 16 子项目构建清单（pmulti_video_qt 已排除） ==="
+  echo "=== sophon-tools 16 子项目构建清单（pmulti_video_qt 已排除，单镜像 ${IMAGE}） ==="
   for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
-    img="${IMAGE_OVERRIDES[$p]:-$IMAGE}"
-    printf "  %-22s 平台: %-40s 镜像: %s\n" "$p" "${PLATFORMS[$p]}" "$img"
+    printf "  %-22s 平台: %-40s 镜像: %s\n" "$p" "${PLATFORMS[$p]}" "${IMAGE}"
   done
   exit 0
 fi
 
 # 输出目录
 mkdir -p "${REPO_ROOT}/output"
-echo "==> 统一构建, 输出: ${REPO_ROOT}/output"
+echo "==> 统一构建, 输出: ${REPO_ROOT}/output, 镜像: ${IMAGE}"
 
 # 各子项目构建结果（失败隔离汇总）: "<项目>|<退出码>"
 RESULTS=()
@@ -127,9 +124,8 @@ RESULTS=()
 run_one() {
   local p="$1"
   local arch="${ONLY_ARCH:-${DEFAULT_ARCH[$p]}}"
-  local img="${IMAGE_OVERRIDES[$p]:-$IMAGE}"
   echo ""
-  echo "========== [${p}] 平台: ${PLATFORMS[$p]} arch=${arch} 镜像: ${img} =========="
+  echo "========== [${p}] 平台: ${PLATFORMS[$p]} arch=${arch} 镜像: ${IMAGE} =========="
   local src_dir="${REPO_ROOT}/source/${p}"
   if [[ ! -d "${src_dir}" ]]; then
     echo "  [SKIP] 目录不存在: ${src_dir}"
@@ -138,33 +134,22 @@ run_one() {
   fi
 
   local rc=0
-  # pqt 系列在宿主直接执行 release.sh（内部需要 docker 起专用容器）
-  if [[ "${HOST_RUN[$p]:-0}" = "1" ]]; then
-    (
-      cd "${src_dir}"
-      echo "  >> (宿主) bash release.sh ${arch} ${BUILD_VERSION}"
-      OUTPUT_DIR="${REPO_ROOT}/output/${p}" bash release.sh "${arch}" ${BUILD_VERSION} 2>&1 | tail -20
-    ) | sed 's/^/    /'
-    rc=${PIPESTATUS[0]}
-    echo "  [${p}] 退出码: ${rc}"
-  else
-    local extra_env="${EXTRA_ENV[$p]:-}"
-    docker run --rm --privileged \
-      -v /dev:/dev \
-      -v "${REPO_ROOT}":/workspace/sophon-tools \
-      -w "/workspace/sophon-tools/source/${p}" \
-      -e OUTPUT_DIR="/workspace/sophon-tools/output/${p}" \
-      "${img}" bash -c "
-        set -euo pipefail
-        git config --global --add safe.directory '*' 2>/dev/null || true
-        git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
-        ${extra_env}
-        echo '  >> bash release.sh ${arch} ${BUILD_VERSION}'
-        bash release.sh ${arch} ${BUILD_VERSION} 2>&1 | tail -20
-      " 2>&1 | sed 's/^/    /'
-    rc=${PIPESTATUS[0]}
-    echo "  [${p}] 退出码: ${rc}"
-  fi
+  local extra_env="${EXTRA_ENV[$p]:-}"
+  docker run --rm --privileged \
+    -v /dev:/dev \
+    -v "${REPO_ROOT}":/workspace/sophon-tools \
+    -w "/workspace/sophon-tools/source/${p}" \
+    -e OUTPUT_DIR="/workspace/sophon-tools/output/${p}" \
+    "${IMAGE}" bash -c "
+      set -euo pipefail
+      git config --global --add safe.directory '*' 2>/dev/null || true
+      git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
+      ${extra_env}
+      echo '  >> bash release.sh ${arch} ${BUILD_VERSION}'
+      bash release.sh ${arch} ${BUILD_VERSION} 2>&1 | tail -20
+    " 2>&1 | sed 's/^/    /'
+  rc=${PIPESTATUS[0]}
+  echo "  [${p}] 退出码: ${rc}"
 
   if [[ "${rc}" = "0" ]]; then
     RESULTS+=("${p}|ok")

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,13 +2,14 @@
 # sophon-tools-build 镜像构建脚本（一条命令构建，M5 单镜像合并）
 #
 # 用法:
-#   bash docker/build.sh                 # 基础镜像(不含 dfss/qt-mingw 私有工具链)
+#   bash docker/build.sh                 # 基础镜像(不含 dfss/qt-mingw/pSophUI 私有工具链)
 #   bash docker/build.sh --with-dfss-toolchains   # 内置 sw_64/loongarch64 私有工具链
 #   bash docker/build.sh --with-qt-mingw          # 内置 Qt mingw 静态库(pqt windows)
+#   bash docker/build.sh --with-sophui-toolchain  # 内置 pSophUI aarch64 Qt 交叉工具链
 #   bash docker/build.sh --tag mytag --no-cache
 #
-# 依赖: docker(≥20.10, BuildKit 默认开启), 网络可访问 go.dev/nodejs.org/musl.cc,
-#       cross_build_sophon_u20:v1 镜像(内置 pSophUI aarch64 Qt 交叉工具链)。
+# 依赖: docker(≥20.10, BuildKit 默认开启), 网络可访问 go.dev/nodejs.org/musl.cc。
+#       pSophUI 工具链(及 dfss)以 toolchains/ 归档内置, 不依赖 cross_build_sophon_u20:v1 独立镜像。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -20,12 +21,14 @@ IMAGE_NAME="${IMAGE_NAME:-sophon-tools-build}"
 TAG=""
 WITH_DFSS=0
 WITH_QT_MINGW=0
+WITH_SOPHUI=0
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --with-dfss-toolchains) WITH_DFSS=1; shift ;;
     --with-qt-mingw) WITH_QT_MINGW=1; shift ;;
+    --with-sophui-toolchain) WITH_SOPHUI=1; shift ;;
     --tag) TAG="$2"; shift 2 ;;
     --no-cache) EXTRA_ARGS+=(--no-cache); shift ;;
     *) echo "未知参数: $1" >&2; exit 1 ;;
@@ -43,16 +46,6 @@ BASE_IMG="${UBUNTU_BASE_DIGEST}"
 echo "==> 基础镜像: ${BASE_IMG}"
 docker pull "${BASE_IMG}" >/dev/null 2>&1 || { echo "无法拉取基础镜像, 检查网络" >&2; exit 1; }
 
-# pSophUI 交叉工具链来源镜像: Dockerfile 多阶段 FROM 直接复用, 必须存在
-SOPHUI_SRC_IMAGE="${SOPHUI_SRC_IMAGE:-cross_build_sophon_u20:v1}"
-if ! docker image inspect "${SOPHUI_SRC_IMAGE}" >/dev/null 2>&1; then
-  echo "错误: 未找到 pSophUI 工具链来源镜像 '${SOPHUI_SRC_IMAGE}'。" >&2
-  echo "       本镜像从它 COPY /env/qt_5.12.8_nosysroot + /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu。" >&2
-  echo "       请在 13.24 服务器确认该镜像存在: docker images | grep cross_build_sophon_u20" >&2
-  exit 1
-fi
-echo "==> pSophUI 工具链来源镜像: ${SOPHUI_SRC_IMAGE}"
-
 # dfss 私有工具链: 检查 toolchains/ 目录
 BUILD_CONTEXT="${DOCKER_DIR}"
 TOOLCHAIN_DIR="${DOCKER_DIR}/toolchains"
@@ -64,6 +57,18 @@ if [[ "${WITH_DFSS}" = "1" ]]; then
     bash "${DOCKER_DIR}/scripts/export-dfss-toolchains.sh" --out "${TOOLCHAIN_DIR}"
   fi
   EXTRA_ARGS+=(--build-arg WITH_DFSS=1)
+fi
+
+# pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3): 检查 toolchains/ 归档
+# 来源优先 13.24 cross_build_sophon_u20:v1 镜像内容导出(参考 M2 处理 dfss 工具链的方式),
+# 以归档内置后, 构建期不再依赖独立镜像。
+SOPHUI_ARCHIVE="${TOOLCHAIN_DIR}/${SOPHUI_ARCHIVE:-sophui-cross-toolchains.tar.zst}"
+if [[ "${WITH_SOPHUI}" = "1" ]]; then
+  if [[ ! -f "${SOPHUI_ARCHIVE}" ]]; then
+    echo "==> sophui-cross-toolchains.tar.zst 不存在, 先从 13.24 cross_build_sophon_u20:v1 导出..." >&2
+    bash "${DOCKER_DIR}/scripts/export-sophui-toolchains.sh" --out "${TOOLCHAIN_DIR}"
+  fi
+  EXTRA_ARGS+=(--build-arg WITH_SOPHUI=1)
 fi
 
 # Qt mingw 静态库(pqt windows exe): 检查 toolchains/qt-mingw
@@ -94,6 +99,7 @@ echo "==> 构建上下文: ${BUILD_CONTEXT}"
 echo "==> 版本: Go ${GO_VERSION} / Rust ${RUST_VERSION} / Node ${NODE_VERSION} / pnpm ${PNPM_VERSION}"
 [[ "${WITH_DFSS}" = "1" ]] && echo "==> 内置 dfss 私有工具链(sw_64 + loongarch64)"
 [[ "${WITH_QT_MINGW}" = "1" ]] && echo "==> 内置 Qt mingw 静态库(pqt windows)"
+[[ "${WITH_SOPHUI}" = "1" ]] && echo "==> 内置 pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3)"
 
 docker build \
   --build-arg UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST}" \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
-# sophon-tools-build 镜像构建脚本（一条命令构建）
+# sophon-tools-build 镜像构建脚本（一条命令构建，M5 单镜像合并）
 #
 # 用法:
-#   bash docker/build.sh                 # 基础镜像(不含 dfss 私有工具链)
+#   bash docker/build.sh                 # 基础镜像(不含 dfss/qt-mingw 私有工具链)
 #   bash docker/build.sh --with-dfss-toolchains   # 内置 sw_64/loongarch64 私有工具链
+#   bash docker/build.sh --with-qt-mingw          # 内置 Qt mingw 静态库(pqt windows)
 #   bash docker/build.sh --tag mytag --no-cache
 #
-# 依赖: docker(≥20.10, BuildKit 默认开启), 网络可访问 go.dev/nodejs.org/musl.cc
+# 依赖: docker(≥20.10, BuildKit 默认开启), 网络可访问 go.dev/nodejs.org/musl.cc,
+#       cross_build_sophon_u20:v1 镜像(内置 pSophUI aarch64 Qt 交叉工具链)。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -17,18 +19,20 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 IMAGE_NAME="${IMAGE_NAME:-sophon-tools-build}"
 TAG=""
 WITH_DFSS=0
+WITH_QT_MINGW=0
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --with-dfss-toolchains) WITH_DFSS=1; shift ;;
+    --with-qt-mingw) WITH_QT_MINGW=1; shift ;;
     --tag) TAG="$2"; shift 2 ;;
     --no-cache) EXTRA_ARGS+=(--no-cache); shift ;;
     *) echo "未知参数: $1" >&2; exit 1 ;;
   esac
 done
 
-[[ -n "${TAG}" ]] || TAG="latest"
+[[ -n "${TAG}" ]] || TAG="unified"
 
 # 版本源: docker/versions.env(唯一版本锁定点)
 # shellcheck disable=SC1091
@@ -39,10 +43,21 @@ BASE_IMG="${UBUNTU_BASE_DIGEST}"
 echo "==> 基础镜像: ${BASE_IMG}"
 docker pull "${BASE_IMG}" >/dev/null 2>&1 || { echo "无法拉取基础镜像, 检查网络" >&2; exit 1; }
 
+# pSophUI 交叉工具链来源镜像: Dockerfile 多阶段 FROM 直接复用, 必须存在
+SOPHUI_SRC_IMAGE="${SOPHUI_SRC_IMAGE:-cross_build_sophon_u20:v1}"
+if ! docker image inspect "${SOPHUI_SRC_IMAGE}" >/dev/null 2>&1; then
+  echo "错误: 未找到 pSophUI 工具链来源镜像 '${SOPHUI_SRC_IMAGE}'。" >&2
+  echo "       本镜像从它 COPY /env/qt_5.12.8_nosysroot + /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu。" >&2
+  echo "       请在 13.24 服务器确认该镜像存在: docker images | grep cross_build_sophon_u20" >&2
+  exit 1
+fi
+echo "==> pSophUI 工具链来源镜像: ${SOPHUI_SRC_IMAGE}"
+
 # dfss 私有工具链: 检查 toolchains/ 目录
 BUILD_CONTEXT="${DOCKER_DIR}"
+TOOLCHAIN_DIR="${DOCKER_DIR}/toolchains"
+mkdir -p "${TOOLCHAIN_DIR}"   # Dockerfile 无条件 COPY toolchains/, 目录必须存在(可为空)
 if [[ "${WITH_DFSS}" = "1" ]]; then
-  TOOLCHAIN_DIR="${DOCKER_DIR}/toolchains"
   if [[ ! -f "${TOOLCHAIN_DIR}/swgcc830_cross_tools.tar.zst" ]] \
      && [[ ! -f "${TOOLCHAIN_DIR}/loongarch64-cross-tools.tar.zst" ]]; then
     echo "==> toolchains/ 为空, 先从 13.24 容器导出(需要 docker 容器 bm1684_zzt 或 cross_build_sophon_u20:v1)..." >&2
@@ -51,9 +66,34 @@ if [[ "${WITH_DFSS}" = "1" ]]; then
   EXTRA_ARGS+=(--build-arg WITH_DFSS=1)
 fi
 
+# Qt mingw 静态库(pqt windows exe): 检查 toolchains/qt-mingw
+# 注意: 必须在 20.04 基座内从源码交叉编译——宿主机 /opt/qt-mingw 若是 22.04 编译的,
+#       其宿主工具(uic/moc 等)依赖 glibc 2.33+, 在 20.04 镜像内无法运行。
+#       故这里一律走 build-qt-mingw.sh 从源码构建, 不复用宿主现成目录。
+if [[ "${WITH_QT_MINGW}" = "1" ]]; then
+  if [[ ! -f "${TOOLCHAIN_DIR}/qt-mingw.tar.zst" ]]; then
+    if [[ ! -d /opt/qt-mingw ]] || [[ ! -f /opt/qt-mingw/lib/libQt5Widgets.a ]]; then
+      echo "==> toolchains/qt-mingw 不存在, 开始交叉编译 Qt (约 20-40 分钟)..." >&2
+      PREFIX=/opt/qt-mingw bash "${DOCKER_DIR}/pqt/build-qt-mingw.sh"
+    else
+      echo "==> 复用 /opt/qt-mingw 已编译产物, 校验宿主工具与 20.04 基座兼容..." >&2
+      if docker run --rm -v /opt/qt-mingw:/opt/qt-mingw:ro "${IMAGE_NAME}:unified" bash -c '/opt/qt-mingw/bin/uic --version' >/dev/null 2>&1; then
+        echo "==> /opt/qt-mingw 与 20.04 基座兼容, 直接复用" >&2
+      else
+        echo "==> /opt/qt-mingw 宿主工具依赖过高 glibc(22.04 编译), 重新从源码编译..." >&2
+        sudo rm -rf /opt/qt-mingw 2>/dev/null || rm -rf /opt/qt-mingw
+        PREFIX=/opt/qt-mingw bash "${DOCKER_DIR}/pqt/build-qt-mingw.sh"
+      fi
+    fi
+    tar -C /opt/qt-mingw -cf - . | zstd -q -T0 > "${TOOLCHAIN_DIR}/qt-mingw.tar.zst"
+  fi
+  EXTRA_ARGS+=(--build-arg WITH_QT_MINGW=1)
+fi
+
 echo "==> 构建上下文: ${BUILD_CONTEXT}"
 echo "==> 版本: Go ${GO_VERSION} / Rust ${RUST_VERSION} / Node ${NODE_VERSION} / pnpm ${PNPM_VERSION}"
 [[ "${WITH_DFSS}" = "1" ]] && echo "==> 内置 dfss 私有工具链(sw_64 + loongarch64)"
+[[ "${WITH_QT_MINGW}" = "1" ]] && echo "==> 内置 Qt mingw 静态库(pqt windows)"
 
 docker build \
   --build-arg UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST}" \

--- a/docker/examples/cross-test/run.sh
+++ b/docker/examples/cross-test/run.sh
@@ -6,7 +6,7 @@
 #   bash docker/examples/cross-test/run.sh [--image <name>]
 set -u
 
-IMAGE="${IMAGE:-sophon-tools-build:latest}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 [[ $# -ge 1 ]] && IMAGE="$1"
 
 echo "== 使用镜像: ${IMAGE}"

--- a/docker/pqt/build-pqt.sh
+++ b/docker/pqt/build-pqt.sh
@@ -9,7 +9,11 @@
 #   bash docker/pqt/build-pqt.sh --project pqt_memory_edit --all         # 两端
 #   bash docker/pqt/build-pqt.sh --project pqt_batch_deployment --linux
 #
-# 依赖: docker, sophon-tools-build-pqt 镜像(linux端); mingw Qt(交叉编译) 见下
+# 两种运行模式:
+#   * 宿主模式(默认): 用 docker 起 pqt 专用容器(旧三镜像方案, 镜像 sophon-tools-build-pqt)。
+#   * inplace 模式(--inplace 或 env PQT_INPLACE=1): 直接在当前环境执行(不嵌套 docker)。
+#     M5 起统一镜像 sophon-tools-build:unified 已内置全部依赖(20.04 基座 + Qt5 + mingw),
+#     build-all.sh 在统一镜像内以 PQT_INPLACE=1 驱动本脚本, 不再按子项目切换镜像。
 #
 # 关键前置(linux): pqt_memory_edit 的 resources.qrc 引用 memory_edit.tar.xz,
 #   该文件由 source/pmemory_edit/release.sh 生成; 构建前自动生成并复制。
@@ -22,6 +26,7 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 PQT_IMAGE="${PQT_IMAGE:-sophon-tools-build-pqt:latest}"
 PROJECT="pqt_memory_edit"
 MODE=""  # linux / windows / all
+INPLACE="${PQT_INPLACE:-0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -29,9 +34,10 @@ while [[ $# -gt 0 ]]; do
     --linux) MODE="linux" ;;
     --windows) MODE="windows" ;;
     --all) MODE="all" ;;
+    --inplace) INPLACE=1 ;;
     --image) PQT_IMAGE="$2"; shift 2; continue ;;
     -h|--help)
-      grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -30
+      grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -35
       exit 0 ;;
     *) echo "未知参数: $1" >&2; exit 1 ;;
   esac
@@ -63,9 +69,38 @@ prepare_memory_edit_tarxz() {
   echo "==> 已复制: ${src}"
 }
 
+# mingw posix 线程包装(统一镜像/宿主通用): Qt 静态库需要 std::mutex, 强制 posix 变体
+setup_mingw_posix() {
+  if ! command -v x86_64-w64-mingw32-g++-posix >/dev/null; then
+    echo "==> 安装 g++-mingw-w64-x86-64 (posix)..." >&2
+    apt-get update -qq
+    apt-get install -y --no-install-recommends g++-mingw-w64-x86-64 >/dev/null 2>&1
+  fi
+  mkdir -p /opt/mingw-posix/bin
+  for t in gcc g++ cpp cc c++ gcc-ar gcc-nm gcc-ranlib; do
+    [ -x /usr/bin/x86_64-w64-mingw32-${t}-posix ] && ln -sf /usr/bin/x86_64-w64-mingw32-${t}-posix /opt/mingw-posix/bin/x86_64-w64-mingw32-${t}
+  done
+  export PATH=/opt/mingw-posix/bin:$PATH
+  printf '#include <mutex>\nint main(){std::mutex m; m.lock(); return 0;}\n' > /tmp/mt.cpp
+  x86_64-w64-mingw32-g++ /tmp/mt.cpp -o /tmp/mt.exe || { echo 'posix g++ 不可用' >&2; exit 1; }
+}
+
+# 大写 mingw 头文件 + WS2_32 兼容(代码 include <Winsock2.h>)
+setup_mingw_headers() {
+  mkdir -p /tmp/mingw-inc
+  ln -sf /usr/x86_64-w64-mingw32/include/winsock2.h /tmp/mingw-inc/Winsock2.h
+  ln -sf /usr/x86_64-w64-mingw32/lib/libws2_32.a /usr/x86_64-w64-mingw32/lib/libWS2_32.a
+}
+
 # ---- linux 端: AppImage ----
 build_linux() {
   prepare_memory_edit_tarxz
+  if [[ "${INPLACE}" = "1" ]]; then
+    echo "==> (inplace) 构建 ${PROJECT} linux AppImage ..."
+    (cd "${SRC_DIR}" && bash linux_release.sh)
+    echo "==> linux AppImage 完成"
+    return 0
+  fi
   echo "==> 构建 ${PROJECT} linux AppImage (镜像 ${PQT_IMAGE})..."
   # 确保镜像存在
   docker image inspect "${PQT_IMAGE}" >/dev/null 2>&1 || {
@@ -86,18 +121,50 @@ build_linux() {
 # ---- windows 端: exe (需 Qt mingw 交叉编译环境) ----
 build_windows() {
   echo "==> windows 端交叉编译..."
-  # 注意: windows 构建需要 sophon-tools-build(含 mingw g++), 非 pqt 镜像
-  local image="${IMAGE:-sophon-tools-build:m2}"
+  prepare_memory_edit_tarxz
   local qt_prefix="${QT_PREFIX:-/opt/qt-mingw}"
   # 确保 Qt mingw 静态库存在
   if [[ ! -f "${qt_prefix}/lib/libQt5Widgets.a" ]]; then
+    if [[ "${INPLACE}" = "1" ]]; then
+      echo "错误: 统一镜像内缺少 Qt mingw 静态库 (${qt_prefix})。" >&2
+      echo "       请用 --with-qt-mingw 重建统一镜像(或把 13.24 /opt/qt-mingw 导出为 toolchains/qt-mingw.tar.zst)。" >&2
+      exit 1
+    fi
     echo "==> 未找到 Qt mingw 静态库 (${qt_prefix}), 先交叉编译 Qt (约 20-40 分钟)..."
     PREFIX="${qt_prefix}" bash "${DOCKER_DIR}/pqt/build-qt-mingw.sh" || {
       echo "Qt mingw 编译失败" >&2; exit 1
     }
   fi
-  # 内存修改工具前置依赖
-  prepare_memory_edit_tarxz
+
+  if [[ "${INPLACE}" = "1" ]]; then
+    # 直接在统一镜像内执行(工具链已内置, 当前 shell 内函数可直接使用)
+    setup_mingw_posix
+    setup_mingw_headers
+    cd "${SRC_DIR}"
+    rm -rf build-win
+    mkdir build-win && cd build-win
+    export QT_PLATFORM_DIR="${qt_prefix}"
+    export QT_GCC_PLATFORM_DIR=/opt/mingw-posix/bin
+    cat > /tmp/tc.cmake <<TOOL
+set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR x86_64)
+set(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)
+set(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)
+set(CMAKE_FIND_ROOT_PATH ${qt_prefix} /usr/x86_64-w64-mingw32)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+TOOL
+    cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
+      "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc"
+    make -j"$(nproc)"
+    echo "==> windows exe 产物:"
+    ls -la qt_mem_edit*.exe 2>/dev/null || ls -la *.exe
+    return 0
+  fi
+
+  # 宿主模式: 在 sophon-tools-build 镜像内交叉编译
+  local image="${IMAGE:-sophon-tools-build:unified}"
   docker run --rm \
     -v "${SRC_DIR}":/workspace/src \
     -v "${qt_prefix}":/opt/qt-mingw \

--- a/docker/pqt/build-qt-mingw.sh
+++ b/docker/pqt/build-qt-mingw.sh
@@ -25,7 +25,7 @@ QT_MODULE="qtbase-everywhere-src-${QT_VERSION}"
 QT_URL="https://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/5.15/${QT_VERSION}/submodules/${QT_MODULE}.tar.xz"
 PREFIX="${PREFIX:-/opt/qt-mingw}"
 JOBS="${JOBS:-$(nproc)}"
-IMAGE="${IMAGE:-sophon-tools-build:m2}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 
 echo "==> 下载 Qt ${QT_VERSION} qtbase 源码..."
 if [[ ! -f "${REPO_ROOT}/docker/toolchains/${QT_MODULE}.tar.xz" ]]; then

--- a/docker/scripts/build-dfss-pip.sh
+++ b/docker/scripts/build-dfss-pip.sh
@@ -14,7 +14,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 DOCKER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-IMAGE="${IMAGE:-sophon-tools-build:m2}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 PDFSS_SRC="${REPO_ROOT}/source/pdfss_cpp"
 SKIP_LIBS=0
 ARCHES=()

--- a/docker/scripts/export-sophui-toolchains.sh
+++ b/docker/scripts/export-sophui-toolchains.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# 从 13.24 服务器的 cross_build_sophon_u20:v1 镜像导出 pSophUI 交叉工具链
+# （aarch64 Qt 5.12.8 + Linaro GCC 6.3）。
+#
+# 用法:
+#   bash docker/scripts/export-sophui-toolchains.sh [--image <name>] [--out <dir>]
+#     --image  源镜像名（默认 cross_build_sophon_u20:v1）
+#     --out    导出目录（默认 docker/toolchains/）
+#
+# 导出为 .tar.zst 后，`bash docker/build.sh --with-sophui-toolchain` 会将其内置于镜像；
+# 内置后构建期不再依赖独立镜像（与 M2 处理 dfss 工具链的方式一致）。
+# 若导出目录已存在同名归档，直接复用，不重复导出。
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DOCKER_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+IMAGE="${IMAGE:-cross_build_sophon_u20:v1}"
+OUT_DIR="${OUT_DIR:-${DOCKER_DIR}/toolchains}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) IMAGE="$2"; shift 2 ;;
+    --out) OUT_DIR="$2"; shift 2 ;;
+    *) echo "未知参数: $1" >&2; exit 1 ;;
+  esac
+done
+
+mkdir -p "${OUT_DIR}"
+
+# 容器内工具链路径（cross_build_sophon_u20:v1 同款，绝对引用硬编码 /env）
+QT_SRC="/env/qt_5.12.8_nosysroot"
+GCC_SRC="/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+
+ARCHIVE="${OUT_DIR}/sophui-cross-toolchains.tar.zst"
+
+if [[ -f "${ARCHIVE}" ]]; then
+  echo "已存在: ${ARCHIVE}（跳过）"
+  exit 0
+fi
+
+if ! docker image inspect "${IMAGE}" >/dev/null 2>&1; then
+  echo "错误: 找不到源镜像 '${IMAGE}'。" >&2
+  echo "请在 13.24 服务器确认该镜像存在: docker images | grep cross_build_sophon_u20" >&2
+  exit 1
+fi
+
+if ! docker run --rm "${IMAGE}" sh -c "test -d '${QT_SRC}' && test -d '${GCC_SRC}'" >/dev/null 2>&1; then
+  echo "错误: 镜像 '${IMAGE}' 中未找到 ${QT_SRC} 或 ${GCC_SRC}。" >&2
+  exit 1
+fi
+
+echo "导出 ${QT_SRC} + ${GCC_SRC} -> ${ARCHIVE} ..."
+# 镜像内无 zstd, 直接流式导到宿主用 zstd 压缩
+docker run --rm "${IMAGE}" sh -c "tar -C /env -cf - qt_5.12.8_nosysroot gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu" \
+  | zstd -q -T0 -o "${ARCHIVE}"
+ls -lh "${ARCHIVE}"
+
+echo "完成。构建镜像时加 --with-sophui-toolchain 自动内置，或在 Dockerfile 构建上下文放 toolchains/ 目录。"

--- a/docker/verify.sh
+++ b/docker/verify.sh
@@ -2,15 +2,15 @@
 # sophon-tools-build 镜像自检（对照 M1 盘点清单逐项验证工具链）
 #
 # 用法:
-#   bash docker/verify.sh                 # 默认镜像 sophon-tools-build:latest
+#   bash docker/verify.sh                 # 默认镜像 sophon-tools-build:unified
 #   bash docker/verify.sh --image <name>  # 指定镜像
-#   bash docker/verify.sh --cross         # 额外跑交叉编译实测(arm64 musl 静态 + windows)
+#   bash docker/verify.sh --cross         # 额外跑交叉编译实测(arm64 musl 静态 + windows + pqt + pSophUI)
 #
 # 退出码: 0=全部通过, 1=存在失败项
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
-IMAGE="${IMAGE:-sophon-tools-build:latest}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 DO_CROSS=0
 
 while [[ $# -gt 0 ]]; do
@@ -44,7 +44,8 @@ VERSION() {
 
 echo "== sophon-tools-build 镜像自检 ($IMAGE) =="
 
-echo "--- 基础工具链 ---"
+echo "--- 基座 / 基础工具链 ---"
+VERSION "glibc (基座)"          "ldd --version | head -1"
 VERSION "gcc (host)"            "gcc --version | head -1"
 VERSION "g++ (host)"            "g++ --version | head -1"
 VERSION "make"                  "make --version | head -1"
@@ -91,6 +92,18 @@ else
   echo "  [SKIP] dfss 私有工具链未内置(基础镜像; 用 --with-dfss-toolchains 重建)"
 fi
 
+echo "--- pqt 系列 (AppImage + windows exe) ---"
+VERSION "qmake (Qt5)"           "qmake --version 2>/dev/null | tail -1"
+CHECK  "libgl1-mesa-dev"        "test -f /usr/include/GL/gl.h"
+CHECK  "fuse"                   "ls /usr/lib/x86_64-linux-gnu/libfuse* >/dev/null 2>&1"
+CHECK  "Qt mingw 静态库"        "test -f /opt/qt-mingw/lib/libQt5Widgets.a"
+CHECK  "mingw posix g++"        "command -v x86_64-w64-mingw32-g++-posix"
+
+echo "--- pSophUI (aarch64 Qt 5.12.8 交叉) ---"
+VERSION "aarch64 Qt qmake"      "/env/qt_5.12.8_nosysroot/bin/qmake --version 2>/dev/null | tail -1"
+VERSION "Linaro aarch64 gcc"    "/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc --version | head -1"
+CHECK  "sophui-check"           "sophui-check | grep -q '已就绪'"
+
 echo "--- 打包 / 文档 / 验证工具 ---"
 CHECK  "dpkg-deb"               "dpkg-deb --version"
 CHECK  "dpkg-dev"               "dpkg-buildpackage --version | head -1"
@@ -102,13 +115,15 @@ CHECK  "patchelf"               "patchelf --version"
 CHECK  "pandoc"                 "pandoc --version | head -1"
 CHECK  "sudo"                   "sudo --version | head -1"
 CHECK  "qemu-aarch64-static"    "qemu-aarch64-static --version | head -1"
-CHECK  "qemu-loongarch64"       "qemu-loongarch64 --version | head -1"
+# ubuntu:20.04 仓库含 loongarch64 模拟器静态版 (qemu-loongarch64-static)
+CHECK  "qemu-loongarch64-static" "qemu-loongarch64-static --version | head -1"
 
 # ---- 交叉编译实测 ----
 if [[ "${DO_CROSS}" = "1" ]]; then
   echo "--- 交叉编译实测 ---"
-  # C: aarch64 musl 静态
-  if run 'printf "int main(){return 0;}\n" > /tmp/c.c && aarch64-linux-musl-gcc -static /tmp/c.c -o /tmp/c.out && file /tmp/c.out | grep -qE "statically linked|static-pie linked"'; then
+  # C: aarch64 musl 静态 (musl gcc 默认产出 static-PIE, file 会显示 dynamically linked,
+  #    判据改为: 编译成功 且 无 INTERP 段 即真静态)
+  if run 'printf "int main(){return 0;}\n" > /tmp/c.c && aarch64-linux-musl-gcc -static /tmp/c.c -o /tmp/c.out && ! readelf -l /tmp/c.out | grep -q INTERP'; then
     echo "  [PASS] C aarch64 musl 静态编译"
   else
     echo "  [FAIL] C aarch64 musl 静态编译"
@@ -147,6 +162,31 @@ if [[ "${DO_CROSS}" = "1" ]]; then
       echo "  [PASS] loongarch64 静态交叉编译"
     else
       echo "  [FAIL] loongarch64 静态交叉编译"
+      FAIL=1
+    fi
+  fi
+  # pqt: 宿主机 Qt5 qmake 能编译 AppImage 依赖(简单 Qt 程序)
+  if run 'mkdir -p /tmp/qt && cd /tmp/qt && printf "QT += core\nCONFIG += console c++11\nSOURCES += main.cpp\n" > t.pro && printf "#include <QCoreApplication>\nint main(int argc,char**argv){QCoreApplication a(argc,argv);return 0;}\n" > main.cpp && qmake t.pro >/dev/null 2>&1 && make -s -j2 >/dev/null 2>&1 && test -x t'; then
+    echo "  [PASS] pqt 宿主机 Qt5 qmake 编译"
+  else
+    echo "  [FAIL] pqt 宿主机 Qt5 qmake 编译"
+    FAIL=1
+  fi
+  # pqt: windows Qt mingw 交叉(若有 Qt 静态库) —— 用与 build-pqt.sh 相同的 CMake 流程
+  if run '[ -f /opt/qt-mingw/lib/libQt5Widgets.a ]'; then
+    if run 'mkdir -p /opt/mingw-posix/bin && for t in gcc g++ cpp cc c++ gcc-ar gcc-nm gcc-ranlib; do [ -x /usr/bin/x86_64-w64-mingw32-${t}-posix ] && ln -sf /usr/bin/x86_64-w64-mingw32-${t}-posix /opt/mingw-posix/bin/x86_64-w64-mingw32-${t}; done && export PATH=/opt/mingw-posix/bin:$PATH && mkdir -p /tmp/mingw-inc && ln -sf /usr/x86_64-w64-mingw32/include/winsock2.h /tmp/mingw-inc/Winsock2.h && ln -sf /usr/x86_64-w64-mingw32/lib/libws2_32.a /usr/x86_64-w64-mingw32/lib/libWS2_32.a && mkdir -p /tmp/qtwin && cd /tmp/qtwin && printf "cmake_minimum_required(VERSION 3.10)\nproject(qttest CXX)\nset(CMAKE_CXX_STANDARD 11)\nfind_package(Qt5 REQUIRED COMPONENTS Core)\nadd_executable(qtmain main.cpp)\ntarget_link_libraries(qtmain Qt5::Core)\n" > CMakeLists.txt && printf "#include <QCoreApplication>\nint main(int argc,char**argv){QCoreApplication a(argc,argv);return 0;}\n" > main.cpp && printf "set(CMAKE_SYSTEM_NAME Windows)\nset(CMAKE_SYSTEM_PROCESSOR x86_64)\nset(CMAKE_C_COMPILER x86_64-w64-mingw32-gcc)\nset(CMAKE_CXX_COMPILER x86_64-w64-mingw32-g++)\nset(CMAKE_FIND_ROOT_PATH /opt/qt-mingw /usr/x86_64-w64-mingw32)\nset(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)\nset(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)\nset(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)\n" > tc.cmake && export QT_PLATFORM_DIR=/opt/qt-mingw && export QT_GCC_PLATFORM_DIR=/opt/mingw-posix/bin && mkdir -p build-win && cd build-win && cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/qtwin/tc.cmake -DCMAKE_BUILD_TYPE=Release "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" >/dev/null 2>&1 && make -s -j2 >/dev/null 2>&1 && file qtmain.exe | grep -qE "PE32\+.*x86-64"'; then
+      echo "  [PASS] pqt windows Qt mingw 交叉编译"
+    else
+      echo "  [FAIL] pqt windows Qt mingw 交叉编译"
+      FAIL=1
+    fi
+  fi
+  # pSophUI: aarch64 Qt qmake 生成 Makefile + Linaro gcc 可编译(若有交叉 Qt)
+  if run '[ -x /env/qt_5.12.8_nosysroot/bin/qmake ]'; then
+    if run 'export QMAKESPEC=/env/qt_5.12.8_nosysroot/mkspecs/linux-aarch64-gnu-g++ && export PATH=/env/qt_5.12.8_nosysroot/bin:/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin:$PATH && mkdir -p /tmp/pu && cd /tmp/pu && printf "QT += core gui widgets\nCONFIG += c++11\nSOURCES += main.cpp\n" > s.pro && printf "#include <QApplication>\nint main(int argc,char**argv){QApplication a(argc,argv);return 0;}\n" > main.cpp && qmake s.pro >/dev/null 2>&1 && make -s -j2 >/dev/null 2>&1 && file s | grep -q aarch64'; then
+      echo "  [PASS] pSophUI aarch64 Qt 交叉编译"
+    else
+      echo "  [FAIL] pSophUI aarch64 Qt 交叉编译"
       FAIL=1
     fi
   fi

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -70,9 +70,11 @@ QT_MINGW_ARCHIVE="qt-mingw.tar.zst"
 #   qt_5.12.8_nosysroot  -> /env/qt_5.12.8_nosysroot                (aarch64 Qt 无 sysroot)
 #   gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
 #                        -> /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu (Linaro GCC 6.3)
-# 由 Dockerfile 多阶段 FROM cross_build_sophon_u20:v1 直接 COPY(保持原始 /env 路径,
-# 因 qmake/mkspecs 硬编码绝对路径); 无需额外导出。
+# 通过 docker/scripts/export-sophui-toolchains.sh 从 13.24 cross_build_sophon_u20:v1 导出为
+# sophui-cross-toolchains.tar.zst，放入 docker/toolchains/ 后由 build.sh --with-sophui-toolchain 内置
+# (解压到 /env 原始路径，因 qmake/mkspecs 硬编码绝对路径); 内置后不再依赖独立镜像。
 SOPHUI_QT_NAME="qt_5.12.8_nosysroot"
 SOPHUI_QT_SRC="/env/qt_5.12.8_nosysroot"
 SOPHUI_GCC_NAME="gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
 SOPHUI_GCC_SRC="/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+SOPHUI_ARCHIVE="sophui-cross-toolchains.tar.zst"

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -3,8 +3,10 @@
 # 修改版本后重新运行: bash docker/build.sh
 
 # ---- 基础镜像 ----
-# ubuntu:22.04 的 digest（不可变引用，保证可复现）
-UBUNTU_BASE_DIGEST="ubuntu@sha256:445586e41c1de7dfda82d2637f5ff688deea9eb5f5812f8c145afacc35b9f0db"
+# ubuntu:20.04 的 digest（不可变引用，保证可复现）。
+# M5 合并: 三镜像(22.04 主镜像 + pqt 20.04 + pSophUI 20.04)统一为单个 20.04 基座。
+# 20.04 glibc=2.31，满足 pqt AppImage 的 linuxdeployqt 硬约束(glibc<=2.31)。
+UBUNTU_BASE_DIGEST="ubuntu@sha256:8feb4d8ca5354def3d8fce243717141ce31e2c428701f6682bd2fafe15388214"
 
 # ---- Go（pbmssm / psophliteos 后端）----
 GO_VERSION="1.25.5"
@@ -24,8 +26,8 @@ PNPM_VERSION="9.15.9"
 YARN_VERSION="1.22.22"
 
 # ---- C/C++ 交叉工具链（apt 精确版本，Dockerfile 内固定）----
-# 宿主机 gcc/g++（amd64）: 由 ubuntu:22.04 仓库提供，版本 11.x
-# aarch64-linux-gnu / arm-linux-gnueabi / riscv64-linux-gnu / mingw-w64: 由 ubuntu:22.04 仓库提供
+# 宿主机 gcc/g++（amd64）: 由 ubuntu:20.04 仓库提供，版本 9.4
+# aarch64-linux-gnu / arm-linux-gnueabi / riscv64-linux-gnu / mingw-w64: 由 ubuntu:20.04 仓库提供
 #   gcc-aarch64-linux-gnu / g++-aarch64-linux-gnu      -> aarch64 (pdfss_cpp arm64)
 #   gcc-arm-linux-gnueabi / g++-arm-linux-gnueabi      -> armbi (pdfss_cpp armel)
 #   gcc-riscv64-linux-gnu / g++-riscv64-linux-gnu      -> riscv64 (pdfss_cpp riscv64)
@@ -50,6 +52,27 @@ DFSS_LOONGARCH64_NAME="loongarch64-cross-tools"
 DFSS_LOONGARCH64_ARCHIVE="loongarch64-cross-tools.tar.zst"
 
 # ---- 其他工具（打包 / 文档 / 验证）----
-QT_VERSION="5.15.3"              # pqt 系列 AppImage 依赖（qmake）
-PANDOC_VERSION="2.9"
+QT_VERSION="5.15.2"              # Qt mingw 静态库版本（pqt windows exe 依赖，build-qt-mingw.sh 编译）
+PANDOC_VERSION="2.5"             # ubuntu:20.04 仓库版本
 UPX_VERSION="4.2.4"
+
+# ---- pqt 系列（AppImage + windows exe）----
+# linux AppImage: 依赖宿主 glibc<=2.31 -> 新基座 ubuntu:20.04 已满足，无需独立镜像。
+# windows exe:   依赖 Qt 5.15 mingw 静态库(交叉编译产物, 默认 /opt/qt-mingw)。
+#   必须在 20.04 基座内从源码交叉编译(bash docker/pqt/build-qt-mingw.sh, 约 20-40 分钟):
+#   若复用 22.04 基座编译的 /opt/qt-mingw, 其宿主工具(uic/moc)依赖 glibc 2.33+, 在 20.04 内无法运行。
+#   产物归档到 docker/toolchains/qt-mingw.tar.zst 后由 build.sh --with-qt-mingw 内置。
+QT_MINGW_NAME="qt-mingw"
+QT_MINGW_ARCHIVE="qt-mingw.tar.zst"
+
+# ---- pSophUI（aarch64 Qt 5.12.8 + Linaro GCC 6.3 交叉工具链）----
+# 来源: 13.24 cross_build_sophon_u20:v1 容器 /env/ 下现成工具链。
+#   qt_5.12.8_nosysroot  -> /env/qt_5.12.8_nosysroot                (aarch64 Qt 无 sysroot)
+#   gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
+#                        -> /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu (Linaro GCC 6.3)
+# 由 Dockerfile 多阶段 FROM cross_build_sophon_u20:v1 直接 COPY(保持原始 /env 路径,
+# 因 qmake/mkspecs 硬编码绝对路径); 无需额外导出。
+SOPHUI_QT_NAME="qt_5.12.8_nosysroot"
+SOPHUI_QT_SRC="/env/qt_5.12.8_nosysroot"
+SOPHUI_GCC_NAME="gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
+SOPHUI_GCC_SRC="/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"

--- a/release.sh
+++ b/release.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 # =============================================================================
-# sophon-tools 一键全量多平台 release（M4 统一入口）
+# sophon-tools 一键全量多平台 release（M4 统一入口 / M5 单镜像）
 #
 # 用法:
 #   bash release.sh [--project <子项目>] [--version <版本号>] [--no-image-check]
 #
 # 行为:
-#   1. 检查统一构建镜像 sophon-tools-build:m2 是否可用；缺失时提示用
-#      `bash docker/build.sh` 构建（不自动构建，避免长时间阻塞）。
+#   1. 检查统一构建镜像 sophon-tools-build:unified（M5 单镜像, ubuntu:20.04 基座）
+#      是否可用；缺失时提示用 `bash docker/build.sh` 构建（不自动构建，避免长时间阻塞）。
 #   2. 驱动 docker/build-all.sh 对全部子项目做多平台构建（失败隔离：单项目
 #      失败不阻塞整体，结束后列出失败项，非零退出）。
 #   3. 汇聚产物到 output/<子项目>/（保持既有 output 约定），并生成:
@@ -26,7 +26,7 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 cd "${SCRIPT_DIR}" || exit 1
 
-IMAGE="${IMAGE:-sophon-tools-build:m2}"
+IMAGE="${IMAGE:-sophon-tools-build:unified}"
 ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -43,7 +43,7 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
-echo "==> sophon-tools 一键全量 release（M4 统一入口）"
+echo "==> sophon-tools 一键全量 release（M5 单镜像 ${IMAGE}）"
 echo "==> 工作目录: ${SCRIPT_DIR}"
 
 # --- 1. 镜像前置检查 --------------------------------------------------------


### PR DESCRIPTION
## Summary

M5 里程碑：把当前三镜像方案合并为**单个 ubuntu:20.04 基座镜像** `sophon-tools-build:unified`。

| 旧镜像 | 基座 | 去向 |
|--------|------|------|
| `sophon-tools-build:m2` | ubuntu:22.04 | → 合并入 unified |
| `sophon-tools-build-pqt` | ubuntu:20.04 | → 合并入 unified（pqt 依赖并入） |
| `cross_build_sophon_u20:v1` | ubuntu:20.04 | → pSophUI 工具链归档内置（不再依赖独立镜像） |

**为什么 20.04**：pqt 打 AppImage 依赖 linuxdeployqt，强制宿主 glibc ≤ 2.31（保证产物兼容旧发行版），ubuntu:20.04 glibc=2.31 满足。

## 变更内容

- **Dockerfile**：基座切 ubuntu:20.04；并入 pqt 依赖（`libgl1-mesa-dev`/`fuse`/Qt5）；新增 `--with-qt-mingw` 内置 Qt mingw 静态库
- **pSophUI 工具链并入（U3）**：aarch64 Qt 5.12.8 + Linaro GCC 6.3 以 `toolchains/sophui-cross-toolchains.tar.zst` 归档内置（`--with-sophui-toolchain`），解压到 `/env` 原始路径；移除多阶段 `FROM cross_build_sophon_u20:v1`，构建期不再需要独立镜像存在（参考 M2 处理 dfss 工具链的方式）
- **新增** `docker/scripts/export-sophui-toolchains.sh`：从 13.24 `cross_build_sophon_u20:v1` 导出工具链归档（一次性来源）
- **关键修复**：dfss sw_64 工具链含通用名 `ldd`（sw64 glibc 版），原全局 PATH 会遮蔽系统 ldd，破坏 linuxdeployqt 对 x86 二进制的解析 —— 已移除全局 PATH，改由 `build-all.sh` 按 pdfss_cpp 子项目注入
- **build-all.sh**：移除按子项目切换镜像与宿主执行逻辑，16 子项目统一在单镜像内构建；pqt 系列以 `PQT_INPLACE=1` 在容器内直接执行
- **build.sh**：移除对 `cross_build_sophon_u20:v1` 的强制存在检查；新增 `--with-sophui-toolchain`
- **verify.sh**：新增基座 glibc / pqt / pSophUI 工具链检查与交叉编译实测
- **release.sh / README / versions.env**：同步单镜像方案

## 验证结果（13.24 实测）

- 统一镜像构建成功（glibc 2.31）
- `docker/verify.sh --cross` 全部通过（含 aarch64 musl / Rust / mingw / sw_64 / loongarch64 / pqt Qt5 / pqt mingw / pSophUI aarch64 Qt 交叉编译）
- **16/16 子项目全量回归通过**（对照 M3 矩阵）
- 产物核对：pqt AppImage（26M）+ windows exe（PE32+ x86-64）+ pSophUI `sophgo-hdmi_1.6.8_arm64.deb` + dfss 8 架构全部产出
- **U3 独立镜像不再需要**：构建期无 `FROM cross_build_sophon_u20:v1`，pSophUI 在单镜像内产出 arm64 产物

## Test plan

- [x] 单镜像构建成功（ubuntu:20.04 基座）
- [x] 16 子项目全量回归 16/16
- [x] pqt AppImage + windows exe 在单镜像内产出
- [x] pSophUI aarch64 Qt 交叉编译产出 deb（无独立镜像依赖）
- [x] dfss sw_64 / loongarch64 8 架构产物
- [x] `docker/verify.sh --cross` 全部通过
- [x] build-all.sh 单镜像一条命令全量（无镜像切换）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
