### PR TITLE
fix(psoph_phytool): 修复 MYS-63 review 问题（写失败检测/参数校验前移）

### DIFF
--- a/source/psoph_phytool/sophon_phytool.sh
+++ b/source/psoph_phytool/sophon_phytool.sh
@@ -1,24 +1,18 @@
 #!/bin/bash
 #set -x
-reg1=$(sudo phytool read eth1/0/0x02)  # PHY ID1 
-reg2=$(sudo phytool read eth1/0/0x03)  # PHY ID2 
 
-reg1_dec=$((reg1))
-reg2_dec=$((reg2))
-
-combined_dec=$(( (reg1_dec << 16) | reg2_dec ))
-combined_hex=$(printf "0x%08x" $combined_dec)
-
-echo "[info]: PHY chip ID: $combined_hex"
-
-if [ "$#" -lt 6 ]; then
+usage() {
     echo "usage: $0 <read|write> <ic_name> <device> <phy_addr> <page> <reg_addr> [write_data]"
     echo "examples:"
     echo "read:  $0 read YT eth1 0x0 0xa003 0x1f"
     echo "write: $0 write RTL eth1 0x0 0xd08 0x15 0x19"
+}
+
+# 参数校验（在硬件探测之前），避免参数错误时先触发硬件读
+if [ "$#" -lt 6 ]; then
+    usage
     exit 1
 fi
-
 
 operation=$1
 ic_name=$2
@@ -27,22 +21,47 @@ phy_addr=$4
 page=$5
 reg_addr=$6
 
-
-# set page_reg according to ic_name
-if [ "$ic_name" == "YT" ]; then
-    page_reg=0x1e
-    echo "[info]: ic page reg: $page_reg"
-elif [ "$ic_name" == "RTL" ]; then
-    page_reg=0x1f
-    echo "[info]: ic page reg: $page_reg"
-elif [ "$ic_name" == "MARVEL" ]; then
-    page_reg=0x16
-    echo "[info]: ic page reg: $page_reg"
-else
-    echo "[Warning]: $ic_name is not support!"
+if [ "$operation" != "read" ] && [ "$operation" != "write" ]; then
+    echo "[Error]: invalid operation: $operation. choose 'read' or 'write'."
     exit 1
 fi
 
+if [ "$operation" == "write" ] && [ "$#" -ne 7 ]; then
+    echo "[Warning]: need: <write_data>"
+    exit 1
+fi
+
+# set page_reg according to ic_name
+case "$ic_name" in
+    YT)
+        page_reg=0x1e
+        echo "[info]: ic page reg: $page_reg"
+        ;;
+    RTL)
+        page_reg=0x1f
+        echo "[info]: ic page reg: $page_reg"
+        ;;
+    MARVEL)
+        page_reg=0x16
+        echo "[info]: ic page reg: $page_reg"
+        ;;
+    *)
+        echo "[Warning]: $ic_name is not support!"
+        exit 1
+        ;;
+esac
+
+# 硬件探测（参数校验通过后进行）
+reg1=$(sudo phytool read eth1/0/0x02)  # PHY ID1
+reg2=$(sudo phytool read eth1/0/0x03)  # PHY ID2
+
+reg1_dec=$((reg1))
+reg2_dec=$((reg2))
+
+combined_dec=$(( (reg1_dec << 16) | reg2_dec ))
+combined_hex=$(printf "0x%08x" $combined_dec)
+
+echo "[info]: PHY chip ID: $combined_hex"
 
 function read_phy_reg() {
 	device=$1
@@ -64,27 +83,28 @@ function write_phy_reg() {
 	write_data=$5
 
 	sudo phytool write ${device}/${phy_addr}/${page_reg} ${page}
-	sudo phytool write ${device}/${phy_addr}/${reg_addr} ${write_data}
-	sudo phytool write ${device}/${phy_addr}/${page_reg} 0x00
-
-	# check if write data successfully
 	if [ $? -ne 0 ]; then
-            echo "[Error]: write reg failed: ${device}/${phy_addr}/${reg_addr}"
-            exit 1
+	    echo "[Error]: write page failed: ${device}/${phy_addr}/${page_reg}"
+	    exit 1
+	fi
+
+	sudo phytool write ${device}/${phy_addr}/${reg_addr} ${write_data}
+	if [ $? -ne 0 ]; then
+	    echo "[Error]: write reg failed: ${device}/${phy_addr}/${reg_addr}"
+	    exit 1
+	fi
+
+	sudo phytool write ${device}/${phy_addr}/${page_reg} 0x00
+	if [ $? -ne 0 ]; then
+	    echo "[Error]: restore page failed: ${device}/${phy_addr}/${page_reg}"
+	    exit 1
 	fi
 }
 
 if [ "$operation" == "read" ]; then
     read_phy_reg $device $phy_addr $page $reg_addr
 elif [ "$operation" == "write" ]; then
-    if [ "$#" -ne 7 ]; then
-        echo "[Warning]: need: <write_data>"
-        exit 1
-    fi
     write_data=$7
     write_phy_reg $device $phy_addr $page $reg_addr $write_data
     echo "[info]: $device: page: $page, reg addr: $reg_addr, write data: $write_data"
-else
-    echo "[Error]: invalid operation: $operation. choose 'read' or 'write'."
-    exit 1
 fi


### PR DESCRIPTION
## Summary
修复 psoph_phytool 子项目代码 review（MYS-63）发现的 2 个 🟠 问题。

1. **write_phy_reg 错误检测失效** — 原来连续三次 `sudo phytool write` 后 `if [ $? -ne 0 ]` 检查的是恢复 page 那一步的退出码。改为每次 write 后立即检查，写数据失败明确报 `write reg failed`，恢复 page 失败明确报 `restore page failed`。
2. **参数校验在硬件操作之后** — 原来脚本先 `sudo phytool read` 探测硬件再校验 `$#`。现在参数校验（`$#`/operation/write_data/ic_name）全部前移到硬件探测之前，参数错误不再触发硬件读。

## 验证
- `bash -n` 语法检查通过
- mock phytool 测试 14 项全部通过：参数不足/无效 operation/write 缺 write_data/无效 ic_name 均 rc=1 且不触发 phytool；写数据失败报 write reg failed；恢复 page 失败报 restore page failed；正常 write rc=0

## 涉及文件
- `source/psoph_phytool/sophon_phytool.sh`