### PR TITLE
fix(pbmssm): 修复 MYS-49 review 应修项 + 收敛建议项

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,7 @@ ARG GO_VERSION GO_TARBALL_URL GO_TARBALL_SHA256
 ARG RUST_VERSION
 ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
 ARG PNPM_VERSION YARN_VERSION
+ARG MUSL_AARCH64_URL MUSL_AARCH64_SHA256 MUSL_X86_64_URL MUSL_X86_64_SHA256
 ARG WITH_DFSS=0
 ARG WITH_QT_MINGW=0
 ARG WITH_SOPHUI=0
@@ -117,11 +118,15 @@ RUN rustup target add aarch64-unknown-linux-musl aarch64-unknown-linux-gnu \
     && printf '[target.aarch64-unknown-linux-musl]\nlinker = "aarch64-linux-musl-gcc"\nrustflags = ["-C", "link-arg=-s"]\n' > "${CARGO_HOME}/config.toml"
 
 # ---- musl 交叉工具链(静态链接: pbmssm/psophliteos/pbm_set_ip) ----
-# 预置 aarch64 + x86_64; 若构建期网络受限, 子项目脚本会自行从 musl.cc 拉取。
+# 预置 aarch64 + x86_64; 下载即校验 SHA256(versions.env 锁定); 若构建期网络受限,
+# 子项目脚本会自行从 musl.cc 拉取。
+ARG MUSL_AARCH64_URL MUSL_AARCH64_SHA256 MUSL_X86_64_URL MUSL_X86_64_SHA256
 RUN mkdir -p /opt/musl \
-    && curl -fsSL "https://musl.cc/aarch64-linux-musl-cross.tgz" -o /tmp/musl-aarch64.tgz \
+    && curl -fsSL "${MUSL_AARCH64_URL}" -o /tmp/musl-aarch64.tgz \
+    && echo "${MUSL_AARCH64_SHA256}  /tmp/musl-aarch64.tgz" | sha256sum -c - \
     && tar -C /opt/musl -xzf /tmp/musl-aarch64.tgz && rm /tmp/musl-aarch64.tgz \
-    && curl -fsSL "https://musl.cc/x86_64-linux-musl-cross.tgz" -o /tmp/musl-x86_64.tgz \
+    && curl -fsSL "${MUSL_X86_64_URL}" -o /tmp/musl-x86_64.tgz \
+    && echo "${MUSL_X86_64_SHA256}  /tmp/musl-x86_64.tgz" | sha256sum -c - \
     && tar -C /opt/musl -xzf /tmp/musl-x86_64.tgz && rm /tmp/musl-x86_64.tgz \
     && aarch64-linux-musl-gcc --version | head -1 && x86_64-linux-musl-gcc --version | head -1
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -169,6 +169,10 @@ docker build \
   --build-arg NODE_TARBALL_SHA256="${NODE_TARBALL_SHA256}" \
   --build-arg PNPM_VERSION="${PNPM_VERSION}" \
   --build-arg YARN_VERSION="${YARN_VERSION}" \
+  --build-arg MUSL_AARCH64_URL="${MUSL_AARCH64_URL}" \
+  --build-arg MUSL_AARCH64_SHA256="${MUSL_AARCH64_SHA256}" \
+  --build-arg MUSL_X86_64_URL="${MUSL_X86_64_URL}" \
+  --build-arg MUSL_X86_64_SHA256="${MUSL_X86_64_SHA256}" \
   "${EXTRA_ARGS[@]}" \
   -f "${DOCKER_DIR}/Dockerfile" \
   -t "${IMAGE_NAME}:${TAG}" \

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -40,12 +40,14 @@ YARN_VERSION="1.22.22"
 #   gcc-mingw-w64-x86-64 / gcc-mingw-w64-i686          -> mingw64 / mingw (pdfss_cpp windows)
 
 # ---- musl 交叉工具链（pbmssm / psophliteos / pbm_set_ip 静态链接）----
