### PR TITLE
fix(pSophUI): 修复 MYS-62 review 问题（二进制路径/sed 污染/make 检测/引号）

### DIFF
--- a/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/hdmi_status.sh
+++ b/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/hdmi_status.sh
@@ -42,7 +42,7 @@ while true; do
 		status=$(find /sys -name "hdmi_status" 2>/dev/null)
 		path1="$status/status"
 	fi
-	STATUS=$(cat $path1 2>/dev/null)
+	STATUS=$(cat "$path1" 2>/dev/null)
 	if [ $? -eq 1 ]; then
 		STATUS="0"
 	fi

--- a/source/pSophUI/release.sh
+++ b/source/pSophUI/release.sh
@@ -60,25 +60,38 @@ pushd "$BUILD_DIR" >/dev/null
   "$QMAKE" SophUI.pro
 
   # 编译（post-link 的 upx 步骤失败仅告警，不影响二进制产出）
-  make -j"$(nproc)" 2>&1 | tail -5 || {
-    echo "WARN: make 有非零退出（多为尾部 upx 缺失），检查二进制是否已生成" >&2
-  }
+  # make 返回非零时可能只是尾部 upx 缺失（二进制已生成），也可能是真编译失败。
+  # 以二进制 mtime 是否新于 Makefile 区分：真失败时残留旧二进制会早于刚生成的 Makefile。
+  MAKE_RC=0
+  make -j"$(nproc)" 2>&1 | tail -5 || MAKE_RC=1
 
   BIN="SophUI"
   if [ ! -f "$BIN" ]; then
     echo "ERROR: 未生成 $BIN" >&2
     exit 1
   fi
+  if [ "$MAKE_RC" != "0" ]; then
+    if [ "$BIN" -ot "Makefile" ]; then
+      echo "ERROR: make 失败且二进制早于 Makefile（残留旧产物），中止打包" >&2
+      exit 1
+    fi
+    echo "WARN: make 有非零退出（多为尾部 upx 缺失），二进制已更新，继续" >&2
+  fi
   file "$BIN" | head -1
 
-  # 打 deb（复用工程内 deb 数据树）
+  # 打 deb：复制 deb 数据树到临时目录再修改，避免 sed -i 污染仓库跟踪的 control。
+  # 二进制拷到与运行脚本/服务一致的 /bm_services/SophonHDMI/ 布局
+  # （run_hdmi_show.sh、SophonHDMI.service 均从该路径启动 SophUI）。
   if [ -d deb ] && command -v dpkg-deb >/dev/null 2>&1; then
-    DEST_DIR=deb/opt/sophon/SophUI/bin
+    DEB_TMP="$(mktemp -d "${TMPDIR:-/tmp}/pSophUI-deb.XXXXXX")"
+    cp -a deb/. "$DEB_TMP/"
+    DEST_DIR="$DEB_TMP/bm_services/SophonHDMI"
     mkdir -p "$DEST_DIR"
     cp -f "$BIN" "$DEST_DIR/"
     DEST_VER="${VERSION}"
-    sed -i "s/1\.6\.8/${DEST_VER}/" deb/DEBIAN/control 2>/dev/null || true
-    dpkg-deb --root-owner-group -b deb "$OUTPUT_DIR/sophgo-hdmi_${DEST_VER}_arm64.deb" 2>&1 | tail -2 || true
+    sed -i "s/1\.6\.8/${DEST_VER}/" "$DEB_TMP/DEBIAN/control"
+    dpkg-deb --root-owner-group -b "$DEB_TMP" "$OUTPUT_DIR/sophgo-hdmi_${DEST_VER}_arm64.deb" 2>&1 | tail -2 || true
+    rm -rf "$DEB_TMP"
     cp -f "$BIN" "$OUTPUT_DIR/SophUI_arm64"
   else
     cp -f "$BIN" "$OUTPUT_DIR/SophUI_arm64"


### PR DESCRIPTION
## Summary
修复 pSophUI 代码 review（MYS-62）发现的 4 个问题：

- 🔴 **二进制路径**：release.sh 将 SophUI 拷到 `deb/opt/sophon/SophUI/bin/`，但运行入口（`run_hdmi_show.sh`、`SophonHDMI.service`）从 `/bm_services/SophonHDMI/` 启动，安装后服务无法启动。改为拷到 `deb/bm_services/SophonHDMI/`，与运行脚本/服务布局一致。
- 🟠 **sed 污染**：`sed -i` 就地改写仓库跟踪的 `DEBIAN/control`，跨版本构建产生状态污染。改为复制 deb 数据树到临时目录再修改 control 后打包。
- 🟠 **make 检测弱化**：`make | tail -5 || { WARN }` 只告警不中止，残留旧二进制时编译失败也继续打 deb。改为按二进制 mtime 是否新于 Makefile 区分真失败与 upx 尾部缺失，真失败即中止。
- 🟠 **cat 未加引号**：`hdmi_status.sh` 中 `cat $path1` 多路径/含空白时未定义，改为 `cat "$path1"`。

## Test plan
- [x] 在 `sophon-tools-build:unified` 镜像内 `release.sh arm64 1.6.8` 构建成功，deb 内二进制位于 `./bm_services/SophonHDMI/SophUI`（可执行）
- [x] 跨版本构建 `1.6.9` 后仓库 control 仍为 1.6.8（无污染），deb 内 version 正确
- [x] 模拟 make 失败 + 残留旧二进制 → release.sh 退出码 1 中止打包
- [x] deb 内 `hdmi_status.sh` 引号修复已生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)