### PR TITLE
fix(docker): 修复 MYS-47 review 问题（verify 可选组件 SKIP/Linaro 残留清理）

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -151,10 +151,12 @@ RUN mkdir -p /opt/musl \
 # 不把 /env/qt_5.12.8_nosysroot/bin 加入全局 PATH——其含通用名 qmake/moc,
 #       会遮蔽宿主机 Qt5 qmake, 破坏 pqt 系列(linuxdeployqt)构建。
 #       pSophUI 的 release.sh 内部自行 export 自己的 qmake/gcc 到 PATH(见 source/pSophUI/release.sh)。
-# 默认不内置(约 300MB, 私有源); 加 --with-sophui-toolchain 或构建上下文放归档自动内置。
+# 默认不内置(约 300MB, 私有源); 加 --with-sophui-toolchain 或构建上下文 toolchains/ 放
+# sophui-cross-toolchains.tar.zst 自动内置（与 dfss 段语义一致）。
 ARG WITH_SOPHUI=0
 COPY toolchains/ /tmp/toolchains/
-RUN if [ "${WITH_SOPHUI}" = "1" ] && [ -f /tmp/toolchains/sophui-cross-toolchains.tar.zst ]; then \
+RUN if { [ "${WITH_SOPHUI}" = "1" ] || [ -f /tmp/toolchains/sophui-cross-toolchains.tar.zst ]; } \
+       && [ -f /tmp/toolchains/sophui-cross-toolchains.tar.zst ]; then \
         mkdir -p /env \
         && tar -C /env -I zstd -xf /tmp/toolchains/sophui-cross-toolchains.tar.zst \
         && rm -f /tmp/toolchains/sophui-cross-toolchains.tar.zst \

--- a/docker/README.md
+++ b/docker/README.md
@@ -97,7 +97,7 @@ ubuntu:20.04 的 glibc 是 2.31（22.04 是 2.35）。M5 决定以 20.04 为唯�
 |------|-----------|---------------------|
 | pqt AppImage（glibc≤2.31） | `sophon-tools-build-pqt`（20.04） | 基座即 20.04，Qt5 + libgl1-mesa-dev + fuse + patchelf 内置 |
 | pqt windows exe（Qt mingw 静态库） | `sophon-tools-build:m2` + 宿主 `/opt/qt-mingw` | `--with-qt-mingw` 内置 `/opt/qt-mingw` |
-| pSophUI（aarch64 Qt 5.12.8 交叉） | `cross_build_sophon_u20:v1`（20.04） | `--with-sophui-toolchain` 内置 `/env/qt_5.12.8_nosysroot` + `/env/gcc-linaro-...` |
+| pSophUI（aarch64 Qt 5.12.8 交叉） | `cross_build_sophon_u20:v1`（20.04） | `--with-sophui-toolchain` 内置 `/env/qt_5.12.8_nosysroot`（编译用系统 apt aarch64-linux-gnu-gcc 9.4） |
 | dfss sw_64 / loongarch64 | `sophon-tools-build:m2` 内置 | `--with-dfss-toolchains` 内置（不变） |
 | 其余 13 子项目 | `sophon-tools-build:m2` | 直接满足 |
 

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -101,7 +101,7 @@ PLATFORMS[pspacc_efuse_demo]="amd64/arm64"
 # M5: 全部子项目统一用 sophon-tools-build:unified（20.04 基座）, 不再按子项目切换镜像。
 #   pqt 系列: 统一镜像基座即 20.04(glibc 2.31), AppImage 的 linuxdeployqt 约束已满足,
 #             windows exe 依赖的 Qt mingw 静态库由 --with-qt-mingw 内置。
-#   pSophUI: 统一镜像内置 /env/qt_5.12.8_nosysroot + /env/gcc-linaro-6.3.1-2017.05...。
+#   pSophUI: 统一镜像内置 /env/qt_5.12.8_nosysroot（编译用系统 apt aarch64-linux-gnu-gcc 9.4）。
 
 # 子项目 -> 额外环境 (镜像内 export; 以 ; 分隔)
 # M5: 统一镜像已在 PATH/ENV 预置 Go/Node/Rust/交叉工具链及 pSophUI 工具链,

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -140,7 +140,7 @@ if [[ "${WITH_QT_MINGW}" = "1" ]]; then
       PREFIX=/opt/qt-mingw bash "${DOCKER_DIR}/pqt/build-qt-mingw.sh"
     else
       echo "==> 复用 /opt/qt-mingw 已编译产物, 校验宿主工具与 20.04 基座兼容..." >&2