+# SHA256 对应 musl.cc 固定版本；工具链为持续构建的滚动发布，musl.cc 页面本身无版本号，
+# 这里锁的是 2026-08-09 拉取内容的哈希。若上游更新需重发镜像，先重算哈希再填回。
 MUSL_AARCH64_NAME="aarch64-linux-musl-cross"
 MUSL_AARCH64_URL="https://musl.cc/${MUSL_AARCH64_NAME}.tgz"
-MUSL_AARCH64_SHA256=""           # 留空则首次构建时打印实际哈希，填回即可固定
+MUSL_AARCH64_SHA256="c909817856d6ceda86aa510894fa3527eac7989f0ef6e87b5721c58737a06c38"
 MUSL_X86_64_NAME="x86_64-linux-musl-cross"
 MUSL_X86_64_URL="https://musl.cc/${MUSL_X86_64_NAME}.tgz"
-MUSL_X86_64_SHA256=""
+MUSL_X86_64_SHA256="c5d410d9f82a4f24c549fe5d24f988f85b2679b452413a9f7e5f7b956f2fe7ea"
 
 # ---- dfss 私有工具链（sw_64 / loongarch64，13.24 服务器容器导出）----
 # 来源: 13.24 服务器 bm1684_zzt 容器（镜像 cross_build_sophon_u20:v1）

--- a/source/pbmssm/README.md
+++ b/source/pbmssm/README.md
@@ -3,8 +3,9 @@
 Sophon System Management 服务（由 bmssm 现代化重写）。
 
 ## 编译
-- x86: `bash build/build-bmssm.sh`
-- arm64: `bash build/build-bmssm-arm64.sh`（musl 工具链自动获取）
+- x86（开发机/PCIE 主机，宿主 gcc 动态链接）: `bash build/build-bmssm.sh`
+- arm64（设备端，musl 全静态链接）: `bash build/build-bmssm-arm64.sh`（musl 工具链自动获取）
+- 统一入口: `bash release.sh [arm64|amd64|all] [VERSION]`（产物到 `$OUTPUT_DIR`，默认 `<repo>/output/pbmssm/`）
 
 ## 配置
 默认读取 `/etc/bmssm/conf/bmssm.yaml`，本地开发回退 `./config/bmssm.yaml`。

--- a/source/pbmssm/build/build-bmssm-arm64.sh
+++ b/source/pbmssm/build/build-bmssm-arm64.sh
@@ -26,6 +26,8 @@ file bmssm-arm64 | grep -q 'statically linked' \
 echo "arm64 产物静态链接校验通过"
 
 mkdir -p release
+# 先清空 release/ 再落产物，避免上一架构残留（如连续 all 构建 arm64→amd64 中断）
+rm -f release/bmssm release/bmssm.yaml
 cp bmssm-arm64 release/bmssm
 cp config/bmssm.yaml release/
 echo "built release/bmssm (arm64, musl static)"

--- a/source/pbmssm/build/build-bmssm.sh
+++ b/source/pbmssm/build/build-bmssm.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# x86 构建
+# x86 构建（开发机/PCIE 主机定位：宿主 gcc 动态链接，非部署镜像标准；
+# 设备端使用 arm64 的 musl 全静态产物 —— build-bmssm-arm64.sh）
 set -e
 cd "$(dirname "$0")/.."
 VERSION="${1:-2.1.0}"

--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -8,6 +8,8 @@ set -e
 
 cd "$(dirname "$0")/.."
 VERSION="${1:-2.1.0}"
+# 版本号不允许进入 sed 替换分隔符；若含 / 则替换为 -（同时保持产物名一致）
+VERSION="${VERSION//\//-}"
 ARCH="${2:-arm64}"
 
 # 1. 交叉编译静态二进制 + 打包 bmssm.yaml 到 release/
@@ -32,6 +34,8 @@ cp release/bmssm.yaml "$DEBROOT/opt/sophon/bmssm/config/bmssm.yaml"
 cp build/bmssm.service "$DEBROOT/usr/lib/systemd/system/bmssm.service"
 
 # 3. DEBIAN 控制文件（Version/Architecture 注入）
