### PR TITLE
fix(pqt_batch_deployment): 修复 MYS-60 review 问题

### DIFF
--- a/docker/pqt/build-pqt.sh
+++ b/docker/pqt/build-pqt.sh
@@ -36,6 +36,8 @@ fi
 PROJECT="pqt_memory_edit"
 MODE=""  # linux / windows / all
 INPLACE="${PQT_INPLACE:-0}"
+VERSION=""       # 显式版本号（透传给 linux_release.sh / CMake）
+OUTPUT_DIR=""    # 产物目录（透传给 linux_release.sh 作为工作目录）
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -44,6 +46,8 @@ while [[ $# -gt 0 ]]; do
     --windows) MODE="windows" ;;
     --all) MODE="all" ;;
     --inplace) INPLACE=1 ;;
+    --version) VERSION="$2"; shift 2; continue ;;
+    --output) OUTPUT_DIR="$2"; shift 2; continue ;;
     --image) PQT_IMAGE="$2"; shift 2; continue ;;
     -h|--help)
       grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -35
@@ -104,9 +108,12 @@ setup_mingw_headers() {
 # ---- linux 端: AppImage ----
 build_linux() {
   prepare_memory_edit_tarxz
+  # linux_release.sh 工作目录：产物与中间文件只写这里，不污染源码树
+  local work="${OUTPUT_DIR:-${SRC_DIR}/.build}"
+  mkdir -p "${work}"
   if [[ "${INPLACE}" = "1" ]]; then
     echo "==> (inplace) 构建 ${PROJECT} linux AppImage ..."
-    (cd "${SRC_DIR}" && bash linux_release.sh)
+    (cd "${SRC_DIR}" && bash linux_release.sh "${work}" "${VERSION}")
     echo "==> linux AppImage 完成"
     return 0
   fi
@@ -123,10 +130,11 @@ build_linux() {
   docker run --rm --privileged \
     -v /dev:/dev \
     -v "${SRC_DIR}":/root/workspace \
+    -v "${work}":/pqt-output \
     -w /root/workspace \
     "${PQT_IMAGE}" /bin/bash -c "
       git config --global --add safe.directory /root/workspace
-      bash linux_release.sh
+      bash linux_release.sh /pqt-output ${VERSION}
     " 2>&1 | tail -20
   echo "==> linux AppImage 完成"
 }
@@ -153,9 +161,10 @@ build_windows() {
     # 直接在统一镜像内执行(工具链已内置, 当前 shell 内函数可直接使用)
     setup_mingw_posix
     setup_mingw_headers
-    cd "${SRC_DIR}"
-    rm -rf build-win
-    mkdir build-win && cd build-win
+    # out-of-source: 构建目录放 OUTPUT_DIR（未传则退回源码树 build-win），不污染源码树
+    local wdir="${OUTPUT_DIR:-${SRC_DIR}/build-win}"
+    mkdir -p "${wdir}"
+    cd "${wdir}"
     export QT_PLATFORM_DIR="${qt_prefix}"
     export QT_GCC_PLATFORM_DIR=/opt/mingw-posix/bin
     cat > /tmp/tc.cmake <<TOOL
@@ -168,20 +177,27 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 TOOL
-    cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
-      "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc"
+    cmake "${SRC_DIR}" -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
+      "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc" \
+      ${VERSION:+-DMY_PROJECT_VERSION=${VERSION}}
     make -j"$(nproc)"
+    # windeployqt/openssl 拷贝/静态改名打包步骤挂在 install() 上，必须 make install 才能产出自包含 exe
+    make install
     echo "==> windows exe 产物:"
-    ls -la qt_mem_edit*.exe 2>/dev/null || ls -la *.exe
+    find . -maxdepth 3 -name '*.exe' | head -5
     return 0
   fi
 
-  # 宿主模式: 在 sophon-tools-build 镜像内交叉编译
+  # 宿主模式: 在 sophon-tools-build 镜像内交叉编译（out-of-source: 构建目录为 OUTPUT_DIR）
   local image="${IMAGE:-sophon-tools-build:unified}"
+  local wdir="${OUTPUT_DIR:-${SRC_DIR}/build-win}"
+  mkdir -p "${wdir}"
   docker run --rm \
     -v "${SRC_DIR}":/workspace/src \
+    -v "${wdir}":/pqt-win-output \
     -v "${qt_prefix}":/opt/qt-mingw \
-    -w /workspace/src \
+    -e PQT_WIN_OUT="/pqt-win-output" \
+    -e PQT_VERSION="${VERSION}" \
     "${image}" bash -c '
       set -e
       export DEBIAN_FRONTEND=noninteractive
@@ -211,16 +227,17 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 TOOL
-      cd /workspace/src
-      rm -rf build-win
-      mkdir build-win && cd build-win
       export QT_PLATFORM_DIR=/opt/qt-mingw
       export QT_GCC_PLATFORM_DIR=/opt/mingw-posix/bin
-      cmake .. -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
-        "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc"
+      mkdir -p "${PQT_WIN_OUT}" && cd "${PQT_WIN_OUT}"
+      cmake /workspace/src -DCMAKE_TOOLCHAIN_FILE=/tmp/tc.cmake -DCMAKE_BUILD_TYPE=Release \
+        "-DCMAKE_CXX_FLAGS=-I/tmp/mingw-inc" "-DCMAKE_C_FLAGS=-I/tmp/mingw-inc" \
+        ${PQT_VERSION:+-DMY_PROJECT_VERSION=${PQT_VERSION}}
       make -j$(nproc)
+      # windeployqt/openssl 拷贝/静态改名打包步骤挂在 install() 上，必须 make install 才能产出自包含 exe
+      make install
       echo "==> windows exe 产物:"
-      ls -la qt_mem_edit*.exe 2>/dev/null || ls -la *.exe
+      find . -maxdepth 3 -name '*.exe' | head -5
     '
 }
 

--- a/source/pqt_batch_deployment/CMakeLists.txt
+++ b/source/pqt_batch_deployment/CMakeLists.txt
@@ -26,7 +26,9 @@ endif(CMAKE_SYSTEM_NAME MATCHES "Windows")
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
-set(MY_PROJECT_VERSION "V1.4.1")
+if(NOT DEFINED MY_PROJECT_VERSION)
+  set(MY_PROJECT_VERSION "V1.4.1")
+endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/version.h.in"
   "${CMAKE_BINARY_DIR}/version.h"

--- a/source/pqt_batch_deployment/linux_release.sh
+++ b/source/pqt_batch_deployment/linux_release.sh
@@ -1,90 +1,98 @@
 #!/bin/bash
+# pqt_batch_deployment linux AppImage 构建（M3 统一构建）
+# 用法: bash linux_release.sh [WORK_DIR] [VERSION]
+#   WORK_DIR: 构建工作目录（中间产物 + AppImage 只写这里，默认 $PWD/.build）
+#   VERSION:  显式版本号（默认从 CMakeLists MY_PROJECT_VERSION 解析）
+# out-of-source 构建：源码目录零改动，产物与中间文件全部落在 WORK_DIR。
+set -euo pipefail
+
 get_arch=$(arch)
 host_inf=""
-if [[ $get_arch =~ "x86_64" ]];then
+if [[ $get_arch =~ "x86_64" ]]; then
     echo "this is x86_64"
     host_inf="linux_amd64"
-elif [[ $get_arch =~ "aarch64" ]];then
+elif [[ $get_arch =~ "aarch64" ]]; then
     echo "this is arm64"
     host_inf="linux_arm64"
-elif [[ $get_arch =~ "mips64" ]];then
-    echo "this is mips64"
-    host_inf=""
 else
-    echo "unknown!!"
+    echo "unknown arch: $get_arch" >&2
+    exit 1
 fi
-line=$(grep -E '^set\(MY_PROJECT_VERSION "[^"]+"\)' CMakeLists.txt)
-version=$(echo "$line" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')
-echo "need build version: ${version}"
-source_path=$(pwd)
-rm output -rf
-mkdir output
-mkdir -p output/build
+
+SOURCE_ROOT="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+WORK_DIR="${1:-$SOURCE_ROOT/.build}"
+VERSION="${2:-$(grep -E 'set\(MY_PROJECT_VERSION "[^"]+"\)' "$SOURCE_ROOT/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+if [ -z "$VERSION" ]; then
+    echo "ERROR: 无法从 CMakeLists.txt 解析版本号，请显式传入 VERSION" >&2
+    exit 1
+fi
+echo "need build version: ${VERSION}"
+
+# WORK_DIR 可能是 docker 挂载点，不能 rm 目录本身，只清空内容
+rm -rf "$WORK_DIR"/* "$WORK_DIR"/.[!.]* 2>/dev/null || true
+mkdir -p "$WORK_DIR"
+
+# 并行构建 no_ui 与 GUI（out-of-source：build 目录在 WORK_DIR 下，产物收拢到 WORK_DIR/build/<名>）
 function updateFun(){
-    pushd "$2"
+    local name="$1" src="$2"
     echo "========================================"
-    echo "need build $1"
-    pwd
-    rm build -rf
-    mkdir build
-    echo "need build version: ${version}"
-    pushd build
-    cmake .. -DMY_PROJECT_VERSION=${version} -DCMAKE_BUILD_TYPE=Release
-    make -j4
-    if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-    make install
-    if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-    cp ./output/* "$source_path/output/build/$1" -a
-    if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-    popd # build
-    popd # $2
+    echo "need build $name"
+    local bdir="$WORK_DIR/$name"
+    mkdir -p "$bdir"
+    (cd "$src" && cmake -B "$bdir" -DMY_PROJECT_VERSION="${VERSION}" -DCMAKE_BUILD_TYPE=Release)
+    cmake --build "$bdir" -j"$(nproc)"
+    cmake --install "$bdir"
+    mkdir -p "$WORK_DIR/build/$name"
+    cp -a "$bdir/output/"* "$WORK_DIR/build/$name/"
 }
 updateFun qt_batch_deployment_no_ui "no_ui" &
-updateFun qt_batch_deployment "./" &
+updateFun qt_batch_deployment "." &
 wait
-if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-pushd output
-pushd build
-cp "${source_path}/libs/Appdir" ./ -a
-cp ${source_path}/libs/$host_inf/openssl/lib/*.so.* Appdir/usr/lib
-cp ${source_path}/libs/$host_inf/release/lib/*.so.* Appdir/usr/lib
-find ./ -maxdepth 1 -type f -exec cp {} Appdir/usr/bin \;
-sed -i "s/Name=qt_batch_deployment/Name=qt_batch_deployment_${version}/" Appdir/qt_batch_deployment.desktop
+
+pushd "$WORK_DIR/build" >/dev/null
+cp "${SOURCE_ROOT}/libs/Appdir" ./ -a
+cp ${SOURCE_ROOT}/libs/$host_inf/openssl/lib/*.so.* Appdir/usr/lib
+cp ${SOURCE_ROOT}/libs/$host_inf/release/lib/*.so.* Appdir/usr/lib
+# no_ui 的 CMake 产物名为 no_ui，需改名；run.sh 按 qt_batch_deployment[_no_ui] 分发
+cp qt_batch_deployment/qt_batch_deployment Appdir/usr/bin/qt_batch_deployment
+cp qt_batch_deployment_no_ui/no_ui Appdir/usr/bin/qt_batch_deployment_no_ui
+sed -i "s/Name=qt_batch_deployment/Name=qt_batch_deployment_${VERSION}/" Appdir/qt_batch_deployment.desktop
 mkdir bintools
-pushd bintools
-cp "${source_path}/libs/$host_inf/appimagetool" ./
-chmod +x appimagetool
-cp "${source_path}/libs/linuxdeployqt.tar.gz" ./
-tar -xaf linuxdeployqt.tar.gz 
-pushd linuxdeployqt-continuous
+cp "${SOURCE_ROOT}/libs/$host_inf/appimagetool" bintools/
+chmod +x bintools/appimagetool
+cp "${SOURCE_ROOT}/libs/linuxdeployqt.tar.gz" bintools/
+tar -xaf bintools/linuxdeployqt.tar.gz -C bintools
+pushd bintools/linuxdeployqt-continuous >/dev/null
 qmake -config release
-make -j4
-if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-popd # linuxdeployqt-continuous
-popd # bintools
-./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment_no_ui.desktop -appimage -verbose=2
-./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment.desktop -appimage -verbose=2
+make -j"$(nproc)"
+popd >/dev/null # linuxdeployqt-continuous
+# linuxdeployqt -appimage 会调用 PATH 里的 appimagetool；容器内可能缺失，失败时容忍
+# （打包由下方手动 appimagetool 完成，与原脚本行为一致）
+export PATH="$WORK_DIR/build/bintools:$PATH"
+./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment_no_ui.desktop -appimage -verbose=2 || true
+./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment.desktop -appimage -verbose=2 || true
 sed -i "s/Exec=qt_batch_deployment/Exec=qt_batch_deployment_run.sh/" Appdir/qt_batch_deployment.desktop
 rm Appdir/qt_batch_deployment_no_ui.desktop
 rm Appdir/qt_batch_deployment_no_ui.png
-pushd Appdir
+pushd Appdir >/dev/null
 rm AppRun
 ln -s usr/bin/qt_batch_deployment_run.sh ./AppRun
-popd # Appdir
+popd >/dev/null # Appdir
 ./bintools/appimagetool --comp xz Appdir
-if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; return 1; fi
-cp ./*.AppImage "${source_path}/output"
-if [ $? -ne 0 ]; then echo "command "${FUNCNAME[1]}" "${BASH_SOURCE[1]}" "$LINENO" error"; exit 1; fi
-popd # build
-popd # output
-file_path=$(find "${source_path}/output" -maxdepth 1 -name "qt_batch_deployment*.AppImage" -print -quit)
+cp ./*.AppImage "${WORK_DIR}"/
+popd >/dev/null # build
+
+file_path=$(find "${WORK_DIR}" -maxdepth 1 -name "qt_batch_deployment*.AppImage" ! -name "*no_ui*" -print -quit)
+if [ -z "$file_path" ]; then
+    echo "ERROR: 未生成 AppImage" >&2
+    exit 1
+fi
 file_size=$(stat -c %s "$file_path")
 file_size_kb=$((file_size / 1024))
 if [ $file_size_kb -gt $(( 23 * 1024 )) ]; then
     echo "AppImage size ${file_size_kb}KiB ok"
     exit 0
 else
-    echo "AppImage size ${file_size_kb}KiB error"
+    echo "AppImage size ${file_size_kb}KiB error" >&2
     exit 1
-fi 
+fi

--- a/source/pqt_batch_deployment/no_ui/CMakeLists.txt
+++ b/source/pqt_batch_deployment/no_ui/CMakeLists.txt
@@ -27,7 +27,9 @@ if(CMAKE_SYSTEM_NAME MATCHES "Windows")
 endif(CMAKE_SYSTEM_NAME MATCHES "Windows")
 find_package(Qt5Core)
 
-set(MY_PROJECT_VERSION "V1.4.0")
+if(NOT DEFINED MY_PROJECT_VERSION)
+  set(MY_PROJECT_VERSION "V1.4.0")
+endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/../version.h.in"
   "${CMAKE_BINARY_DIR}/version.h"

--- a/source/pqt_batch_deployment/release.sh
+++ b/source/pqt_batch_deployment/release.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # pqt_batch_deployment 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION]
-#   ARCH:    amd64 | arm64 | all（默认 amd64；对应 linux AppImage 宿主架构）
+#   ARCH:    amd64 | arm64 | linux（默认 amd64；linux AppImage 为宿主架构，见下）
 #            windows=Windows exe 交叉编译
 #   VERSION: 显式版本号（默认从 CMakeLists MY_PROJECT_VERSION 解析）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pqt_batch_deployment/）
 # 说明: linux AppImage 走 docker/pqt 镜像（glibc≤2.31），windows exe 走 sophon-tools-build mingw。
+#       AppImage 的 linuxdeployqt/appimagetool 为宿主架构预编译二进制，无法交叉：
+#       ARCH=amd64 要求构建宿主为 x86_64，ARCH=arm64 要求宿主为 aarch64，否则报错退出。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -13,42 +15,68 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-amd64}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pqt_batch_deployment}"
 
-VERSION="${2:-$(grep -E '^set\(MY_PROJECT_VERSION "[^"]+"\)' "$SCRIPT_DIR/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+VERSION="${2:-$(grep -E 'set\(MY_PROJECT_VERSION "[^"]+"\)' "$SCRIPT_DIR/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: 无法从 CMakeLists.txt 解析版本号，请显式传入 VERSION" >&2
+  exit 1
+fi
 echo "==> pqt_batch_deployment version=$VERSION arch=$ARCH"
 
 mkdir -p "$OUTPUT_DIR"
 
+# ARCH 必须真实影响构建：AppImage 工具链绑定宿主架构，无法交叉。
+# amd64/arm64 分别要求 x86_64/aarch64 宿主；linux 按宿主自动选择。
 build_linux() {
-  echo "==> 构建 linux AppImage ..."
-  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_batch_deployment --linux
-  local app="$(find "$SCRIPT_DIR" -maxdepth 1 -name 'qt_batch_deployment_*.AppImage' | head -1)"
-  if [ -z "$app" ]; then app="$(find "$SCRIPT_DIR/output" -name '*.AppImage' 2>/dev/null | head -1)"; fi
+  local want_arch="$1"
+  local host_arch
+  host_arch="$(arch 2>/dev/null || uname -m)"
+  case "$want_arch" in
+    amd64)
+      if [[ "$host_arch" != "x86_64" ]]; then
+        echo "ERROR: ARCH=amd64 需要 x86_64 构建宿主（当前 $host_arch），AppImage 工具链无法交叉" >&2
+        exit 1
+      fi
+      ;;
+    arm64)
+      if [[ "$host_arch" != "aarch64" ]]; then
+        echo "ERROR: ARCH=arm64 需要 aarch64 构建宿主（当前 $host_arch），AppImage 工具链无法交叉" >&2
+        exit 1
+      fi
+      ;;
+    linux) : ;;  # 宿主自动
+  esac
+  echo "==> 构建 linux AppImage (arch=$want_arch) ..."
+  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_batch_deployment --linux --version "$VERSION" --output "$OUTPUT_DIR"
+  # 精确定位 GUI 版 AppImage（排除 no_ui；产物名形如 qt_batch_deployment-x86_64.AppImage）
+  local app="$(find "$OUTPUT_DIR" -maxdepth 1 -name 'qt_batch_deployment*.AppImage' ! -name '*no_ui*' | head -1)"
+  if [ -z "$app" ]; then app="$(find "$OUTPUT_DIR" -maxdepth 1 -name '*.AppImage' ! -name '*no_ui*' | head -1)"; fi
   if [ -z "$app" ]; then echo "ERROR: 未找到 AppImage 产物" >&2; exit 1; fi
-  cp "$app" "$OUTPUT_DIR/"
+  # linux_release.sh 已把 AppImage 生成到 OUTPUT_DIR（WORK_DIR），已在则不再重复拷贝
+  local appname
+  appname="$(basename "$app")"
+  if [ ! -f "$OUTPUT_DIR/$appname" ]; then cp "$app" "$OUTPUT_DIR/"; fi
   file "$app" | head -1
 }
 
 build_windows() {
   echo "==> windows exe 交叉编译 ..."
-  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_batch_deployment --windows || {
-    echo "WARN: pqt_batch_deployment windows 构建未完成（Qt mingw 依赖），本次跳过" >&2
-    return 0
-  }
+  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_batch_deployment --windows --version "$VERSION" --output "$OUTPUT_DIR"
   local exe
-  exe="$(find "$SCRIPT_DIR" -maxdepth 2 -name 'qt_batch_deployment.exe' 2>/dev/null | head -1)"
-  exe="${exe:-$(find "$SCRIPT_DIR" -maxdepth 2 -name '*.exe' 2>/dev/null | grep -v 'libs/' | head -1)}"
+  exe="$(find "$OUTPUT_DIR" "$SCRIPT_DIR" -maxdepth 3 -name 'qt_batch_deployment_*.exe' 2>/dev/null | grep -v 'libs/' | head -1)"
+  exe="${exe:-$(find "$OUTPUT_DIR" "$SCRIPT_DIR" -maxdepth 3 -name '*.exe' 2>/dev/null | grep -v 'libs/' | head -1)}"
   if [ -n "$exe" ]; then
     cp "$exe" "$OUTPUT_DIR/"
     file "$exe" | head -1
   else
-    echo "WARN: 未找到 windows exe 产物" >&2
+    echo "ERROR: 未找到 windows exe 产物" >&2
+    exit 1
   fi
 }
 
 case "$ARCH" in
-  amd64|arm64|linux) build_linux ;;
+  amd64|arm64|linux) build_linux "$ARCH" ;;
   windows|win) build_windows ;;
-  all) build_linux; build_windows ;;
+  all) build_linux amd64; build_windows ;;
   *) echo "ERROR: ARCH 必须是 amd64|arm64|windows|all" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary
修复 pqt_batch_deployment 子项目代码 review（MYS-60）发现的问题（3 🔴 + 3 🟠）。

### 🔴 阻塞
- **ARCH 参数真正影响构建**：`release.sh` 中 amd64/arm64 分别校验构建宿主为 x86_64/aarch64，不匹配明确报错退出（AppImage 的 linuxdeployqt/appimagetool 为宿主架构预编译二进制，无法交叉编译）
- **VERSION 透传生效**：`release.sh` → `build-pqt.sh --version` → `linux_release.sh` → CMake `-DMY_PROJECT_VERSION` 覆盖，产物名带正确版本号
- **windows 失败退出码非 0**：`release.sh` 不再用 `|| { return 0 }` 吞掉 build-pqt.sh 的失败

### 🟠 应修
- **AppImage 精确匹配**：find 排除 `*no_ui*`，且修正产物名模式 `qt_batch_deployment*.AppImage`（实际产物名 `qt_batch_deployment-x86_64.AppImage`）
- **windows 补 `make install`**：CMake 里 windeployqt/openssl 拷贝/静态改名打包挂在 install() 上，不 install 产物非自包含
- **源码树零污染**：`linux_release.sh` 重构为 out-of-source 构建，中间产物与 AppImage 只写 WORK_DIR（默认 OUTPUT_DIR）

## 验证
- ✅ linux AppImage（amd64）：`qt_batch_deployment_1.4.1-x86_64.AppImage` / `qt_batch_deployment_2.0.0-x86_64.AppImage` 构建通过，大小校验 ok
- ✅ windows exe：`qt_batch_deployment_2.0.0.exe`（PE32+ x86-64，33MB）构建通过
- ✅ `release.sh arm64` 在 x86_64 宿主正确报错（exit 1）
- ✅ 镜像缺失时 windows 构建退出码 125（非 0）
- ✅ 构建后源码树无新增产物（git status 仅 5 个改动文件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)