### PR TITLE
fix(pbmsec): 修复 MYS-51 review 问题（socbak 依赖/文档目录/deb 安全性）

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -115,6 +115,12 @@ EXTRA_ENV[pdfss_cpp]="export PATH=/env/loongson-gnu-toolchain-8.3-x86_64-loongar
 EXTRA_ENV[pqt_batch_deployment]="export PQT_INPLACE=1"
 EXTRA_ENV[pqt_memory_edit]="export PQT_INPLACE=1"
 
+# 子项目 -> 构建依赖（先构建依赖方，再构建本项目）
+# pbmsec 的 socbak.zip 取自 psocbak（release.sh 会优先复用其产物，缺失时现场打包），
+# 因此 psocbak 必须先于 pbmsec 构建，否则干净 checkout 上 pbmsec 会失败。
+declare -A DEPENDS
+DEPENDS[pbmsec]=psocbak
+
 if [[ "${LIST_ONLY:-0}" = "1" ]]; then
   echo "=== sophon-tools 16 子项目构建清单（pmulti_video_qt 已排除，单镜像 ${IMAGE}） ==="
   for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
@@ -167,10 +173,27 @@ run_one() {
   fi
 }
 
+# 构建顺序: 有依赖的项目等其依赖方先构建完；无依赖按字母序。
+# 去重 + 拓扑排序（本项目仅一层依赖，简单处理即可）。
+build_order() {
+  local order=() seen=" "
+  local p d
+  for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
+    d="${DEPENDS[$p]:-}"
+    if [[ -n "$d" && "$seen" != *" $d "* ]]; then
+      order+=("$d"); seen="$seen$d "
+    fi
+    if [[ "$seen" != *" $p "* ]]; then
+      order+=("$p"); seen="$seen$p "
+    fi
+  done
+  printf '%s\n' "${order[@]}"
+}
+
 if [[ -n "${ONLY_PROJECT}" ]]; then
   run_one "${ONLY_PROJECT}"
 else
-  for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
+  for p in $(build_order); do
     run_one "$p"
   done
 fi
@@ -199,6 +222,22 @@ if [[ -z "${ONLY_PROJECT}" || "${ONLY_PROJECT}" = "pSophUI" ]]; then
              "${pui}"/ui_mainwindow.h 2>/dev/null || true
       rm -f "${pui}/SophUI" 2>/dev/null || true
       rm -rf "${pui}/deb/opt" 2>/dev/null || true
+    fi
+  fi
+fi
+
+# ---- 构建后清理：pbmsec 的 pandoc/socbak 会把 HTML/man/zip 生成到源码树 deb/ 下 ----
+# 这些是中间产物（*.html / *.1 / *.zip 被 gitignore，但目录由容器内 root 创建，
+# 宿主后续构建会因权限失败）。统一构建后移除，保持工作区可被宿主持续使用。
+if [[ -z "${ONLY_PROJECT}" || "${ONLY_PROJECT}" = "pbmsec" ]]; then
+  pbmsec_gen="${REPO_ROOT}/source/pbmsec/deb/opt/sophon/bmsec/doc"
+  pbmsec_share="${REPO_ROOT}/source/pbmsec/deb/usr/share"
+  pbmsec_socbak="${REPO_ROOT}/source/pbmsec/deb/opt/sophon/bmsec/binTools/socbak.zip"
+  if [[ -d "${pbmsec_gen}" || -d "${pbmsec_share}" || -f "${pbmsec_socbak}" ]]; then
+    if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
+      sudo rm -rf "${pbmsec_gen}" "${pbmsec_share}" "${pbmsec_socbak}" 2>/dev/null || true
+    else
+      rm -rf "${pbmsec_gen}" "${pbmsec_share}" "${pbmsec_socbak}" 2>/dev/null || true
     fi
   fi
 fi

--- a/source/pbmsec/deb/DEBIAN/control
+++ b/source/pbmsec/deb/DEBIAN/control
@@ -4,4 +4,5 @@ Version: BMSEC_VERSION
 Architecture: all
 Maintainer: sophon
 Priority: optional