+#    注: ARCH 未过 dpkg-architecture 映射，当前 arm64/amd64 即 Debian 架构名；
+#        未来扩展 armhf/armel 等时需映射。
 sed -e "s/@VERSION@/$VERSION/" -e "s/@ARCH@/$ARCH/" \
   build/deb/bmssm.control > "$DEBROOT/DEBIAN/control"
 cp build/deb/postinst "$DEBROOT/DEBIAN/postinst"

--- a/source/pbmssm/build/fetch-musl-toolchain.sh
+++ b/source/pbmssm/build/fetch-musl-toolchain.sh
@@ -13,7 +13,9 @@ TOOLCHAIN_URL="https://musl.cc/${TOOLCHAIN_NAME}.tgz"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TOOLCHAIN_ROOT="${MUSL_TOOLCHAIN_ROOT:-${SCRIPT_DIR}/toolchain}"
 TOOLCHAIN_DIR="${TOOLCHAIN_ROOT}/${TOOLCHAIN_NAME}"
-EXPECTED_SHA256="${MUSL_TOOLCHAIN_SHA256:-}"
+# 固定哈希与 docker/versions.env 的 MUSL_AARCH64_SHA256 一致（2026-08-09 拉取）。
+# 上游 musl.cc 更新后需同步更新；环境变量 MUSL_TOOLCHAIN_SHA256 可覆盖。
+EXPECTED_SHA256="${MUSL_TOOLCHAIN_SHA256:-c909817856d6ceda86aa510894fa3527eac7989f0ef6e87b5721c58737a06c38}"
 
 # 1) 系统 PATH 已有该工具链,直接退出(不输出,沿用系统)
 if command -v aarch64-linux-musl-gcc >/dev/null 2>&1; then

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
 VERSION="${2:-2.1.0}"


### PR DESCRIPTION
## Summary
修复 pbmssm 子项目代码 review（MYS-49）发现的问题，对齐统一构建规范。

### 🟠 应修（必修）
1. **release.sh 补 `cd "$SCRIPT_DIR"`** — `source/pbmssm/release.sh:9` 消除了相对路径对调用方 cwd 的依赖，与根 `release.sh:27` 及其余子项目对齐。
2. **musl 工具链固定 SHA256** — `docker/versions.env` 填入 aarch64/x86_64 哈希；`docker/Dockerfile` musl 下载段改用 ARG + `sha256sum -c` 强制校验；`docker/build.sh` 注入 musl ARG；`source/pbmssm/build/fetch-musl-toolchain.sh` 默认值固定同一哈希（`MUSL_TOOLCHAIN_SHA256` 可覆盖）。

### 🟡 建议（收敛处理）
3. **VERSION 含 `/` 过滤为 `-`** — `build-deb-bmssm.sh:11` 防 sed 替换分隔符破坏。
4. **arm64 落产物前清理 `release/`** — `build-bmssm-arm64.sh:29` 防连续 all 构建跨架构残留。
5. **amd64 动态链接定位写清楚** — `build-bmssm.sh` 注释 + README 明确"开发机/PCIE 主机定位"。
6. **Architecture 映射限制加注释** — 当前 arm64/amd64 即 Debian 架构名，扩展时需映射。

## Test plan
容器（sophon-tools-build:unified-v1.1.0）内从**非 pbmssm 目录**（cwd=/）执行：
- `release.sh amd64 2.1.0` ✅ 产物 `bmssm_2.1.0_amd64.deb`（动态链接，符合设计）
- `release.sh arm64 2.1.0` ✅ 产物 `bmssm_2.1.0_arm64.deb`（musl 全静态，门禁通过）
- `release.sh all 2.1.0` ✅ 双架构连续构建，release/ 无跨架构残留
- 非法 ARCH（riscv64）正确报错退出 1
- fetch-musl-toolchain.sh 哈希校验：默认哈希匹配 ✅ / 错误哈希拒绝并清理 ✅ / env 覆盖 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)