### PR TITLE
fix(psocbak): 修复 MYS-52 review 问题（cwd 依赖/PWD 字面量/历史文件清理）

### DIFF
--- a/source/psocbak/release.sh
+++ b/source/psocbak/release.sh
@@ -7,10 +7,9 @@
 set -uo pipefail
 
 BUILD_RET=0
-export CMD_7Z=$(command -v 7z)
-export CMD_ZIP=$(command -v zip)
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "$SCRIPT_DIR"   # 打包源/产物路径全部以本脚本目录为基准，消除对调用方 cwd 的依赖
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
 VERSION="${2:-$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$SCRIPT_DIR/socbak/socbak.sh" | head -1)}"
@@ -18,26 +17,59 @@ OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/psocbak}"
 
 echo "build socbak (arch=$ARCH version=$VERSION) ..."
 
-rm -rf socbak.zip 2>/dev/null
-rm -rf output 2>/dev/null
-mkdir output
+# 本地中间目录：打包源即 $SCRIPT_DIR/socbak（zip 条目以 socbak/ 为顶层，
+# 与现场 `unzip socbak.zip; cd socbak` 的用法一致）。
+rm -rf "$SCRIPT_DIR/socbak.zip" 2>/dev/null
+rm -rf "$SCRIPT_DIR/output" 2>/dev/null
+mkdir -p "$SCRIPT_DIR/output"
 
-if [ -f "$CMD_7Z" ]; then
+if command -v 7z >/dev/null 2>&1; then
 	echo "found 7z"
-	$CMD_7Z a -mx9 socbak.zip socbak
+	7z a -mx9 "$SCRIPT_DIR/socbak.zip" "$SCRIPT_DIR/socbak" >/dev/null
 	BUILD_RET=$?
-elif [ -f "$CMD_ZIP" ]; then
+elif command -v zip >/dev/null 2>&1; then
 	echo "found zip"
-	$CMD_ZIP -r -9 socbak.zip socbak
+	zip -r -9 "$SCRIPT_DIR/socbak.zip" socbak >/dev/null
 	BUILD_RET=$?
 else
 	echo "Unsatisfied build dependencies"
 	BUILD_RET=-1
 fi
-cp socbak.zip output/
+
+if [ "$BUILD_RET" = "0" ] && [ -s "$SCRIPT_DIR/socbak.zip" ]; then
+	# 校验 zip 非空且至少含 1 个条目，防止错误 cwd 下静默产出空包仍被拷贝
+	if command -v unzip >/dev/null 2>&1; then
+		if ZIP_LIST="$(unzip -Z1 "$SCRIPT_DIR/socbak.zip" 2>/dev/null)"; then
+			ZIP_ENTRIES=0
+			while IFS= read -r _entry; do ZIP_ENTRIES=$((ZIP_ENTRIES + 1)); done <<EOF
+$ZIP_LIST
+EOF
+			if [ "$ZIP_ENTRIES" -lt 1 ]; then
+				echo "ERROR: socbak.zip 为空（条目数 0），打包失败" >&2
+				BUILD_RET=1
+			else
+				echo "socbak.zip ok, entries=$ZIP_ENTRIES"
+			fi
+		else
+			echo "ERROR: socbak.zip 无法解析（unzip 失败），打包失败" >&2
+			BUILD_RET=1
+		fi
+	else
+		echo "socbak.zip ok (unzip 不可用，跳过条目校验)"
+	fi
+else
+	echo "ERROR: socbak.zip 缺失或为空，打包失败" >&2
+	BUILD_RET=1
+fi
+
+if [ "$BUILD_RET" = "0" ]; then
+	cp "$SCRIPT_DIR/socbak.zip" "$SCRIPT_DIR/output/"
+fi
 
 # 统一接口：汇聚产物到 OUTPUT_DIR
 mkdir -p "$OUTPUT_DIR"
-cp socbak.zip "$OUTPUT_DIR/"
+if [ "$BUILD_RET" = "0" ]; then
+	cp "$SCRIPT_DIR/socbak.zip" "$OUTPUT_DIR/"
+fi
 
 exit $BUILD_RET

--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -5,7 +5,7 @@
 # env SOC_BAK_FIXED_DATA_START!="" for socbak fixed data partition start mode
 
 # 配置日志能力
-PWD="$(dirname "$(readlink -f "\$0")")"
+PWD="$(dirname "$(readlink -f "$0")")"
 TGZ_FILES_PATH=${PWD}
 LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f $LOGFILE*
@@ -88,7 +88,7 @@ if [[ "${SOC_BAK_FIXED_DATA_START}" != "" ]]; then
 	echo "INFO: SOC_BAK_FIXED_DATA_START open, some ROOTFS_RW space will be automatically allocated to ROOTFS_RO"
 fi
 
-chmod +x ${TGZ_FILES_PATH}/binTools
+chmod -R +x ${TGZ_FILES_PATH}/binTools
 export PATH="${TGZ_FILES_PATH}/binTools":$PATH
 # find ./ -type f | grep -vE "md5.txt|\.log|output|sparse|\.bin|\.tgz|socbak.sh" | xargs md5sum > socbak_md5.txt
 pushd "${TGZ_FILES_PATH}"
@@ -107,8 +107,8 @@ if [[ "$SOC_BAK_ALL_IN_ONE" != "" ]]; then
 	echo "INFO: open all in one mode for ${ALL_IN_ONE_FLAG}"
 fi
 
-rm /home/*/.bash_history
-rm /root/.bash_history
+rm -f /home/*/.bash_history 2>/dev/null
+rm -f /root/.bash_history 2>/dev/null
 
 if type pigz >/dev/null 2>&1 ; then
 	PIGZ_GZIP_COM="pigz"


### PR DESCRIPTION
## Summary
修复 MYS-52 review 对 psocbak 子项目发现的问题（3 🟠 + 1 🟡，无 🔴）：

- 🟠 **release.sh cwd 依赖**：脚本内 `cd $SCRIPT_DIR`，打包源/产物/清理全部改为 `$SCRIPT_DIR` 绝对路径。任意 cwd（仓库根、/tmp）执行均正确出包；打包后校验 zip 非空且条目数≥1，错误 cwd 下 7z 产 22 字节空 zip 会被拦截，不再 cp 到 OUTPUT_DIR；7z/zip 检测改用 `command -v`。
- 🟠 **socbak.sh PWD 字面量**：`\$0` 转义改为 `$0`，`readlink -f "$0"` 运行时正确解析脚本真实路径，`/socrepack` 路径校验恢复有效；`chmod +x` 目录改 `chmod -R +x`。
- 🟡 **bash_history 清理**：`rm /home/*/.bash_history` 改 `rm -f ... 2>/dev/null`，谨慎处理用户历史文件。
- 🟡-3 7z 安装版为观察项，保持现状。

## Test plan
- [x] 任意 cwd（/tmp、仓库根、source/psocbak）执行 `bash release.sh arm64 1.2.1` 均出非空 zip（56 条目）
- [x] zip 回退路径（无 7z）与无压缩工具失败路径均验证
- [x] 统一镜像内 `build-all.sh --project psocbak` 通过
- [x] `socbak_md5.txt` 与打包文件全部校验通过
- [x] pbmsec 正常复用 psocbak 产物

🤖 Generated with [Claude Code](https://claude.com/claude-code)