### PR TITLE
fix(pqt_memory_edit): 修复 MYS-61 review 问题

### DIFF
--- a/source/pqt_memory_edit/CMakeLists.txt
+++ b/source/pqt_memory_edit/CMakeLists.txt
@@ -23,7 +23,10 @@ find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
 # edit by user
-set(MY_PROJECT_VERSION "V2.12.1")
+# 允许构建时用 -DMY_PROJECT_VERSION=... 覆盖默认版本（linux_release.sh/release.sh 透传）
+if(NOT DEFINED MY_PROJECT_VERSION)
+  set(MY_PROJECT_VERSION "V2.12.1")
+endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/version.h.in"
   "${CMAKE_BINARY_DIR}/version.h"

--- a/source/pqt_memory_edit/linux_release.sh
+++ b/source/pqt_memory_edit/linux_release.sh
@@ -1,62 +1,78 @@
 #!/bin/bash
+# pqt_memory_edit linux AppImage 构建（M3 统一构建）
+# 用法: bash linux_release.sh [WORK_DIR] [VERSION]
+#   WORK_DIR: 构建工作目录（中间产物 + AppImage 只写这里，默认 $PWD/.build）
+#   VERSION:  显式版本号（默认从 CMakeLists MY_PROJECT_VERSION 解析）
+# out-of-source 构建：源码目录零改动，产物与中间文件全部落在 WORK_DIR。
+# 任一步失败立即退出（set -euo pipefail），不再靠 AppImage 大小兜底。
+set -euo pipefail
+
 get_arch=$(arch)
 host_inf=""
-if [[ $get_arch =~ "x86_64" ]];then
+if [[ $get_arch =~ "x86_64" ]]; then
     echo "this is x86_64"
     host_inf="linux_amd64"
-elif [[ $get_arch =~ "aarch64" ]];then
+elif [[ $get_arch =~ "aarch64" ]]; then
     echo "this is arm64"
     host_inf="linux_arm64"
-elif [[ $get_arch =~ "mips64" ]];then
-    echo "this is mips64"
-    host_inf=""
 else
-    echo "unknown!!"
+    echo "unknown arch: $get_arch" >&2
+    exit 1
 fi
