### PR TITLE
fix(pbm_set_ip): 修复 MYS-58 review 问题（架构命名/upx 版本/源码树污染/auto 脚本发布）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,6 +32,7 @@ ARG RUST_VERSION
 ARG NODE_TARBALL_URL NODE_TARBALL_SHA256
 ARG PNPM_VERSION YARN_VERSION
 ARG MUSL_AARCH64_URL MUSL_AARCH64_SHA256 MUSL_X86_64_URL MUSL_X86_64_SHA256
+ARG UPX_TARBALL_URL UPX_TARBALL_SHA256
 ARG WITH_DFSS=0
 ARG WITH_QT_MINGW=0
 ARG WITH_SOPHUI=0
@@ -86,10 +87,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-dev \
         brotli zstd xz-utils bzip2 \
         libssl-dev libtool autoconf automake \
-        file binutils upx-ucl \
+        file binutils \
         qemu-user qemu-user-static binfmt-support \
         libfuse2 fuse ssh strace pandoc sudo \
     && rm -rf /var/lib/apt/lists/*
+
+# ---- upx(固定 4.x, 静态链接; 替代 ubuntu 仓库 upx-ucl 3.95) ----
+# upx 3.x 不支持压缩 static-pie(Rust musl 静态产物), 统一镜像内压缩会静默失败(MYS-58 O-2)。
+# 固定 4.2.4 静态二进制, 下载即校验 SHA256(versions.env 锁定)。
+ARG UPX_TARBALL_URL UPX_TARBALL_SHA256
+RUN curl -fsSL "${UPX_TARBALL_URL}" -o /tmp/upx.tar.xz \
+    && echo "${UPX_TARBALL_SHA256}  /tmp/upx.tar.xz" | sha256sum -c - \
+    && tar -C /usr/local/bin -xJf /tmp/upx.tar.xz --strip-components=1 --wildcards '*/upx' \
+    && rm /tmp/upx.tar.xz \
+    && upx --version | head -1
 
 # ---- Go(来自 Stage1, 已校验) ----
 COPY --from=downloader /opt/go /opt/go

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -173,6 +173,8 @@ docker build \
   --build-arg MUSL_AARCH64_SHA256="${MUSL_AARCH64_SHA256}" \
   --build-arg MUSL_X86_64_URL="${MUSL_X86_64_URL}" \
   --build-arg MUSL_X86_64_SHA256="${MUSL_X86_64_SHA256}" \
+  --build-arg UPX_TARBALL_URL="${UPX_TARBALL_URL}" \
+  --build-arg UPX_TARBALL_SHA256="${UPX_TARBALL_SHA256}" \
   "${EXTRA_ARGS[@]}" \
   -f "${DOCKER_DIR}/Dockerfile" \
   -t "${IMAGE_NAME}:${TAG}" \

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -63,7 +63,11 @@ DFSS_LOONGARCH64_ARCHIVE="loongarch64-cross-tools.tar.zst"
 # ---- 其他工具（打包 / 文档 / 验证）----
 QT_VERSION="5.15.2"              # Qt mingw 静态库版本（pqt windows exe 依赖，build-qt-mingw.sh 编译）
 PANDOC_VERSION="2.5"             # ubuntu:20.04 仓库版本
+# upx 固定 4.x（静态链接二进制，下载后校验 SHA256）：upx 3.x（ubuntu upx-ucl）不支持压缩
+# static-pie 产物，会让 pbm_set_ip 等 Rust 静态二进制在镜像内压缩静默失败（MYS-58 O-2）。
 UPX_VERSION="4.2.4"
+UPX_TARBALL_URL="https://github.com/upx/upx/releases/download/v${UPX_VERSION}/upx-${UPX_VERSION}-amd64_linux.tar.xz"
+UPX_TARBALL_SHA256="75cab4e57ab72fb4585ee45ff36388d280c7afd72aa03e8d4b9c3cbddb474193"
 
 # ---- pqt 系列（AppImage + windows exe）----
 # linux AppImage: 依赖宿主 glibc<=2.31 -> 新基座 ubuntu:20.04 已满足，无需独立镜像。

