### PR TITLE
fix(pmem_aging_test): 修复 MYS-54 review 问题（cwd 依赖/NULL 检查/注入面）

### DIFF
--- a/source/pmem_aging_test/memtest_a53_gdma/memtest_gdma/memtest_gdma.c
+++ b/source/pmem_aging_test/memtest_a53_gdma/memtest_gdma/memtest_gdma.c
@@ -83,6 +83,7 @@ static int parse_shape(const char* arg, unsigned long* shape) {
   int i = 0;
   token = strtok((char*)arg, delimiters);
   while (token != NULL) {
+    if (i >= 4) return -1;
     shape[i++] = strtol(token, &endptr, 10);
     token = strtok(NULL, delimiters);
     if (*endptr != '\0') return 0;
@@ -539,7 +540,7 @@ int main(int argc, char* argv[]) {
     exit(EXIT_FAILURE);
   }
   shape_size = get_shape_size(shape);
-  printf("[INFO] use shape info: [%ld, %ld, %ld, %ld], size: %lld B\r\n",
+  printf("[INFO] use shape info: [%ld, %ld, %ld, %ld], size: %llu B\r\n",
          shape[0], shape[1], shape[2], shape[3], shape_size);
   loop = strtol(argv[3], &endptr, 10);
   if (*endptr != '\0') {
@@ -607,28 +608,28 @@ int main(int argc, char* argv[]) {
   printf("[INFO] use gdma test num: %d\r\n", gdma_test_num);
   gdma_pid = malloc(sizeof(pthread_t) * gdma_test_num);
   if (gdma_pid == NULL) {
-    printf("[ERROR] malloc gdma_pid failed, size: %lld\r\n", shape_size);
+    printf("[ERROR] malloc gdma_pid failed, size: %llu\r\n", shape_size);
     return 1;
   }
   gdma_pid_args = malloc(sizeof(struct gdma_pid_arg_t) * gdma_test_num);
   if (gdma_pid_args == NULL) {
-    printf("[ERROR] malloc gdma_pid_args failed, size: %lld\r\n", shape_size);
+    printf("[ERROR] malloc gdma_pid_args failed, size: %llu\r\n", shape_size);
     return 1;
   }
   for (unsigned int i = 0; i < gdma_test_num; i++) {
     unsigned char* sys_buffer = malloc(shape_size);
     if (sys_buffer == NULL) {
-      printf("[ERROR] malloc sys_buffer failed, size: %lld\r\n", shape_size);
+      printf("[ERROR] malloc sys_buffer failed, size: %llu\r\n", shape_size);
       return 1;
     }
     unsigned char* cmp_buffer = malloc(shape_size);
-    if (sys_buffer == NULL) {
-      printf("[ERROR] malloc cmp_buffer failed, size: %lld\r\n", shape_size);
+    if (cmp_buffer == NULL) {
+      printf("[ERROR] malloc cmp_buffer failed, size: %llu\r\n", shape_size);
       return 1;
     }
     unsigned char* ran_buffer = malloc(shape_size);
-    if (sys_buffer == NULL) {
-      printf("[ERROR] malloc ran_buffer failed, size: %lld\r\n", shape_size);
+    if (ran_buffer == NULL) {
+      printf("[ERROR] malloc ran_buffer failed, size: %llu\r\n", shape_size);
       return 1;
     }
     rand_buffer(sys_buffer, shape_size);
@@ -655,7 +656,7 @@ int main(int argc, char* argv[]) {
     free(gdma_pid_args[i].buffer_cmp);
     free(gdma_pid_args[i].buffer_ran);
   }
-  for (unsigned int i = 1; i < bm_dev_mem_num; i++) {
+  for (unsigned int i = 0; i < bm_dev_mem_num; i++) {
     bm_free_device(bm_handle_all, bm_dev_mems[i]);
   }
   bm_dev_free(bm_handle_all);

--- a/source/pmem_aging_test/memtest_a53_gdma/start.sh
+++ b/source/pmem_aging_test/memtest_a53_gdma/start.sh
@@ -168,7 +168,7 @@ echo "MEMTEST VERSION: V1.4.1"
 
 # prepare memtest_gdma
 dir_path="$(dirname "$(readlink -f "$0")")"
-pushd $dir_path/memtest_gdma
+pushd "$dir_path/memtest_gdma"
 sudo bash build.sh || echo "[MEMTEST ERROR] build memtest gdma error"
 popd
 
@@ -184,9 +184,14 @@ sudo systemctl reset-failed memtest_s.service 2>/dev/null
 sudo rm -f /run/systemd/transient/memtest_s.service 2>/dev/null
 sudo systemctl daemon-reload
 
+# 用 printf %q 转义注入到 bash -c 命令串中的参数，防止引号/分号/$() 被二次解释
+q_pcie_dev_id="$(printf '%q' "${PCIE_DEV_ID:-}")"
+q_work_dir="$(printf '%q' "$dir_path")"
+q_inloop="$(printf '%q' "$inloop")"
+
 sudo systemd-run --unit=memtest_s bash -c \
 	"source /dev/stdin <<< \$(echo \"$fun_str\" | base64 -d | gzip -d -c -); export \
-PCIE_DEV_ID=${PCIE_DEV_ID}; memtest_s $dir_path $inloop;"
+PCIE_DEV_ID=${q_pcie_dev_id}; memtest_s ${q_work_dir} ${q_inloop};"
 sleep 3
 sudo systemctl status memtest_s.service --no-page -l
 if [[ "$(systemctl is-active memtest_s.service)" != "active" ]]; then

--- a/source/pmem_aging_test/release.sh
+++ b/source/pmem_aging_test/release.sh
@@ -4,42 +4,74 @@
 #   ARCH:    arm64（默认，设备侧现场编译）；amd64 仅打包
 #   VERSION: 显式版本号（默认从 memtest_a53_gdma/start.sh 提取 V1.4.1）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pmem_aging_test/）
+#
+# 注意：本包为源码包（memtest_a53_gdma/memtest_gdma 需在设备侧用 build.sh 现场编译，
+# memtester 为 aarch64 预编译二进制），ARCH 仅作标识、不参与构建。
 set -uo pipefail
 
 BUILD_RET=0
-export CMD_7Z=$(command -v 7z)
-export CMD_ZIP=$(command -v zip)
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-$(grep -r "MEMTEST VERSION:" "$SCRIPT_DIR/memtest_a53_gdma/start.sh" | awk '{print $(NF)}' | tr -d '"')}"
+VERSION="${2:-$(awk '/MEMTEST VERSION:/{print $NF}' "$SCRIPT_DIR/memtest_a53_gdma/start.sh" | tr -d '"')}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pmem_aging_test}"
 
 echo "build memtest_a53_gdma ${VERSION} (arch=$ARCH) ..."
 
-rm -rf output
-mkdir -p output
-cp -r memtest_a53_gdma output/mem_aging_test_${VERSION}
-cp *.md output
+# 源路径与中间产物一律基于 $SCRIPT_DIR，消除对调用方 cwd 的依赖
+rm -rf "$SCRIPT_DIR/output"
+mkdir -p "$SCRIPT_DIR/output"
+cp -r "$SCRIPT_DIR/memtest_a53_gdma" "$SCRIPT_DIR/output/mem_aging_test_${VERSION}"
+cp "$SCRIPT_DIR"/*.md "$SCRIPT_DIR/output/mem_aging_test_${VERSION}/"
 
-pushd output
-	if [ -f "$CMD_7Z" ]; then
+pushd "$SCRIPT_DIR/output" >/dev/null
+	# 打包前删除同版本旧 zip，避免 7z 对已存在 zip 走 .tmp 更新失败
+	rm -f "mem_aging_test_${VERSION}.zip"
+	if command -v 7z >/dev/null 2>&1; then
 		echo "found 7z"
-		$CMD_7Z a -mx9 mem_aging_test_${VERSION}.zip mem_aging_test_${VERSION}
+		7z a -y -mx9 "mem_aging_test_${VERSION}.zip" "mem_aging_test_${VERSION}" >/dev/null
 		BUILD_RET=$?
-	elif [ -f "$CMD_ZIP" ]; then
+	elif command -v zip >/dev/null 2>&1; then
 		echo "found zip"
-		$CMD_ZIP -r -9 mem_aging_test_${VERSION}.zip mem_aging_test_${VERSION}
+		zip -r -9 "mem_aging_test_${VERSION}.zip" "mem_aging_test_${VERSION}" >/dev/null
 		BUILD_RET=$?
 	else
 		echo "Unsatisfied build dependencies"
 		BUILD_RET=-1
 	fi
-popd
+popd >/dev/null
 
-# 统一接口：汇聚产物到 OUTPUT_DIR
+# 校验 zip 非空且至少含 8 个条目，防止错误 cwd/打包失败时静默产出空包仍被拷贝
+if [ "$BUILD_RET" = "0" ] && [ -s "$SCRIPT_DIR/output/mem_aging_test_${VERSION}.zip" ]; then
+	if command -v unzip >/dev/null 2>&1; then
+		if ZIP_LIST="$(unzip -Z1 "$SCRIPT_DIR/output/mem_aging_test_${VERSION}.zip" 2>/dev/null)"; then
+			ZIP_ENTRIES=0
+			while IFS= read -r _entry; do ZIP_ENTRIES=$((ZIP_ENTRIES + 1)); done <<EOF
+$ZIP_LIST
+EOF
+			if [ "$ZIP_ENTRIES" -lt 8 ]; then
+				echo "ERROR: mem_aging_test_${VERSION}.zip 条目数 $ZIP_ENTRIES < 8，打包失败" >&2
+				BUILD_RET=1
+			else
+				echo "mem_aging_test_${VERSION}.zip ok, entries=$ZIP_ENTRIES"
+			fi
+		else
+			echo "ERROR: mem_aging_test_${VERSION}.zip 无法解析（unzip 失败），打包失败" >&2
+			BUILD_RET=1
+		fi
+	else
+		echo "mem_aging_test_${VERSION}.zip ok (unzip 不可用，跳过条目校验)"
+	fi
+else
+	echo "ERROR: mem_aging_test_${VERSION}.zip 缺失或为空，打包失败" >&2
+	BUILD_RET=1
+fi
+
+# 统一接口：汇聚产物到 OUTPUT_DIR（校验通过才拷贝）
 mkdir -p "$OUTPUT_DIR"
-cp output/mem_aging_test_${VERSION}.zip "$OUTPUT_DIR/"
+if [ "$BUILD_RET" = "0" ]; then
+	cp "$SCRIPT_DIR/output/mem_aging_test_${VERSION}.zip" "$OUTPUT_DIR/"
+fi
 
 exit $BUILD_RET


### PR DESCRIPTION
## Summary

修复 pmem_aging_test 子项目代码 review（MYS-54）发现的问题（1 🟠 + 6 🟡，无 🔴）。

- **🟠 release.sh cwd 依赖**：打包源/中间产物/清理全部改为 `$SCRIPT_DIR` 绝对路径，任意 cwd（仓库根、/tmp、子项目目录）均正确出包；打包后校验 zip 条目数 ≥8 再拷贝到 OUTPUT_DIR，失败非零退出（消除错误 cwd 下静默产 22 字节空包 + exit 0 混入正式产物目录的问题）
- **🟠 cmp_buffer/ran_buffer malloc 失败检查错位**（memtest_gdma.c:625,630）：检查的是 `sys_buffer`，若这两个分配失败会带 NULL 指针继续运行 → 改为各自检查
- **🟡 设备内存释放漏 index 0**（memtest_gdma.c:658）：free 循环从 i=1 开始，`bm_dev_mems[0]` 泄漏 → 改为从 0 开始，长期压测不再累积泄漏
- **🟡 parse_shape 越界写**（memtest_gdma.c:79-91）：>4 个数字时写 `shape[4]` 栈越界 → 循环内 `if (i >= 4) return -1;`
- **🟡 start.sh systemd-run 命令注入面**（start.sh:187-189）：`PCIE_DEV_ID`/`dir_path`/`inloop` 直接拼进 `bash -c`，含引号/分号/`$()` 会被二次解释 → `printf '%q'` 转义；`pushd $dir_path/memtest_gdma` 未加引号 → 加引号
- **🟡 zip 不含 readme.md**（release.sh:24）：`cp *.md` 到 output 根但 7z 只打版本目录 → 改为 `cp "$SCRIPT_DIR"/*.md 版本目录/`
- **🟡 版本提取/ARCH 说明**：版本默认值从 start.sh 精确提取；明确注释「本包为源码包，memtest_gdma 需设备侧现场编译」；`%lld`→`%llu` 格式修正

## Test plan

- [x] `bash -n` 5 个脚本语法检查通过
- [x] release.sh 任意 cwd（仓库根、/tmp、子项目目录）出非空 zip（12 条目，19KiB），默认版本 V1.4.1 提取正确
- [x] 重复构建同版本不再失败（打包前删旧 zip）；OUTPUT_DIR 覆盖正常；cwd 无污染
- [x] zip 回退路径（无 7z）正常；无压缩工具失败路径非零退出（exit 1）
- [x] memtest_gdma.c 在 bm1684x 测试机（172.26.166.185）`USE_GDMA_WITH_CORE=0` 编译通过，`-Wall -Wextra` 无警告
- [x] start.sh 命令拼接 `%q` 转义验证：含 `; touch /tmp/pwn;` 的 PCIE_DEV_ID 经 bash -c 重解析后保持单参数，注入失效

🤖 Generated with [Claude Code](https://claude.com/claude-code)