### PR TITLE
fix(pspacc_efuse_demo): 修复 MYS-64 review 问题

### DIFF
--- a/source/pspacc_efuse_demo/readme.md
+++ b/source/pspacc_efuse_demo/readme.md
@@ -10,8 +10,19 @@
 
 ## 使用方式
 
+### 统一构建接口（release.sh）
+
+``` bash
+bash release.sh [ARCH]          # ARCH: amd64|arm64|all，默认 amd64
+OUTPUT_DIR=xxx bash release.sh all   # env OUTPUT_DIR 指定产物目录
+```
+
+产物默认输出到 `<repo>/output/pspacc_efuse_demo/`；单 arch 产物为 `spacc_efuse_demo`，`all` 依次构建双架构并输出 `spacc_efuse_demo_amd64` / `spacc_efuse_demo_arm64`。
+
+### 手工编译
+
 ``` bash
 gcc spacc_efuse_demo.c -o spacc_efuse_demo
 chmod +x spacc_efuse_demo
-./spacc_efuse_demo
+./spacc_efuse_demo [明文参数]
 ```

--- a/source/pspacc_efuse_demo/release.sh
+++ b/source/pspacc_efuse_demo/release.sh
@@ -1,35 +1,54 @@
 #!/bin/bash
 # pspacc_efuse_demo 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION]
-#   ARCH:    amd64|arm64（默认 amd64；arm64 走交叉编译）
+#   ARCH:    amd64|arm64|all（默认 amd64；arm64 走交叉编译；all 依次构建双架构）
 #   VERSION: 无版本号（保留参数兼容）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pspacc_efuse_demo/）
+# 产物: 单 arch 输出 spacc_efuse_demo；all 输出 spacc_efuse_demo_<arch>
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-amd64}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pspacc_efuse_demo}"
 
-echo "==> pspacc_efuse_demo gcc 编译 arch=$ARCH"
-mkdir -p "$OUTPUT_DIR"
-
 case "$ARCH" in
-  amd64)
-    gcc spacc_efuse_demo.c -o "$OUTPUT_DIR/spacc_efuse_demo"
-    ;;
-  arm64)
-    CC="${CC:-aarch64-linux-gnu-gcc}"
-    if ! command -v "$CC" >/dev/null 2>&1; then
-      echo "ERROR: 交叉编译器 $CC 不可用" >&2; exit 1
-    fi
-    "$CC" -march=armv8-a spacc_efuse_demo.c -o "$OUTPUT_DIR/spacc_efuse_demo"
-    ;;
-  *)
-    echo "ERROR: ARCH 必须是 amd64|arm64" >&2; exit 1 ;;
+  amd64|arm64) ;;
+  all) ARCH_LIST="amd64 arm64" ;;
+  *) echo "ERROR: ARCH 必须是 amd64|arm64|all，得到: $ARCH" >&2; exit 1 ;;
 esac
 
-chmod +x "$OUTPUT_DIR/spacc_efuse_demo"
-file "$OUTPUT_DIR/spacc_efuse_demo" | head -1
+mkdir -p "$OUTPUT_DIR"
+
+build_one() {
+  local arch="$1"
+  local bin="spacc_efuse_demo"
+  if [ "$ARCH" = "all" ]; then
+    bin="spacc_efuse_demo_$arch"
+  fi
+  echo "==> pspacc_efuse_demo gcc 编译 arch=$arch"
+  case "$arch" in
+    amd64)
+      gcc spacc_efuse_demo.c -o "$OUTPUT_DIR/$bin"
+      ;;
+    arm64)
+      CC="${CC:-aarch64-linux-gnu-gcc}"
+      if ! command -v "$CC" >/dev/null 2>&1; then
+        echo "ERROR: 交叉编译器 $CC 不可用" >&2; exit 1
+      fi
+      "$CC" -march=armv8-a spacc_efuse_demo.c -o "$OUTPUT_DIR/$bin"
+      ;;
+  esac
+  chmod +x "$OUTPUT_DIR/$bin"
+  file "$OUTPUT_DIR/$bin" | head -1
+}
+
+if [ -n "${ARCH_LIST:-}" ]; then
+  for a in $ARCH_LIST; do build_one "$a"; done
+else
+  build_one "$ARCH"
+fi
+
 echo "==> pspacc_efuse_demo 完成, 产物: $OUTPUT_DIR"
 ls -la "$OUTPUT_DIR"