--- a/source/pbm_set_ip/bm_set_ip/build.rs
+++ b/source/pbm_set_ip/bm_set_ip/build.rs
@@ -3,18 +3,24 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    // 获取项目根目录路径
+    // 编译时版本优先取 env（由 release.sh 注入，见 MYS-58 S-2），
+    // 避免统一构建时改写仓库跟踪的 .git_version 文件而弄脏工作区。
+    println!("cargo:rerun-if-env-changed=BM_SET_IP_GIT_VERSION");
+    if let Ok(v) = env::var("BM_SET_IP_GIT_VERSION") {
+        if !v.trim().is_empty() {
+            println!("cargo:rustc-env=GIT_TAG_COMMIT={}", v.trim());
+            return;
+        }
+    }
+
+    // 回退：读取 .git_version 文件内容（直接 bash build.sh 时使用已提交的默认值）
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let git_version_path = Path::new(&manifest_dir).join(".git_version");
-
-    // 读取 .git_version 文件内容
     let git_version = fs::read_to_string(&git_version_path)
         .unwrap_or_else(|_| panic!("Failed to read {:?}", git_version_path))
         .trim()
         .to_string();
 
-    // 将内容设置为编译时环境变量
     println!("cargo:rustc-env=GIT_TAG_COMMIT={}", git_version);
-    // 可选：如果文件变化时重新运行 build.rs
     println!("cargo:rerun-if-changed={}", git_version_path.display());
 }

--- a/source/pbm_set_ip/bm_set_ip/build.sh
+++ b/source/pbm_set_ip/bm_set_ip/build.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+# 官方独立构建脚本（统一构建走 release.sh）。cd 到脚本目录，
+# 避免从仓库根运行 build.sh 时 `rm -rf target` 误删其他目录（MYS-58 S-3）。
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "$SCRIPT_DIR" || exit 1
+
 PATH=${PATH}:~/.cargo/bin/
 CROSS=$(which cross)
 
-rm -rf target
+rm -rf "$SCRIPT_DIR/target"
 cargo install cross cargo-bloat
 echo "$(git describe --tags --abbrev=0)-$(git rev-parse HEAD)-$(date -u "+%Y%m%d_%H%M%S")" > .git_version
 ${CROSS} build --target aarch64-unknown-linux-musl --release

--- a/source/pbm_set_ip/release.sh
+++ b/source/pbm_set_ip/release.sh
@@ -4,6 +4,7 @@
 #   ARCH:    arm64 | amd64 | all（默认 arm64，musl 全静态）
 #   VERSION: 显式版本号（默认从 git describe 生成 v<tag>-<sha>-<ts>）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbm_set_ip/）
+#   env BM_SET_IP_GIT_VERSION: 注入编译时版本（默认取 git describe，避免改写仓库跟踪文件）
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -26,11 +27,10 @@ VERSION="${2:-$(git -C "$SCRIPT_DIR" describe --tags --abbrev=0 2>/dev/null || e
 mkdir -p "$OUTPUT_DIR"
 echo "==> pbm_set_ip version=$VERSION"
 
-# 记录版本（对齐官方 build.sh 的 .git_version 行为）。
-# 注意: 该文件是仓库跟踪文件，仅在能取到真实 git 信息时更新，避免提交垃圾版本号。
-if git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-  echo "$VERSION" > "$CARGO_DIR/.git_version"
-fi
+# 编译时版本通过 env 注入，不改写仓库跟踪的 bm_set_ip/.git_version 文件——
+# 该文件是仓库跟踪文件，若在镜像内构建时改写会弄脏工作区（MYS-58 S-2）。
+# build.rs 优先读 BM_SET_IP_GIT_VERSION，空时回退到 .git_version 的已提交值。
+export BM_SET_IP_GIT_VERSION="$VERSION"
 
 for target in $TARGETS; do
   echo "==> cargo build --target $target --release"
@@ -41,12 +41,38 @@ for target in $TARGETS; do
     exit 1
   fi
   file "$local_bin" | head -1