-      if docker run --rm -v /opt/qt-mingw:/opt/qt-mingw:ro "${IMAGE_NAME}:unified" bash -c '/opt/qt-mingw/bin/uic --version' >/dev/null 2>&1; then
+      if docker run --rm -v /opt/qt-mingw:/opt/qt-mingw:ro "${FULL_IMAGE}" bash -c '/opt/qt-mingw/bin/uic --version' >/dev/null 2>&1; then
         echo "==> /opt/qt-mingw 与 20.04 基座兼容, 直接复用" >&2
       else
         echo "==> /opt/qt-mingw 宿主工具依赖过高 glibc(22.04 编译), 重新从源码编译..." >&2
@@ -157,7 +157,7 @@ echo "==> 构建上下文: ${BUILD_CONTEXT}"
 echo "==> 版本: Go ${GO_VERSION} / Rust ${RUST_VERSION} / Node ${NODE_VERSION} / pnpm ${PNPM_VERSION}"
 [[ "${WITH_DFSS}" = "1" ]] && echo "==> 内置 dfss 私有工具链(sw_64 + loongarch64)"
 [[ "${WITH_QT_MINGW}" = "1" ]] && echo "==> 内置 Qt mingw 静态库(pqt windows)"
-[[ "${WITH_SOPHUI}" = "1" ]] && echo "==> 内置 pSophUI 交叉工具链(aarch64 Qt 5.12.8 + Linaro GCC 6.3)"
+[[ "${WITH_SOPHUI}" = "1" ]] && echo "==> 内置 pSophUI 交叉工具链(aarch64 Qt 5.12.8 + 系统 aarch64-linux-gnu-gcc)"
 
 docker build \
   --build-arg UBUNTU_BASE_DIGEST="${UBUNTU_BASE_DIGEST}" \

--- a/docker/pqt/build-qt-mingw.sh
+++ b/docker/pqt/build-qt-mingw.sh
@@ -26,7 +26,6 @@ QT_URL="https://mirrors.tuna.tsinghua.edu.cn/qt/archive/qt/5.15/${QT_VERSION}/su
 PREFIX="${PREFIX:-/opt/qt-mingw}"
 JOBS="${JOBS:-$(nproc)}"
 # 默认镜像: 优先带版本号 tag（docker/versions.env 的 IMAGE_TAG），未定义则回退 unified
-SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 if [[ -z "${IMAGE:-}" ]]; then
   if [[ -f "${SCRIPT_DIR}/../versions.env" ]]; then
     # shellcheck disable=SC1091