+Depends: tftpd-hpa
 Description: This is a tool for se6/8.

--- a/source/pbmsec/deb/DEBIAN/postinst
+++ b/source/pbmsec/deb/DEBIAN/postinst
@@ -1,22 +1,48 @@
 #!/bin/bash
+# 配置 tftpd-hpa、安装 /bin/bmsec 链接、升级时恢复用户配置。
+# tftpd-hpa 的改动均有存在性守卫（依赖由 control Depends 声明，但服务可能被禁用/缺失）。
+set -e
 
 file="/etc/default/tftpd-hpa"
 
-if [[ $(grep -o '\-v' "$file") ]]; then
-    echo "TFTP_OPTIONS already contains '-v'. No changes made."
+if [ -f "$file" ]; then
+    if [[ $(grep -o '\-v' "$file") ]]; then
+        echo "TFTP_OPTIONS already contains '-v'. No changes made."
+    else
+        sed -i 's/\(TFTP_OPTIONS="\)/\1-v /' "$file"
+        echo "Added '-v' to TFTP_OPTIONS."
+    fi
 else
-    sed -i 's/\(TFTP_OPTIONS="\)/\1-v /' "$file"
-    echo "Added '-v' to TFTP_OPTIONS."
+    echo "WARN: $file not found, skip TFTP_OPTIONS modification"
 fi
 
-systemctl restart tftpd-hpa
+if systemctl list-unit-files tftpd-hpa.service >/dev/null 2>&1; then
+    systemctl restart tftpd-hpa
+else
+    echo "WARN: tftpd-hpa.service not found, skip restart"
+fi
+
 rm -rf /bin/bmsec
-ln -s /opt/sophon/bmsec/bmsec /bin/
+ln -sf /opt/sophon/bmsec/bmsec /bin/bmsec
 
 rm -rf /opt/sophon/bmsec/configs/subNANInfo
 
-if command -v mandb &> /dev/null
-then
+# 升级时恢复 preinst 备份的用户配置（覆盖新包默认值，保留用户修改）
+BKUP="/opt/sophon/bmsec-config-backup"
+if [ -n "${2:-}" ] && [ -d "$BKUP/configs" ]; then
+    if [ -d /opt/sophon/bmsec/configs ]; then
+        cp -a "$BKUP/configs/." /opt/sophon/bmsec/configs/
+    else
+        cp -a "$BKUP/configs" /opt/sophon/bmsec/configs
+    fi
+    rm -rf "$BKUP"
+    echo "bmsec: restored user configs from backup"
+fi
+
+# 恢复的备份中不含 subNANInfo；但新包解包/备份合并可能引入，统一再清理一次
+rm -rf /opt/sophon/bmsec/configs/subNANInfo
+
+if command -v mandb >/dev/null 2>&1; then
     mandb
 fi
 

--- a/source/pbmsec/deb/DEBIAN/preinst
+++ b/source/pbmsec/deb/DEBIAN/preinst
@@ -1,3 +1,16 @@
 #!/bin/bash
+# 升级时先备份用户配置（configs/，排除运行时产物 subNANInfo），postinst 恢复；
+# 全新安装/卸载无需备份。备份放 /opt/sophon/bmsec-config-backup（不在清理范围内）。
+set -e
 
+BKUP="/opt/sophon/bmsec-config-backup"
+if [ "$1" = "upgrade" ] && [ -d /opt/sophon/bmsec/configs ]; then
+    rm -rf "$BKUP"
+    mkdir -p "$BKUP"
+    rm -rf /opt/sophon/bmsec/configs/subNANInfo  # 运行时产物不备份
+    cp -a /opt/sophon/bmsec/configs "$BKUP/configs"
+    echo "bmsec: backed up user configs to $BKUP"
+fi
+
+# 清理旧安装（配置已备份，运行时产物一并清除）
 rm -rf /opt/sophon/bmsec

--- a/source/pbmsec/release.sh
+++ b/source/pbmsec/release.sh
@@ -4,7 +4,9 @@
 #   ARCH:    all（默认，deb 为 Architecture: all 双架构合并包）
 #   VERSION: 显式版本号（默认 1.6.4）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbmsec/）