--- a/source/pspacc_efuse_demo/spacc_efuse_demo.c
+++ b/source/pspacc_efuse_demo/spacc_efuse_demo.c
@@ -43,11 +43,9 @@ int setkey(int fd, char* key, int keylen) {
     int err = setsockopt(fd, SOL_ALG, ALG_SET_KEY, key, keylen);
     if (err) {
         perror("setkey err");
-        goto out;
+        return -1;
     }
-out:
-    err = errno;
-    return err;
+    return 0;
 }
  
 int sendmsg_to_crypto(int opfd, int cmsg_type, __u32 cmsg_data, char* plaintext_buf, int buflen) {
@@ -95,12 +93,8 @@ int sendmsg_to_crypto(int opfd, int cmsg_type, __u32 cmsg_data, char* plaintext_
     err = sendmsg(opfd, &msg, MSG_MORE);
     if (err == -1) {
         perror("sendmsg err");
-        goto out;
+        return -1;
     }
-    else
-        return err;
-out:
-    err = errno;
     return err;
 }
  
@@ -118,30 +112,27 @@ int recvmsg_from_crypto(int opfd, char* src, int len) {
     err = recvmsg(opfd, &msg, 0);
     if (err == -1) {
         perror("recvmsg err");
-        goto out;
+        return -1;
     }
-    else {
-        /* 打印出接收到的加密后的数据 */
-        printf("recvmsg_from_crypto hex: ");
-        print(src, len);
-        return err;
-    }
- 
- 
-out:
-    err = errno;
+    /* 打印出接收到的加密后的数据 */
+    printf("recvmsg_from_crypto hex: ");
+    print(src, len);
     return err;
 }
- 
+
 char* text_align16(const char* src, long int* len) {
     /* 对字符串进行16字节对齐不足补\0，用于处理AES加密的16字节分组 */
     char* new_str;
     long int new_len = ((*len) / 16 + 1) * 16;
     new_str = malloc((*len) % 16 == 0 ? *len : new_len);
+    if (new_str == NULL) {
+        perror("text_align16 malloc err");
+        exit(EXIT_FAILURE);
+    }
     memcpy(new_str, src, *len);
     if ((*len) % 16 == 0)
         return new_str;
-    memset((new_str + (unsigned int)(*len)), 0, new_len - *len - 1);
+    memset(new_str + *len, 0, new_len - *len);
     *len = new_len;
     return new_str;
 }
@@ -164,8 +155,8 @@ int main(int argc, char** argv) {
     char* plaintext_buf;
     long int plaintext_buf_len;
     int tfmfd;
-    int opfd;
-    int opfd2;
+    int opfd = -1;
+    int opfd2 = -1;
     int err;
     /* 实例需要加密的明文数据 */
     if (argc > 1)
@@ -175,7 +166,8 @@ int main(int argc, char** argv) {
     plaintext_buf_len = strlen(plaintext_buf);
     /* 根据输入进行内存空间的申请，确保可以处理超大字符串 */
     encrypt_buf = malloc(plaintext_buf_len + 16);
-    decrypt_buf = malloc(plaintext_buf_len + 16);
+    /* calloc 清零保证解密输出为 NUL 终止，避免 %s/strlen 越界读 */
+    decrypt_buf = calloc(plaintext_buf_len + 16, 1);
     plaintext_buf = text_align16(plaintext_buf, &plaintext_buf_len);
     printf("src text: %s len: %ld->%ld\n", plaintext_buf, strlen(plaintext_buf), plaintext_buf_len);
     /* 申请socket控制句柄 */
@@ -195,12 +187,14 @@ int main(int argc, char** argv) {
     opfd = accept(tfmfd, NULL, 0);
     if (opfd == -1) {
         perror("accept err");
+        goto accept_err;
     }
  
     /* 申请一个句柄，用于解密 */
     opfd2 = accept(tfmfd, NULL, 0);
     if (opfd2 == -1) {
         perror("accept err");
+        goto accept_err;
     }
  
     /* 发送数据用以加密 */
@@ -224,8 +218,6 @@ int main(int argc, char** argv) {
     if (err == -1) {
         goto sendmsg_err;
     }
-    int bytesToRecv = 0;
- 
 #if RECV==0
     /* 接收加密后的数据 */
     err = recvmsg_from_crypto(opfd2, decrypt_buf, plaintext_buf_len);


### PR DESCRIPTION
## Summary

修复 MYS-64 review 发现的 `pspacc_efuse_demo` 子项目问题（2 🟠 + 7 🟡）：

**🟠 应修**
- `text_align16` 越界写：`memset` 补齐长度修正为 `new_len - *len`，非 16 倍数输入不再越界（off-by-one）
- `setkey` 错误检测失效：setsockopt 成功直接返回 0，失败返回 -1，不再受 errno 残留影响误判

**🟡 建议（一并修复）**
- sendmsg/recvmsg 失败统一返回 -1，与 main 的 `err == -1` 判断一致
- accept 失败 goto 收尾，不再在无效句柄上继续操作
- decrypt_buf 改 calloc 归零，保证 NUL 终止，避免 `%s`/`strlen` 越界读
- 移除未用 `bytesToRecv` 变量
- release.sh 加 `cd "$SCRIPT_DIR"`，支持 `ARCH=all`
- readme 补充统一构建接口说明

## Test plan

- [x] gcc / aarch64-linux-gnu-gcc 双路径 `-Wall -Wextra` 编译零告警
- [x] 非 16 倍数输入越界修复验证（4 组输入 + 16 倍数边界）
- [x] release.sh amd64/arm64/all/非法 ARCH 全路径验证
- [x] 真机（SE7 / BM1684X）验证：加密→解密全流程正常，非 16 倍数输入正常对齐

🤖 Generated with [Claude Code](https://claude.com/claude-code)