-rm build -rf
-rm *.AppImage -rf
-mkdir build
-line=$(grep -E '^set\(MY_PROJECT_VERSION "[^"]+"\)' CMakeLists.txt)
-version=$(echo "$line" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')
-echo "need build version: ${version}"
-pushd build
-cmake ..
-make -j4
-make install
-pushd output
-cp ../../libs/Appdir ./ -a
-cp ../../libs/$host_inf/openssl/lib/*.so.* Appdir/usr/lib
-cp ../../libs/$host_inf/release/lib/*.so.* Appdir/usr/lib
-cp ./qt_mem_edit Appdir/usr/bin
-sed -i "s/Name=qt_mem_edit/Name=qt_mem_edit_V${version}/" Appdir/qt_mem_edit.desktop
-mkdir bintools
-pushd bintools
-cp ../../../libs/$host_inf/appimagetool ./
-chmod +x appimagetool
-# sudo apt-get -y install qt5-default qttools5-dev g++ libgl1-mesa-dev patchelf cmake make gcc
-cp ../../../libs/linuxdeployqt.tar.gz ./
-tar -xaf linuxdeployqt.tar.gz 
-pushd linuxdeployqt-continuous
-qmake
-make -j4
-popd # linuxdeployqt-continuous
-popd # bintools
+
+SOURCE_ROOT="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+WORK_DIR="${1:-$SOURCE_ROOT/.build}"
+VERSION="${2:-$(grep -E 'set\(MY_PROJECT_VERSION "[^"]+"\)' "$SOURCE_ROOT/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+if [ -z "$VERSION" ]; then
+    echo "ERROR: 无法从 CMakeLists.txt 解析版本号，请显式传入 VERSION" >&2
+    exit 1
+fi
+echo "need build version: ${VERSION}"
+
+# WORK_DIR 可能是 docker 挂载点，不能 rm 目录本身，只清空内容
+rm -rf "$WORK_DIR"/* "$WORK_DIR"/.[!.]* 2>/dev/null || true
+mkdir -p "$WORK_DIR"
+
+echo "==> cmake 配置 + 编译 (out-of-source, 版本 ${VERSION}) ..."
+cmake -S "$SOURCE_ROOT" -B "$WORK_DIR/build" -DMY_PROJECT_VERSION="${VERSION}" -DCMAKE_BUILD_TYPE=Release
+cmake --build "$WORK_DIR/build" -j"$(nproc)"
+cmake --install "$WORK_DIR/build"
+
+echo "==> 组装 AppDir 并打包 AppImage ..."
+mkdir -p "$WORK_DIR/appimage"
+cp "$SOURCE_ROOT/libs/Appdir" "$WORK_DIR/appimage/" -a
+cp "$SOURCE_ROOT/libs/$host_inf/openssl/lib/"*.so.* "$WORK_DIR/appimage/Appdir/usr/lib"
+cp "$SOURCE_ROOT/libs/$host_inf/release/lib/"*.so.* "$WORK_DIR/appimage/Appdir/usr/lib"
+cp "$WORK_DIR/build/output/qt_mem_edit" "$WORK_DIR/appimage/Appdir/usr/bin"
+# 产物名由桌面文件 Name 决定，写进版本号使显式 VERSION 生效
+sed -i "s/Name=qt_mem_edit/Name=qt_mem_edit_V${VERSION}/" "$WORK_DIR/appimage/Appdir/qt_mem_edit.desktop"
+mkdir -p "$WORK_DIR/appimage/bintools"
+cp "$SOURCE_ROOT/libs/$host_inf/appimagetool" "$WORK_DIR/appimage/bintools/"
+chmod +x "$WORK_DIR/appimage/bintools/appimagetool"
+cp "$SOURCE_ROOT/libs/linuxdeployqt.tar.gz" "$WORK_DIR/appimage/bintools/"
+tar -xaf "$WORK_DIR/appimage/bintools/linuxdeployqt.tar.gz" -C "$WORK_DIR/appimage/bintools"
+
+pushd "$WORK_DIR/appimage" >/dev/null
+# linuxdeployqt 为源码包，需现场 qmake+make；编译/运行失败即退出，
+# 否则 AppImage 缺 Qt 库且不报错（依赖库收集由它完成）
+(cd bintools/linuxdeployqt-continuous && qmake linuxdeployqt.pro && make -j"$(nproc)")
+export PATH="$PWD/bintools:$PATH"
 ./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_mem_edit.desktop -appimage -verbose=2
 ./bintools/appimagetool --comp xz Appdir
-cp ./*.AppImage ../../
-popd # output
-popd # build
-# rm build -rf
-file_path=$(find . -maxdepth 1 -name '*.AppImage' -print -quit)
+cp ./*.AppImage "$WORK_DIR"/
+popd >/dev/null # appimage
+
+file_path=$(find "$WORK_DIR" -maxdepth 1 -name '*.AppImage' -print -quit)
 if [ -z "$file_path" ]; then
-  echo "cannot find AppImage"
-  exit -1
+    echo "ERROR: 未生成 AppImage" >&2
+    exit 1
 fi
 file_size=$(stat -c %s "$file_path")
-file_size_mb=$((file_size / 1024 / 1024))
-if [ $file_size_mb -gt 20 ]; then
-  exit 0
+file_size_kb=$((file_size / 1024))
+if [ $file_size_kb -gt $(( 20 * 1024 )) ]; then
+    echo "AppImage size ${file_size_kb}KiB ok"
+    exit 0
 else
-  echo "AppImage size error"
-  exit -1
+    echo "AppImage size ${file_size_kb}KiB error" >&2
+    exit 1
 fi

--- a/source/pqt_memory_edit/memoryedit.cpp
+++ b/source/pqt_memory_edit/memoryedit.cpp
@@ -1,5 +1,13 @@
 #include "memoryedit.h"
 
+// 对作为命令参数内嵌的用户输入做 shell 单引号转义：
+// 输入中的 ' 用 '\'' 闭合，使整段内容在远程 shell 中始终作为单个字面量，
+// 防止密码等含空格/元字符的输入改写命令语义（命令注入）。
+static QString
+shellQuote(const QString& s) {
+  return "'" + QString(s).replace("'", "'\\''") + "'";
+}
+
 MemoryEdit::MemoryEdit(QWidget* iparent) {
   parent = iparent;
   QObject::connect(
@@ -324,7 +332,7 @@ MemoryEdit::comP() {
     currentDateTimeString +
     ".tgz";
   QString rex;
-  const QString sudoAu("echo " + passwd + " | sudo -S");
+  const QString sudoAu("echo " + shellQuote(passwd) + " | sudo -S");
   const QString localFile("://mem_edit_file");
   const QString remoteFile("/data/.memedit/mem_edit.tar.xz");
   const QString
@@ -333,7 +341,7 @@ MemoryEdit::comP() {
   const QString com2("tar -xaf " + remoteFile + " -C /data/.memedit/");
   const QString
   com3("pushd /data/.memedit/memory_edit;chmod +x memory_edit.sh; echo "
-    + passwd + " | sudo -S ./memory_edit.sh -p | tee memory_edit_p.log");
+    + shellQuote(passwd) + " | sudo -S ./memory_edit.sh -p | tee memory_edit_p.log");
   QStringList com3RexList;
   const QString com4("pushd /data/.memedit; tar -caf " + default_file +
     " memory_edit");
@@ -416,7 +424,7 @@ MemoryEdit::comC(bool autoRestart) {
     ".tgz";
   QString localFile("://mem_edit_file");
   QString remoteFile("/data/.memedit/mem_edit.tar.xz");
-  const QString sudoAu("echo " + passwd + " | sudo -S");
+  const QString sudoAu("echo " + shellQuote(passwd) + " | sudo -S");
   const QString com1 =
     QString("%1 rm -rf /data/.memedit && %1 mkdir -p /data/.memedit && %1 "
       "ls -lah /data/.memedit && %1 chmod 777 -R /data/.memedit").arg(sudoAu);
@@ -429,14 +437,14 @@ MemoryEdit::comC(bool autoRestart) {
       QString::number(quint64(memSet.vpp_mem) * 1024 * 1024, 16).toUpper());
   const QString
   com3("pushd /data/.memedit/memory_edit; chmod +x memory_edit.sh; echo "
-    + passwd + " | sudo -S ./memory_edit.sh -c" +
+    + shellQuote(passwd) + " | sudo -S ./memory_edit.sh -c" +
     sizeStr + " | tee memory_edit_c.log");
-  const QString com4("pushd /data/.memedit/memory_edit; echo " + passwd +
+  const QString com4("pushd /data/.memedit/memory_edit; echo " + shellQuote(passwd) +
     " | sudo -S cp *.itb /boot; sync");
   const QString com5("pushd /data/.memedit; tar -caf " + default_file +
     " memory_edit");
   const QString com6("rm -rf /data/.memedit");
-  const QString com7("echo " + passwd + " | sudo -S reboot");
+  const QString com7("echo " + shellQuote(passwd) + " | sudo -S reboot");
   QString localFilePath = localDir.filePath(default_file);
   bool ok;
   emit SI_FS("正在进行前置准备，请稍等");

--- a/source/pqt_memory_edit/release.sh
+++ b/source/pqt_memory_edit/release.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # pqt_memory_edit 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION]
-#   ARCH:    amd64 | arm64 | all | windows（默认 amd64；linux AppImage 宿主架构）
+#   ARCH:    amd64 | arm64 | linux（默认 amd64；linux AppImage 为宿主架构，见下）
+#            windows=Windows exe 交叉编译
 #   VERSION: 显式版本号（默认从 CMakeLists MY_PROJECT_VERSION 解析）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pqt_memory_edit/）
+# 说明: linux AppImage 走 docker/pqt 镜像（glibc≤2.31），windows exe 走 sophon-tools-build mingw。
+#       AppImage 的 linuxdeployqt/appimagetool 为宿主架构预编译二进制，无法交叉：
+#       ARCH=amd64 要求构建宿主为 x86_64，ARCH=arm64 要求宿主为 aarch64，否则报错退出。
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
@@ -11,39 +15,67 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-amd64}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pqt_memory_edit}"
 
-VERSION="${2:-$(grep -E '^set\(MY_PROJECT_VERSION "[^"]+"\)' "$SCRIPT_DIR/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+VERSION="${2:-$(grep -E 'set\(MY_PROJECT_VERSION "[^"]+"\)' "$SCRIPT_DIR/CMakeLists.txt" | grep -o -E '[0-9]+\.[0-9]+\.[0-9]+')}"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: 无法从 CMakeLists.txt 解析版本号，请显式传入 VERSION" >&2
+  exit 1
+fi
 echo "==> pqt_memory_edit version=$VERSION arch=$ARCH"
 
 mkdir -p "$OUTPUT_DIR"
 
+# ARCH 必须真实影响构建：AppImage 工具链绑定宿主架构，无法交叉。
+# amd64/arm64 分别要求 x86_64/aarch64 宿主；linux 按宿主自动选择。
 build_linux() {
-  echo "==> 构建 linux AppImage ..."
-  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_memory_edit --linux
-  local app="$(find "$SCRIPT_DIR" -maxdepth 1 -name 'qt_mem_edit_*.AppImage' | head -1)"
-  if [ -z "$app" ]; then app="$(find "$SCRIPT_DIR" -maxdepth 1 -name '*.AppImage' | head -1)"; fi
+  local want_arch="$1"
+  local host_arch
+  host_arch="$(arch 2>/dev/null || uname -m)"
+  case "$want_arch" in
+    amd64)
+      if [[ "$host_arch" != "x86_64" ]]; then
+        echo "ERROR: ARCH=amd64 需要 x86_64 构建宿主（当前 $host_arch），AppImage 工具链无法交叉" >&2
+        exit 1
+      fi
+      ;;
+    arm64)
+      if [[ "$host_arch" != "aarch64" ]]; then
+        echo "ERROR: ARCH=arm64 需要 aarch64 构建宿主（当前 $host_arch），AppImage 工具链无法交叉" >&2
+        exit 1
+      fi
+      ;;
+    linux) : ;;  # 宿主自动
+  esac
+  echo "==> 构建 linux AppImage (arch=$want_arch) ..."
+  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_memory_edit --linux --version "$VERSION" --output "$OUTPUT_DIR"
+  # linux_release.sh 已把 AppImage 生成到 OUTPUT_DIR（WORK_DIR），不存在则从源码树回退拷贝
+  local app="$(find "$OUTPUT_DIR" -maxdepth 1 -name 'qt_mem_edit_*.AppImage' | head -1)"
+  if [ -z "$app" ]; then app="$(find "$SCRIPT_DIR" -maxdepth 1 -name 'qt_mem_edit_*.AppImage' | head -1)"; fi
   if [ -z "$app" ]; then echo "ERROR: 未找到 AppImage 产物" >&2; exit 1; fi
-  cp "$app" "$OUTPUT_DIR/"
+  local appname
+  appname="$(basename "$app")"
+  if [ ! -f "$OUTPUT_DIR/$appname" ]; then cp "$app" "$OUTPUT_DIR/"; fi
   file "$app" | head -1
 }
 
 build_windows() {
   echo "==> windows exe 交叉编译 ..."
-  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_memory_edit --windows
+  bash "$REPO_ROOT/docker/pqt/build-pqt.sh" --project pqt_memory_edit --windows --version "$VERSION" --output "$OUTPUT_DIR"
   local exe
-  exe="$(find "$SCRIPT_DIR" -maxdepth 2 -name 'qt_mem_edit.exe' 2>/dev/null | head -1)"
-  exe="${exe:-$(find "$SCRIPT_DIR" -maxdepth 2 -name '*.exe' 2>/dev/null | grep -v 'libs/' | head -1)}"
+  exe="$(find "$OUTPUT_DIR" "$SCRIPT_DIR" -maxdepth 3 -name 'qt_mem_edit_*.exe' 2>/dev/null | grep -v 'libs/' | head -1)"
+  exe="${exe:-$(find "$OUTPUT_DIR" "$SCRIPT_DIR" -maxdepth 3 -name '*.exe' 2>/dev/null | grep -v 'libs/' | head -1)}"
   if [ -n "$exe" ]; then
     cp "$exe" "$OUTPUT_DIR/"
     file "$exe" | head -1
   else
-    echo "WARN: 未找到 windows exe 产物" >&2
+    echo "ERROR: 未找到 windows exe 产物" >&2
+    exit 1
   fi
 }
 
 case "$ARCH" in
-  amd64|arm64|linux) build_linux ;;
+  amd64|arm64|linux) build_linux "$ARCH" ;;
   windows|win) build_windows ;;
-  all) build_linux; build_windows ;;
+  all) build_linux amd64; build_windows ;;
   *) echo "ERROR: ARCH 必须是 amd64|arm64|windows|all" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary

修复 pqt_memory_edit 子项目代码 review（MYS-61）发现的 4 项 🟠 应修问题：

- **VERSION 透传生效**：release.sh 将 VERSION 传给 build-pqt.sh `--version`，经 linux_release.sh `-DMY_PROJECT_VERSION` 覆盖 CMake 版本，并写入桌面文件 `Name`，AppImage 产物名带版本号（`qt_mem_edit_V<ver>-x86_64.AppImage`）
- **arch 语义校验**：amd64/arm64 分别校验宿主为 x86_64/aarch64，不匹配明确报错退出，不再静默产出错误架构包
- **set -euo pipefail**：linux_release.sh 任一步失败即退出，不再靠 AppImage >20MB 兜底；重构为 out-of-source 构建，接受 WORK_DIR/VERSION 参数，源码树零污染
- **命令注入修复**：memoryedit.cpp 新增 `shellQuote()`，对 passwd 做 shell 单引号转义后拼入 `echo | sudo -S` 命令（comP/comC 共 6 处）
- CMakeLists.txt 支持 `-DMY_PROJECT_VERSION` 命令行覆盖

## Test plan

- [x] linux AppImage 构建（V2.12.1 / V2.0.0 产物名均带版本，25MB+ 含 Qt 库）
- [x] windows exe 构建（`qt_mem_edit_2.12.1.exe`）
- [x] arm64 在 x86_64 宿主正确报错退出
- [x] 源码树零污染（out-of-source）

🤖 Generated with [Claude Code](https://claude.com/claude-code)