### PR TITLE
fix(pdfss_cpp): 修复 MYS-59 review 问题（参数/dfss 窗口映射/NULL 句柄/命令注入）

### DIFF
--- a/source/pdfss_cpp/dfss_pip/dfss/__main__.py
+++ b/source/pdfss_cpp/dfss_pip/dfss/__main__.py
@@ -14,12 +14,12 @@ def get_architecture():
         if system == 'linux':
             return 'linux-amd64'
         elif system == 'windows':
-            return 'win-i686.exe'
+            return 'win-amd64.exe'
     if arch == 'amd64':
         if system == 'linux':
             return 'linux-amd64'
         elif system == 'windows':
-            return 'win-i686.exe'
+            return 'win-amd64.exe'
     elif arch == 'i686' or arch == 'x86':
         if system == 'windows':
             return 'win-i686.exe'

--- a/source/pdfss_cpp/libs/build_libs.sh
+++ b/source/pdfss_cpp/libs/build_libs.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 unset build_shell
 build_shell="$(dirname "$(readlink -f "$0")")"
 
@@ -39,7 +41,7 @@ if [[ "$1" == "host" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=gcc ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -71,7 +73,7 @@ elif [[ "$1" == "aarch64" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -99,7 +101,7 @@ elif [[ "$1" == "aarch64" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --disable-examples-build --disable-sshd-tests --disable-docker-tests --host=aarch64-linux-gnu --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -119,7 +121,7 @@ elif [[ "$1" == "mingw64" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -147,7 +149,7 @@ elif [[ "$1" == "mingw64" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=x86_64-pc-mingw64 --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -168,7 +170,7 @@ elif [[ "$1" == "mingw" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -196,7 +198,7 @@ elif [[ "$1" == "mingw" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=i686-pc-mingw32 --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -217,7 +219,7 @@ elif [[ "$1" == "loongarch64" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -245,7 +247,7 @@ elif [[ "$1" == "loongarch64" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=loongarch64-pc-linux --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -266,7 +268,7 @@ elif [[ "$1" == "riscv64" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -294,7 +296,7 @@ elif [[ "$1" == "riscv64" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=riscv64-pc-linux --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -315,7 +317,7 @@ elif [[ "$1" == "armbi" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -339,7 +341,7 @@ elif [[ "$1" == "armbi" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=arm-pc-linux --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC
@@ -361,7 +363,7 @@ elif [[ "$1" == "sw_64" ]]; then
 
 	## zlib static
 	pushd "${build_shell}/zlib"
-	CC=${CROSS_COMPILE}gcc ./configure --prefix="${build_target}" --static
+	CC=${CROSS_COMPILE}gcc CFLAGS="-O3 -fPIC" ./configure --prefix="${build_target}" --static
 	make clean
 	make -j$(nproc)
 	make install -j$(nproc)
@@ -389,7 +391,7 @@ elif [[ "$1" == "sw_64" ]]; then
 
 	## libssh2 static
 	pushd "${build_shell}/libssh2"
-	make clean
+	make clean 2>/dev/null || true
 
 	./configure --host=alpha-pc-linux --disable-examples-build --disable-sshd-tests --disable-docker-tests --with-sysroot="${build_target}" --enable-static=yes --enable-shared=no --with-libmbedcrypto-prefix="${build_target}" --prefix="${build_target}" --with-crypto=mbedtls --with-libz --with-libz-prefix="${build_target}"
 	unset CC

--- a/source/pdfss_cpp/linux_release.sh
+++ b/source/pdfss_cpp/linux_release.sh
@@ -9,7 +9,7 @@ if [[ "$2" == "lib" ]]; then
 fi
 
 NEED_DEBUG=0
-if [[ "$3" == "debug" ]]; then
+if [[ "${3:-}" == "debug" ]]; then
 	NEED_DEBUG=1
 fi
 

--- a/source/pdfss_cpp/src/main.cpp
+++ b/source/pdfss_cpp/src/main.cpp
@@ -555,7 +555,6 @@ int64_t sftp_get_file(struct ServerInfo* server, string path,
       libssh2_sftp_open(sftp_session, path.c_str(), LIBSSH2_FXF_READ, 0);
   if (!sftp_handle) {
     log_error("Unable to open file with SFTP");
-    libssh2_sftp_close(sftp_handle);
     libssh2_sftp_shutdown(sftp_session);
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
@@ -784,8 +783,7 @@ int64_t sftp_put_file(struct ServerInfo* server, string local_path,
       LIBSSH2_SFTP_S_IRUSR | LIBSSH2_SFTP_S_IWUSR | LIBSSH2_SFTP_S_IRGRP |
           LIBSSH2_SFTP_S_IROTH);
   if (!sftp_handle) {
-    log_error("Unable to open file with SFTP: %s", remote_path);
-    libssh2_sftp_close(sftp_handle);
+    log_error("Unable to open file with SFTP: %s", remote_path.c_str());
     libssh2_sftp_shutdown(sftp_session);
     libssh2_session_disconnect(session, "Normal Shutdown");
     libssh2_session_free(session);
@@ -1072,7 +1070,22 @@ bool starts_with(const std::string& str, const std::string& prefix) {
          str.compare(0, prefix.size(), prefix) == 0;
 }
 
+// 用户名会被拼进 system() 的 sftp 命令，限制为安全字符集，避免 shell 注入。
+bool is_safe_username(const std::string& username) {
+  for (char c : username) {
+    if (!(isalnum(static_cast<unsigned char>(c)) || c == '_' || c == '.' ||
+          c == '-')) {
+      return false;
+    }
+  }
+  return !username.empty();
+}
+
 void sftp_login(string username) {
+  if (!is_safe_username(username)) {
+    log_error("invalid username: %s", username.c_str());
+    return;
+  }
   struct ServerInfo* login_info;
   if (starts_with(username, "sophgo") || starts_with(username, "h_s")) {
     log_info("%s sftp login hdk server", username.c_str());
@@ -1214,8 +1227,10 @@ bool sftp_upfile(std::string upflag, std::string upfile) {
     return false;
   }
   ServerInfo upload_server = *server;  // 使用副本，不修改全局服务器列表
-  upload_server.user = "customerUploadAccount";
-  upload_server.pass = "1QQHJONFflnI2BLsxUvA";
+  const char* upload_user = getenv("DFSS_UPLOAD_USER");
+  const char* upload_pass = getenv("DFSS_UPLOAD_PASS");
+  upload_server.user = upload_user ? upload_user : "customerUploadAccount";
+  upload_server.pass = upload_pass ? upload_pass : "1QQHJONFflnI2BLsxUvA";
   if (sftp_put_file(&upload_server, upfile, base64_decode(upflag)) > 0) return true;
   return false;
 }


### PR DESCRIPTION
## Summary
- 🟠 O-1 `linux_release.sh` debug 参数 `$3` → `${3:-}` 防御性展开，语义与 readme「第二参数是 lib」对齐
- 🟠 O-2 `build_libs.sh` zlib 交叉编译：host 显式 `CC=gcc`；交叉分支补 `CFLAGS=-fPIC`、去 aarch64 重复 `CC=` 赋值
- 🟠 O-3 `main.cpp` 对 NULL `sftp_handle` 不再调用 `libssh2_sftp_close`（UB），open 失败直接 shutdown/free
- 🟠 O-4 `dfss_pip` Windows x86_64 映射：返回 `win-amd64.exe`（原错返 `win-i686.exe`）
- 🟡 命令注入：`sftp_login` 校验用户名仅含 `[A-Za-z0-9_.-]`
- 🟡 硬编码上传凭据：改读 `DFSS_UPLOAD_USER/DFSS_UPLOAD_PASS` 环境变量，回退原值
- 🟡 `build_libs.sh` 加 `set -e`（configure/make 失败即终止），预 configure 的 `make clean` 容忍无 Makefile
- 附带修复 clang `-Wnon-pod-varargs`：`log_error` 传 `std::string` → `.c_str()`

## Test plan
- [x] 8 架构（host/aarch64/armbi/loongarch64/riscv64/sw_64/mingw64/mingw）统一镜像内全量编译通过
- [x] amd64 产物可运行（`--help` 正常）
- [x] `--user` 注入测试被拦截（无命令执行）
- [x] `dfss_pip` win-amd64.exe 映射与产物名匹配

🤖 Generated with [Claude Code](https://claude.com/claude-code)