--- a/docker/scripts/build-dfss-pip.sh
+++ b/docker/scripts/build-dfss-pip.sh
@@ -40,6 +40,14 @@ done
 
 [[ ${#ARCHES[@]} -gt 0 ]] || ARCHES=(host aarch64 armbi loongarch64 riscv64 sw_64 mingw64 mingw)
 
+# 需要 dfss 私有工具链的架构（loongarch64 / sw_64）: 循环前预检, 避免前 4 个架构白编
+NEEDS_DFSS=0
+for a in "${ARCHES[@]}"; do
+  case "$a" in
+    loongarch64|sw_64) NEEDS_DFSS=1 ;;
+  esac
+done
+
 echo "==> 在镜像 ${IMAGE} 内编译 dfss-cpp 全部架构: ${ARCHES[*]}"
 docker run --rm \
   -v "${PDFSS_SRC}":/workspace/pdfss_cpp \
@@ -48,6 +56,12 @@ docker run --rm \
     set -e
     export PATH=\"/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1/bin:/usr/sw/swgcc830_cross_tools/usr/bin:\$PATH\"
     git config --global --add safe.directory /workspace/pdfss_cpp
+
+    if [ \"${NEEDS_DFSS}\" = \"1\" ] && ! command -v loongarch64-linux-gnu-gcc >/dev/null 2>&1; then
+      echo 'ERROR: 架构含 loongarch64/sw_64, 但镜像未内置 dfss 私有工具链。' >&2
+      echo '       请用 --with-dfss-toolchains 重建镜像(或从 13.24 容器导出归档: bash docker/scripts/export-dfss-toolchains.sh)。' >&2
+      exit 1
+    fi
 
     for arch in ${ARCHES[*]}; do
       echo \"===== 构建 \${arch} =====\"

--- a/docker/scripts/export-dfss-toolchains.sh
+++ b/docker/scripts/export-dfss-toolchains.sh
@@ -33,40 +33,54 @@ LOONG_SRC="/env/loongson-gnu-toolchain-8.3-x86_64-loongarch64-linux-gnu-rc1.1"
 SW64_ARCHIVE="${OUT_DIR}/swgcc830_cross_tools.tar.zst"
 LOONG_ARCHIVE="${OUT_DIR}/loongarch64-cross-tools.tar.zst"
 
-if ! docker inspect "${CONTAINER}" >/dev/null 2>&1 && ! docker image inspect "${CONTAINER}" >/dev/null 2>&1; then
+# 区分容器 / 镜像两种来源: 容器用 docker exec, 镜像用 docker run（避免镜像名误入 docker exec 报误导错误）
+RUN_MODE=""
+if docker inspect "${CONTAINER}" >/dev/null 2>&1; then
+  RUN_MODE="container"
+elif docker image inspect "${CONTAINER}" >/dev/null 2>&1; then
+  RUN_MODE="image"
+else
   echo "错误: 找不到容器/镜像 '${CONTAINER}'。" >&2
   echo "请在 13.24 服务器上运行（镜像 cross_build_sophon_u20:v1 / cross_build_sophon:v7 内置工具链）:" >&2
   echo "  docker run -d --name dfss-toolchain-src --entrypoint sleep cross_build_sophon_u20:v1 infinity" >&2
   exit 1
 fi
 
+# 在容器 / 镜像内执行命令
+run_in() {
+  local cmd="$1"
+  if [[ "${RUN_MODE}" = "container" ]]; then
+    docker exec "${CONTAINER}" sh -c "${cmd}"
+  else
+    docker run --rm --entrypoint sh "${CONTAINER}" -c "${cmd}"
+  fi
+}
+
 # 工具链是否在容器 / 镜像内
-if ! docker exec "${CONTAINER}" test -d "${SW64_SRC}" >/dev/null 2>&1 \
-   && ! docker exec "${CONTAINER}" test -d "${LOONG_SRC}" >/dev/null 2>&1; then
-  echo "错误: 容器 '${CONTAINER}' 中未找到 ${SW64_SRC} 或 ${LOONG_SRC}。" >&2
+if ! run_in "test -d '${SW64_SRC}'" >/dev/null 2>&1 \
+   && ! run_in "test -d '${LOONG_SRC}'" >/dev/null 2>&1; then
+  echo "错误: ${RUN_MODE} '${CONTAINER}' 中未找到 ${SW64_SRC} 或 ${LOONG_SRC}。" >&2
   exit 1
 fi
 
-export CONTAINER SW64_SRC LOONG_SRC
-
 # 打 tar（容器内无 zstd 则用 tar czf 走 gzip）
 pack_from_container() {
-  local container="$1" src="$2" archive="$3"
+  local src="$1" archive="$2"
   if [[ -f "${archive}" ]]; then
     echo "已存在: ${archive}（跳过）"
     return 0
   fi
   echo "导出 ${src} -> ${archive} ..."
-  if docker exec "${container}" sh -c 'command -v zstd' >/dev/null 2>&1; then
-    docker exec "${container}" sh -c "tar -C '$(dirname "${src}")' -cf - '$(basename "${src}")' | zstd -q -T0" > "${archive}"
+  if run_in 'command -v zstd' >/dev/null 2>&1; then
+    run_in "tar -C '$(dirname "${src}")' -cf - '$(basename "${src}")' | zstd -q -T0" > "${archive}"
   else
-    docker exec "${container}" sh -c "tar -C '$(dirname "${src}")' -czf - '$(basename "${src}")'" > "${archive}"
+    run_in "tar -C '$(dirname "${src}")' -czf - '$(basename "${src}")'" > "${archive}"
   fi
   ls -lh "${archive}"
 }
 
-pack_from_container "${CONTAINER}" "${SW64_SRC}" "${SW64_ARCHIVE}"
-pack_from_container "${CONTAINER}" "${LOONG_SRC}" "${LOONG_ARCHIVE}"
+pack_from_container "${SW64_SRC}" "${SW64_ARCHIVE}"
+pack_from_container "${LOONG_SRC}" "${LOONG_ARCHIVE}"
 
 echo "完成。工具链归档位于 ${OUT_DIR}"
 echo "构建镜像时加 --with-dfss-toolchains 自动内置，或在 Dockerfile 构建上下文放 toolchains/ 目录。"

--- a/docker/verify.sh
+++ b/docker/verify.sh
@@ -105,13 +105,21 @@ echo "--- pqt 系列 (AppImage + windows exe) ---"
 VERSION "qmake (Qt5)"           "qmake --version 2>/dev/null | tail -1"
 CHECK  "libgl1-mesa-dev"        "test -f /usr/include/GL/gl.h"
 CHECK  "fuse"                   "ls /usr/lib/x86_64-linux-gnu/libfuse* >/dev/null 2>&1"
-CHECK  "Qt mingw 静态库"        "test -f /opt/qt-mingw/lib/libQt5Widgets.a"
 CHECK  "mingw posix g++"        "command -v x86_64-w64-mingw32-g++-posix"
+if run "test -f /opt/qt-mingw/lib/libQt5Widgets.a"; then
+  echo "  [PASS] Qt mingw 静态库"
+else
+  echo "  [SKIP] Qt mingw 静态库未内置(基础镜像; 用 --with-qt-mingw 重建)"
+fi
 
 echo "--- pSophUI (aarch64 Qt 5.12.8 交叉) ---"
 VERSION "aarch64 Qt qmake"      "/env/qt_5.12.8_nosysroot/bin/qmake --version 2>/dev/null | tail -1"
-VERSION "Linaro aarch64 gcc"    "/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin/aarch64-linux-gnu-gcc --version | head -1"
-CHECK  "sophui-check"           "sophui-check | grep -q '已就绪'"
+VERSION "aarch64-linux-gnu-gcc" "aarch64-linux-gnu-gcc --version | head -1"
+if run "sophui-check 2>/dev/null" | grep -q "已就绪"; then
+  echo "  [PASS] pSophUI 交叉 Qt 库已就绪"
+else
+  echo "  [SKIP] pSophUI 交叉 Qt 库未内置(基础镜像; 用 --with-sophui-toolchain 重建)"
+fi
 
 echo "--- 打包 / 文档 / 验证工具 ---"
 CHECK  "dpkg-deb"               "dpkg-deb --version"
@@ -190,9 +198,9 @@ if [[ "${DO_CROSS}" = "1" ]]; then
       FAIL=1
     fi
   fi
-  # pSophUI: aarch64 Qt qmake 生成 Makefile + Linaro gcc 可编译(若有交叉 Qt)
+  # pSophUI: aarch64 Qt qmake 生成 Makefile + 系统 aarch64-linux-gnu-gcc 可编译(若有交叉 Qt)
   if run '[ -x /env/qt_5.12.8_nosysroot/bin/qmake ]'; then
-    if run 'export QMAKESPEC=/env/qt_5.12.8_nosysroot/mkspecs/linux-aarch64-gnu-g++ && export PATH=/env/qt_5.12.8_nosysroot/bin:/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu/bin:$PATH && mkdir -p /tmp/pu && cd /tmp/pu && printf "QT += core gui widgets\nCONFIG += c++11\nSOURCES += main.cpp\n" > s.pro && printf "#include <QApplication>\nint main(int argc,char**argv){QApplication a(argc,argv);return 0;}\n" > main.cpp && qmake s.pro >/dev/null 2>&1 && make -s -j2 >/dev/null 2>&1 && file s | grep -q aarch64'; then
+    if run 'export QMAKESPEC=/env/qt_5.12.8_nosysroot/mkspecs/linux-aarch64-gnu-g++ && export PATH=/env/qt_5.12.8_nosysroot/bin:$PATH && mkdir -p /tmp/pu && cd /tmp/pu && printf "QT += core gui widgets\nCONFIG += c++11\nSOURCES += main.cpp\n" > s.pro && printf "#include <QApplication>\nint main(int argc,char**argv){QApplication a(argc,argv);return 0;}\n" > main.cpp && qmake s.pro >/dev/null 2>&1 && make -s -j2 >/dev/null 2>&1 && file s | grep -q aarch64'; then
       echo "  [PASS] pSophUI aarch64 Qt 交叉编译"
     else
       echo "  [FAIL] pSophUI aarch64 Qt 交叉编译"

--- a/docker/versions.env
+++ b/docker/versions.env
@@ -78,16 +78,13 @@ UPX_TARBALL_SHA256="75cab4e57ab72fb4585ee45ff36388d280c7afd72aa03e8d4b9c3cbddb47
 QT_MINGW_NAME="qt-mingw"
 QT_MINGW_ARCHIVE="qt-mingw.tar.zst"
 
-# ---- pSophUI（aarch64 Qt 5.12.8 + Linaro GCC 6.3 交叉工具链）----
-# 来源: 13.24 cross_build_sophon_u20:v1 容器 /env/ 下现成工具链。
+# ---- pSophUI（aarch64 Qt 5.12.8 + 系统 aarch64-linux-gnu-gcc 交叉）----
+# 来源: 13.24 cross_build_sophon_u20:v1 容器 /env/ 下现成 aarch64 Qt 库。
 #   qt_5.12.8_nosysroot  -> /env/qt_5.12.8_nosysroot                (aarch64 Qt 无 sysroot)
-#   gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu
-#                        -> /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu (Linaro GCC 6.3)
+# 编译用系统 apt aarch64-linux-gnu-gcc 9.4（原 Linaro GCC 6.3 已移除，见 source/pSophUI/release.sh）。
 # 通过 docker/scripts/export-sophui-toolchains.sh 从 13.24 cross_build_sophon_u20:v1 导出为
 # sophui-cross-toolchains.tar.zst，放入 docker/toolchains/ 后由 build.sh --with-sophui-toolchain 内置
 # (解压到 /env 原始路径，因 qmake/mkspecs 硬编码绝对路径); 内置后不再依赖独立镜像。
 SOPHUI_QT_NAME="qt_5.12.8_nosysroot"
 SOPHUI_QT_SRC="/env/qt_5.12.8_nosysroot"
-SOPHUI_GCC_NAME="gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
-SOPHUI_GCC_SRC="/env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu"
 SOPHUI_ARCHIVE="sophui-cross-toolchains.tar.zst"


### PR DESCRIPTION
## Summary

修复 **MYS-47** R4 代码 review（dfss 私有工具链 + pqt/pSophUI 集成）发现的问题：docker 脚本与 v1.1.0 单镜像合并后的实现脱节。

### 🟠 应修

1. **verify.sh 可选私有组件 SKIP 统一** — `docker/verify.sh`
   - Qt mingw 静态库、sophui-check 在组件未内置时改 SKIP（原 FAIL），与 dfss 段一致
   - 对默认 `build.sh` 构建的基础镜像跑 `verify.sh` 不再误报 2 个 FAIL

2. **Linaro GCC 6.3 残留引用清理**（统一镜像已改系统 apt aarch64-linux-gnu-gcc 9.4）
   - `verify.sh:113` 删除不存在的 `/env/gcc-linaro-6.3.1-...` 检查，改 `aarch64-linux-gnu-gcc`
   - `verify.sh:195` pSophUI 交叉实测 PATH 去掉 Linaro，改系统 gcc（与 release.sh `CROSS_PREFIX=/usr` 一致）
   - `versions.env` 删除 `SOPHUI_GCC_NAME`/`SOPHUI_GCC_SRC` 变量残留
   - `build.sh:160`、`build-all.sh:104`、`README.md:100` 注释清理

### 🟡 建议收敛

- `Dockerfile` pSophUI 段与 dfss 段语义统一：构建上下文放归档即自动内置
- `build-qt-mingw.sh` 删除重复 `SCRIPT_DIR` 赋值
- `build.sh` qt-mingw 兼容校验改用当前 `FULL_IMAGE`（非固定 `:unified` tag）
- `export-dfss-toolchains.sh` 区分容器/镜像来源，避免镜像名误入 `docker exec`
- `build-dfss-pip.sh` 循环前预检 dfss 工具链，避免前 4 个架构白编

（🟡 make install 一项已由 `d7687ec` 修复，未重复改动）

## Test plan

- [x] 全部脚本 `bash -n` 通过
- [x] `verify.sh` 对基础镜像（无 Qt mingw/pSophUI）：可选组件 SKIP、退出码 0
- [x] `verify.sh --cross` 对完整镜像 unified-v1.1.0：9 项交叉实测全 PASS（含 pSophUI 系统 gcc 编译）
- [x] `grep Linaro` 确认无指向不存在路径/变量的残留