-# 依赖: 先构建 psocbak（自动同步 socbak.zip，缺失时用入库旧包）
+# 依赖: socbak.zip（打进 binTools/）。获取顺序: ① ../psocbak/output/ 的构建产物
+#       → ② 现场从 ../psocbak/socbak/ 打包 → ③ 本地已入库 socbak.zip（无则报错）。
+#       build-all.sh 已声明 psocbak 先于 pbmsec 构建（DEPENDS）。
 set -uo pipefail
 
 BUILD_RET=0
@@ -12,6 +14,7 @@ BUILD_RET=0
 echo "build bmsec ..."
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "$SCRIPT_DIR"   # 相对路径全部以本脚本目录为基准，与其余子项目对齐
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-all}"
 BMSEC_PACKAGE_VERSION="${2:-1.6.4}"
@@ -21,67 +24,107 @@ export CMD_PANDOC=$(command -v pandoc)
 export CMD_DPKG_DEB=$(command -v dpkg-deb)
 
 rm -rf bmsec*.deb 2>/dev/null
-rm -rf *.deb* 2>/dev/null
-rm -rf output 2>/dev/null
 rm -rf ./*.html
-mkdir output
+rm -rf ./*.1
+rm -rf deb/opt/sophon/bmsec/doc deb/usr/share/man/man1 2>/dev/null
 
 # Sync socbak.zip from sibling psocbak project.
-# Run psocbak/release.sh first if a fresh build is needed; otherwise the
-# prebuilt socbak.zip is reused. The zip is shipped inside bmsec/binTools/.
-SOCBAK_SRC="$(dirname "$(pwd)")/psocbak/socbak.zip"
-SOCBAK_DST="deb/opt/sophon/bmsec/binTools/socbak.zip"
-if [ -f "$SOCBAK_SRC" ]; then
-	echo "sync socbak.zip from $SOCBAK_SRC"
-	cp "$SOCBAK_SRC" "$SOCBAK_DST"
-else
-	if [ ! -f "$SOCBAK_DST" ]; then
-		echo "ERROR: socbak.zip not found at $SOCBAK_SRC or $SOCBAK_DST"
-		echo "       run bash release.sh in the psocbak project first, or place socbak.zip manually"
-		exit 1
-	fi
-	echo "WARN: $SOCBAK_SRC not found, reuse existing $SOCBAK_DST"
+# 优先复用 psocbak 的构建产物（output/socbak.zip 或项目根 socbak.zip）；
+# 缺失时现场从 ../psocbak/socbak/ 目录打包（与 psocbak/release.sh 同一压缩方式）；
+# 兜底复用本地已入库 socbak.zip，再不行则报错退出。
+SOCBAK_DST="$SCRIPT_DIR/deb/opt/sophon/bmsec/binTools/socbak.zip"
+ensure_socbak() {
+  local src=""
+  for candidate in \
+    "$SCRIPT_DIR/../psocbak/output/socbak.zip" \
+    "$SCRIPT_DIR/../psocbak/socbak.zip"; do
+    if [ -f "$candidate" ]; then
+      src="$candidate"
+      break
+    fi
+  done
+
+  if [ -n "$src" ]; then
+    echo "sync socbak.zip from $src"
+    cp "$src" "$SOCBAK_DST"
+    return 0
+  fi
+
+  # 现场打包: psocbak 源码目录入库（socbak.zip 本身被 gitignore），
+  # 与 psocbak/release.sh 的打包方式一致（7z 优先, 退 zip）。
+  local socbak_dir="$SCRIPT_DIR/../psocbak/socbak"
+  if [ -d "$socbak_dir" ]; then
+    echo "socbak.zip not prebuilt, packaging from $socbak_dir ..."
+    if command -v 7z >/dev/null 2>&1; then
+      (cd "$SCRIPT_DIR/../psocbak" && 7z a -mx9 "$SOCBAK_DST" socbak >/dev/null) \
+        && echo "packed socbak.zip with 7z" && return 0
+    fi
+    if command -v zip >/dev/null 2>&1; then
+      (cd "$SCRIPT_DIR/../psocbak" && zip -r -9 "$SOCBAK_DST" socbak >/dev/null) \
+        && echo "packed socbak.zip with zip" && return 0
+    fi
+    echo "ERROR: 需要 7z 或 zip 来现场打包 socbak.zip (psocbak 未预构建)"
+    return 1
+  fi
+
+  if [ -f "$SOCBAK_DST" ]; then
+    echo "WARN: socbak.zip not found in psocbak, reuse existing $SOCBAK_DST"
+    return 0
+  fi
+
+  echo "ERROR: socbak.zip not found at $SOCBAK_DST (psocbak 未构建且无法现场打包)"
+  echo "       run bash release.sh in the psocbak project first, or place socbak.zip manually"
+  return 1
+}
+
+if ! ensure_socbak; then
+  exit 1
 fi
 
 if [ -f "$CMD_PANDOC" ] && [ -f "$CMD_DPKG_DEB" ]; then
-	echo "found $CMD_PANDOC and $CMD_DPKG_DEB"
-	pushd doc
-		for file in *.md; do
-			if [ -f "$file" ]; then
-				echo "Converting $file to HTML ${file%.md}.html ..."
-				$CMD_PANDOC "$file" --self-contained -c bootstrap.min.css --metadata title=${file%.md} -o "${file%.md}.html"
-			fi
-		done
-		mkdir -p deb/opt/sophon/bmsec/doc/
-		rm -rf deb/opt/sophon/bmsec/doc/*
-		cp *.html deb/opt/sophon/bmsec/doc/
-		rm -rf bmsec.1
-		echo "Converting man Doc file ..."
-		cat *.md | $CMD_PANDOC -s --self-contained -c bootstrap.min.css -t man -o bmsec.1
-		mkdir -p deb/usr/share/man/man1/
-		rm -rf deb/usr/share/man/man1/*
-		cp bmsec.1 deb/usr/share/man/man1/
-	popd
-	rm -rf deb/opt/sophon/bmsec/configs/subNANInfo
-	BMSEC_VERSION=${BMSEC_PACKAGE_VERSION}
-	cp deb/DEBIAN/control ./control.bak
-	sed -i "s/BMSEC_VERSION/$BMSEC_VERSION/" deb/DEBIAN/control
-	echo "deb build version: ${BMSEC_VERSION}"
-	$CMD_DPKG_DEB -b deb bmsec_v$BMSEC_VERSION.deb
-	mv ./control.bak deb/DEBIAN/control
-	if [ -f "bmsec_v$BMSEC_VERSION.deb" ]; then
-		BUILD_RET=0
-	else
-		BUILD_RET=-1
-	fi
+  echo "found $CMD_PANDOC and $CMD_DPKG_DEB"
+  pushd doc
+    mkdir -p "$SCRIPT_DIR/deb/opt/sophon/bmsec/doc/"
+    for file in *.md; do
+      if [ -f "$file" ]; then
+        echo "Converting $file to HTML ${file%.md}.html ..."
+        "$CMD_PANDOC" "$file" --self-contained -c bootstrap.min.css --metadata title="${file%.md}" -o "$SCRIPT_DIR/deb/opt/sophon/bmsec/doc/${file%.md}.html" || { echo "ERROR: pandoc 转换 $file 失败" >&2; BUILD_RET=1; }
+      fi
+    done
+    echo "Converting man Doc file ..."
+    mkdir -p "$SCRIPT_DIR/deb/usr/share/man/man1/"
+    "$CMD_PANDOC" -s --self-contained -c bootstrap.min.css -t man *.md -o "$SCRIPT_DIR/deb/usr/share/man/man1/bmsec.1" || { echo "ERROR: pandoc 生成 man 页失败" >&2; BUILD_RET=1; }
+  popd
+  rm -rf deb/opt/sophon/bmsec/configs/subNANInfo
+  BMSEC_VERSION=${BMSEC_PACKAGE_VERSION}
+  # sed 只替换第一处 BMSEC_VERSION（Version 字段），避免将来 Description 等再出现同名
+  # 占位符时被误替换；版本号含 / 时先转义防 sed 破坏。
+  VERSION_SAFE="$(printf '%s' "$BMSEC_VERSION" | sed 's|/|\\/|g')"
+  # -p 保留属主，容器内 root 构建后 mv 回来时 control 不变成 root 属主
+  cp -p deb/DEBIAN/control ./control.bak
+  if ! sed -i "0,/BMSEC_VERSION/s/BMSEC_VERSION/$VERSION_SAFE/" deb/DEBIAN/control; then
+    echo "ERROR: 写入版本号到 control 失败" >&2
+    BUILD_RET=1
+  fi
+  echo "deb build version: ${BMSEC_VERSION}"
+  if [ "$BUILD_RET" = "0" ]; then
+    "$CMD_DPKG_DEB" -b deb "bmsec_v$BMSEC_VERSION.deb" || BUILD_RET=1
+  fi
+  mv ./control.bak deb/DEBIAN/control
+  if [ "$BUILD_RET" = "0" ] && [ -f "bmsec_v$BMSEC_VERSION.deb" ]; then
+    BUILD_RET=0
+  else
+    BUILD_RET=1
+  fi
 else
-	echo "Unsatisfied build dependencies"
-	BUILD_RET=-1
+  echo "Unsatisfied build dependencies"
+  BUILD_RET=1
 fi
-cp *.deb output/
 
-# 统一接口：汇聚产物到 OUTPUT_DIR
+# 统一接口：汇聚产物到 OUTPUT_DIR（构建产物与输出目录合并，不重复拷贝）
 mkdir -p "$OUTPUT_DIR"
-cp *.deb "$OUTPUT_DIR/"
+if ls ./*.deb >/dev/null 2>&1; then
+  cp ./*.deb "$OUTPUT_DIR/"
+fi
 
 exit $BUILD_RET


### PR DESCRIPTION
## Summary
修复 pbmsec 子项目 code review（MYS-51）发现的 1🔴 + 3🟠 + 建议项：

- **🔴 socbak.zip 顺序依赖解除**：`release.sh` 改三级获取（psocbak output 产物 → 现场从 `../psocbak/socbak/` 打包 → 本地兜底），干净 checkout 不再因 socbak.zip 缺失失败；`docker/build-all.sh` 声明 `DEPENDS[pbmsec]=psocbak`，全量构建先 psocbak 后 pbmsec
- **🟠 文档/man 页写入错误目录**：`pushd doc` 内改用 `$SCRIPT_DIR` 绝对路径写入 deb 文档树，deb 包不再静默缺文档（3 个 HTML + man 页现正确进包）
- **🟠 postinst/preinst 安全性**：`control` 补 `Depends: tftpd-hpa`；`preinst` 升级前备份用户配置（排除 subNANInfo 运行时产物）再清理，`postinst` 恢复；`postinst` 对 `/etc/default/tftpd-hpa` 与服务加存在性守卫
- **🟡 建议项收敛**：`cd $SCRIPT_DIR` 消除 cwd 依赖；sed 版本注入改首处替换 + 失败检查 + 版本号转义；pandoc 参数加引号；`exit -1` 改 `exit 1`；OUTPUT_DIR 与本地 output 合并去冗余；build-all 构建后清理 pbmsec 中间产物

## Test plan
- [x] 干净 checkout 宿主导 `bash release.sh all` 通过（exit 0）
- [x] 干净 checkout 容器内 `bash docker/build-all.sh --project pbmsec` 通过（退出码 0）
- [x] deb 包含 3 个 HTML 文档 + man 页 + socbak.zip，`Depends: tftpd-hpa` 正确
- [x] 容器沙箱测试：升级备份/恢复用户配置、全新安装、subNANInfo 清理、tftpd 守卫均通过
- [x] 构建后 git 工作区干净（0 root 残留），build-all 清理 pbmsec 中间产物生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)