-  arch_suffix="${target%%-*}"
+  # 架构命名统一用 M1 规范的 arm64/amd64 口径（aarch64→arm64、x86_64→amd64），
+  # 不要用 ${target%%-*} 直接截取（会得到 aarch64/x86_64，与全仓命名不一致）。
+  case "$target" in
+    aarch64-*) arch_suffix="arm64" ;;
+    x86_64-*)  arch_suffix="amd64" ;;
+    *) echo "ERROR: 未知 target '$target'，无法映射架构后缀" >&2; exit 1 ;;
+  esac
+  # upx 仅 4.x+ 支持压缩 static-pie 产物（arm64 musl 静态 / amd64 static-pie）。
+  # 旧版 upx 3.x（如 ubuntu 仓库 upx-ucl 3.95）对 static-pie 直接报 not supported，
+  # 若静默吞掉会导致同一脚本在不同环境产物体积漂移（MYS-58 O-2）。
   if command -v upx >/dev/null 2>&1; then
-    upx -9 --best --nrv2b --no-color "$local_bin" >/dev/null 2>&1 || true
+    upx_major="$(upx --version 2>/dev/null | head -1 | awk '{print $2}' | cut -d. -f1)"
+    if [ -n "$upx_major" ] && [ "$upx_major" -ge 4 ] 2>/dev/null; then
+      echo "==> upx $upx_major.x 压缩 $local_bin"
+      if ! upx -9 --best --nrv2b --no-color "$local_bin" >/dev/null 2>&1; then
+        echo "WARN: upx 压缩 $local_bin 失败（产物未压缩，功能不受影响）" >&2
+      fi
+    else
+      echo "WARN: upx 版本过旧（$(upx --version 2>/dev/null | head -1)），不支持压缩 static-pie 产物，跳过压缩（若要压缩请用 upx 4.x+）" >&2
+    fi
+  else
+    echo "WARN: 未找到 upx，跳过压缩" >&2
   fi
   cp "$local_bin" "$OUTPUT_DIR/bm_set_ip_${arch_suffix}_musl"
 done
+
+# bm_set_ip_auto 是配网自动脚本（bm_set_ip eth0 dhcp 包装），被其他子项目引用安装到
+# /usr/sbin/bm_set_ip_auto，随产物一起发布（MYS-58 S-4）。
+if [ -f "$CARGO_DIR/bm_set_ip_auto" ]; then
+  cp "$CARGO_DIR/bm_set_ip_auto" "$OUTPUT_DIR/bm_set_ip_auto"
+  chmod +x "$OUTPUT_DIR/bm_set_ip_auto"
+fi
 
 echo "==> pbm_set_ip 完成, 产物: $OUTPUT_DIR"
 ls -la "$OUTPUT_DIR"


### PR DESCRIPTION
## Summary

修复 MYS-58 review 发现的 pbm_set_ip 子项目问题（2 🟠 + 3 🟡，无 🔴）：

- **O-1 架构命名映射**：`release.sh` 用 `case` 显式映射 `aarch64→arm64`、`x86_64→amd64`，产物命名统一为 M1 规范口径 `bm_set_ip_arm64_musl` / `bm_set_ip_amd64_musl`（原 `${target%%-*}` 产出 `aarch64`/`x86_64` 后缀）
- **O-2 upx 版本漂移**：`release.sh` 按主版本号门控（4.x+ 才压缩 static-pie，旧版明确 WARN 跳过而非静默失败）；统一镜像固定 upx 4.2.4（下载静态二进制 + SHA256 校验，替代 ubuntu 仓库 upx-ucl 3.95），`versions.env`/`build.sh` 接线
- **S-2 源码树污染**：编译时版本改由 `BM_SET_IP_GIT_VERSION` env 注入（`build.rs` 优先读 env，回退已提交文件），不再在统一构建中改写仓库跟踪的 `.git_version`
- **S-3 路径安全**：`build.sh` cd 到脚本目录 + `rm -rf` 带路径前缀，防从仓库根运行误删
- **S-4 发布闭环**：`bm_set_ip_auto` 随产物复制到 `output/pbm_set_ip/`

## Test plan

- [x] `arm64`/`amd64`/`all` 三种 ARCH 实测出包成功，产物命名符合 M1 口径
- [x] upx 4.2.4 压缩 static-pie 成功（729KB→337KB）且压缩后可运行
- [x] `cargo test` 79 例全过
- [x] 构建后 git 工作区无 `.git_version` 改动
- [x] 修改脚本 `bash -n` 语法检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)