### PR TITLE
fix(docs): 修复 MYS-92 review 问题（文档/脚本与单镜像实现一致性）

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,31 +25,36 @@
 | [ota_update](./source/pota_update) | source/pota_update | 是 | OTA远程刷机工具 |
 | [mem_aging_test](./source/pmem_aging_test) | source/pmem_aging_test | 是 | DDR压测工具 |
 | [autotelecomm](./source/pautotelecomm) | source/pautotelecomm | 是 | 4G/5G自动拨号工具 |
-| [multi_video_qt](./source/pmulti_video_qt) | source/pmulti_video_qt | 否 | QT多路视频解码播放器 |
 | [bm_set_ip](./source/pbm_set_ip) | source/pbm_set_ip | 否 | 配网工具 |
-| [get_info_exporter](./source/pget_info_exporter) | source/pget_info_exporter | 否 | 已并入 bmssm（Prometheus 指标采集） |
+| [phytool](./source/psoph_phytool) | source/psoph_phytool | 是 | 网口 PHY 寄存器读写工具（纯脚本，无编译） |
 | [bmssm](./source/pbmssm) | source/pbmssm | 否 | 设备端后端（:9779）：鉴权/硬件指标/systemd/端口/网络/OTA/文件。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
 | [sophliteos](./source/psophliteos) | source/psophliteos | 否 | 算力设备管理 Web 平台（Go+Vue，:8080），反代 bmssm。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
 
 ## 编译方式
 
-### 一键全量多平台 release（推荐）
+### 一键全量 release（推荐）
 
 本仓库已接入统一构建工程（M1~M4）：16 个子项目全部提供统一接口 `release.sh`，由
-Docker 统一镜像 `sophon-tools-build` 在容器内完成全部多平台编译。**一条命令全量出包**：
+Docker 统一镜像 `sophon-tools-build` 在容器内完成编译。**一条命令全量出包**：
 
 ```bash
 # 前置：统一构建镜像（首次）
-bash docker/build.sh --with-dfss-toolchains   # 完整镜像（含 dfss 私有 sw_64/loongarch64 工具链）
+bash docker/build.sh --with-dfss-toolchains --with-qt-mingw --with-sophui-toolchain   # 完整镜像（含 dfss 私有 sw_64/loongarch64、Qt mingw 静态库、pSophUI 交叉 Qt 库）
 
-# 一键全量 release（所有子项目多平台，Docker 内编译）
+# 一键全量 release（各子项目默认平台，Docker 内编译）
 bash release.sh
 
 # 常用变体
 bash release.sh --project pbmssm            # 单项目快速构建
 bash release.sh --version 2.1.0             # 全量 + 统一版本号
-bash release.sh --project pqt_memory_edit   # 宿主执行（pqt 系列需 docker-in-docker）
+bash release.sh --project pqt_memory_edit   # 宿主执行（pqt 系列在统一镜像内直接构建，无需 docker-in-docker）
 ```
+
+> **平台说明**：默认 `release.sh` 对每个子项目构建其**默认平台**（多数为单平台，
+> 如 pbmssm/pbm_set_ip=arm64、pget_info/pdfss_cpp=amd64；仅 pbmsec/psoph_phytool 默认出全平台）。
+> 需要跨平台出包时，对支持 `all` 的子项目在其源码目录执行 `bash release.sh all`
+> （如 pdfss_cpp 可一次出 amd64/arm64/armbi/loongarch64/riscv64/sw_64/win-amd64/win-i686 8 平台），
+> 或 `bash docker/build-all.sh --arch all` 对支持 `all` 的子项目统一驱动。
 
 构建结束后：
 
@@ -74,4 +79,4 @@ bash release.sh --project pqt_memory_edit   # 宿主执行（pqt 系列需 docke
 * 7z/zip
 * dpkg-deb
 * pandoc
-* docker（统一构建镜像 `sophon-tools-build:m2`）
+* docker（统一构建镜像 `sophon-tools-build:unified`）

--- a/docker/README.md
+++ b/docker/README.md
@@ -205,16 +205,22 @@ cd /workspace/sophon-tools/source/pbmssm
 bash build/build-deb-bmssm.sh   # 需以非 root 用户运行，或改输出目录为可写路径
 ```
 
-## 统一构建入口（M3/M4/M5）：全部子项目一键全量多平台编译
+## 统一构建入口（M3/M4/M5）：全部子项目一键全量编译
 
 每个子项目都提供统一接口的 `release.sh`（M1 规范 v0.1）：
 
 ```bash
 bash release.sh [ARCH] [VERSION]
-#   ARCH:    arm64 | amd64 | all（默认按子项目）
+#   ARCH:    arm64 | amd64 | all（默认按子项目，见各子项目 release.sh）
 #   VERSION: 显式版本号（缺省用子项目版本来源）
 #   env OUTPUT_DIR: 覆盖产物目录（默认 <repo>/output/<子项目>/）
 ```
+
+> **平台说明**：`release.sh` / `build-all.sh` 默认只构建各子项目的**默认平台**
+> （多数为单平台：pbmssm/pbm_set_ip=arm64、pget_info/pdfss_cpp=amd64；仅 pbmsec/psoph_phytool
+> 默认出全平台）。需要跨平台出包时，对支持 `all` 的子项目在其源码目录执行
+> `bash release.sh all`（如 pdfss_cpp 一次出 amd64/arm64/armbi/loongarch64/riscv64/sw_64/win-amd64/win-i686
+> 8 平台），或用 `bash docker/build-all.sh --arch all` 对支持 `all` 的子项目统一驱动。
 
 `docker/build-all.sh` 在镜像内依次驱动全部子项目的 `release.sh`，产物汇聚到仓库根 `output/<子项目>/`：
 
@@ -244,10 +250,10 @@ bash docker/gen-manifest.sh          # -> output/MANIFEST.txt
 ### M4：一条命令全量 release（推荐入口）
 
 仓库根 `release.sh` 是 M4 的一键全量入口，内部依次完成：镜像前置检查 → 驱动
-`build-all.sh` 全量构建 → 生成 `MANIFEST.txt` + `git_hash.txt` + `.build-status.txt`。
+`build-all.sh` 全量构建（各子项目默认平台）→ 生成 `MANIFEST.txt` + `git_hash.txt` + `.build-status.txt`。
 
 ```bash
-bash release.sh                      # 一键全量多平台 release
+bash release.sh                      # 一键全量 release（各子项目默认平台）
 bash release.sh --project pbmssm     # 单项目
 bash release.sh --version 2.1.0      # 统一版本号
 ```
@@ -261,8 +267,11 @@ bash release.sh --version 2.1.0      # 统一版本号
 ```
 子项目                | 文件名                                            | 架构           | 版本      | md5
 pbmssm               | bmssm_2.1.0_arm64.deb                             | arm64          | 2.1.0     | db83...
-pdfss_cpp            | dfss-cpp-linux-loongarch64                        | loongarch64    | 1.10.5    | ...
+pdfss_cpp            | dfss-cpp-linux-loongarch64                        | loongarch64    | unknown   | ...
 ```
+
+版本列从**文件名**提取（`v?<数字>.<数字>[.<数字>]`），文件名不含版本号的一律记 `unknown`
+（如 `dfss-cpp-linux-loongarch64` 无版本后缀，即 `unknown`）。
 
 架构判定优先级：文件名关键字 → `.deb` 包 `Architecture` 字段 → `file` ELF/PE 探测。
 

--- a/docker/gen-manifest.sh
+++ b/docker/gen-manifest.sh
@@ -35,7 +35,15 @@ detect_arch() {
   case "$name" in
     *win*amd64*|*win*x86_64*) echo "win-amd64"; return ;;
     *win*i686*|*win*32*)      echo "win-i686"; return ;;
-    *\.exe)                   echo "win-amd64"; return ;;
+    # 无 win 关键字的 .exe：用 file 探测区分 PE32+ / PE32（不再无条件 win-amd64）
+    *\.exe)
+      local ftype
+      ftype="$(file -b "$path" 2>/dev/null)"
+      case "$ftype" in
+        *PE32+*) echo "win-amd64"; return ;;
+        *PE32*)  echo "win-i686"; return ;;
+      esac
+      echo "win-amd64"; return ;;
     *arm64*|*aarch64*|*_arm64*)  echo "arm64"; return ;;
     *amd64*|*x86_64*|*x86-64*)   echo "amd64"; return ;;
     *armbi*) echo "armbi"; return ;;

--- a/release.sh
+++ b/release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # =============================================================================
-# sophon-tools 一键全量多平台 release（M4 统一入口 / M5 单镜像）
+# sophon-tools 一键全量 release（M4 统一入口 / M5 单镜像；各子项目默认平台）
 #
 # 用法:
 #   bash release.sh [--project <子项目>] [--version <版本号>] [--no-image-check]
@@ -8,8 +8,8 @@
 # 行为:
 #   1. 检查统一构建镜像 sophon-tools-build:unified（M5 单镜像, ubuntu:20.04 基座）
 #      是否可用；缺失时提示用 `bash docker/build.sh` 构建（不自动构建，避免长时间阻塞）。
-#   2. 驱动 docker/build-all.sh 对全部子项目做多平台构建（失败隔离：单项目
-#      失败不阻塞整体，结束后列出失败项，非零退出）。
+#   2. 驱动 docker/build-all.sh 对全部子项目做构建（各子项目默认平台；失败隔离：
+#      单项目失败不阻塞整体，结束后列出失败项，非零退出）。
 #   3. 汇聚产物到 output/<子项目>/（保持既有 output 约定），并生成:
 #        - output/MANIFEST.txt   产物清单（子项目/文件名/架构/版本/md5）
 #        - output/git_hash.txt   构建时仓库 HEAD
@@ -65,8 +65,8 @@ if [[ -z "${NO_IMAGE_CHECK:-}" ]]; then
     echo "ERROR: 统一构建镜像 ${IMAGE} 不存在。" >&2
     echo "       获取方式（按优先级）:" >&2
     echo "         1) 从 dfss 服务器拉取已构建镜像（推荐，免本地构建）:" >&2
-    echo "            python3 -m dfss --url=open@sophgo.com:/<dfss路径>/${IMAGE#*:}.tar.zst" >&2
-    echo "            docker load -i ${IMAGE#*:}.tar.zst" >&2
+    echo "            python3 -m dfss --url=open@sophgo.com:/<dfss路径>/${IMAGE%%:*}-${IMAGE#*:}.tar.zst" >&2
+    echo "            docker load -i ${IMAGE%%:*}-${IMAGE#*:}.tar.zst" >&2
     echo "         2) 本地构建: bash docker/build.sh [--with-dfss-toolchains]" >&2
     echo "         3) 指定已有镜像: bash release.sh --image <镜像名>" >&2
     exit 1

--- a/source/pSophUI/release.sh
+++ b/source/pSophUI/release.sh
@@ -7,7 +7,7 @@
 #   env QT_CROSS_PREFIX: aarch64 Qt 交叉安装前缀
 #     默认 /env/qt_5.12.8_nosysroot（13.24 cross_build_sophon_u20 容器同款）
 #   env CROSS_PREFIX: aarch64 交叉编译器前缀
-#     默认 /env/gcc-linaro-6.3.1-2017.05-x86_64_aarch64-linux-gnu（Linaro GCC 6.3）
+#     默认 /usr（系统 apt aarch64-linux-gnu-gcc 9.4；Linaro GCC 6.3 已移除）
 # 说明: 工程自带 lxqt qtermwidget arm64 静态库 + Makefile 为 qmake 生成物。
 #       本脚本用 qmake 重新生成 Makefile（消除 /env/qt_fl2000 绝对路径依赖），
 #       再 make 出 arm64 二进制并打 deb。


### PR DESCRIPTION
## Summary
按 MYS-48（R5）review 修复文档/脚本与 v1.1.0 单镜像合并后实现不一致，覆盖全部 8 项 🟠 + 4 项同主题 🟡：

- **README.md**
  - 编译依赖旧镜像名 `sophon-tools-build:m2` → `sophon-tools-build:unified`（🟠4）
  - 完整镜像命令补 `--with-qt-mingw --with-sophui-toolchain`（🟠5）
  - "一键全量多平台"改为"一键全量（各子项目默认平台）"并补充跨平台出包方式（🟠7）
  - pqt docker-in-docker 说明更新为统一镜像内直接构建（🟡4）
  - 子项目表移除 multi_video_qt/get_info_exporter、补 psoph_phytool（🟡5）
- **release.sh**
  - dfss 手动拉取文件名修正为 `<image>-<tag>.tar.zst`（🟠6）
  - 头部/行为说明对齐默认平台语义
- **docker/README.md**
  - 统一构建入口平台说明 + M4 段落对齐默认行为（🟠7）
  - MANIFEST 示例版本列修正：无版本号文件名 → `unknown`（🟠8）
- **docker/gen-manifest.sh**
  - `.exe` 不再无条件 win-amd64，用 `file` 探测区分 PE32+/PE32（🟡6）
- **source/pSophUI/release.sh**
  - CROSS_PREFIX 注释默认值改为 `/usr`（Linaro GCC 6.3 已移除）（🟡3）

## 验证
- 3 个改动脚本 `bash -n` 全部通过
- `docker/verify.sh` 与 `--cross` 对 `unified-v1.1.0` 镜像：基础自检 + 9 项交叉实测全 PASS，退出码 0
- gen-manifest `detect_arch`/`detect_ver` 实测：`real-i686.exe`→win-i686（修复前误标 win-amd64）、`dfss-cpp-linux-loongarch64`→unknown，与文档示例一致

## 覆盖说明
🟠1-3（verify.sh Linaro 检查 / build.sh 文案 / docker/README.md 表格矛盾）已由 PR #50（MYS-91）先行修复，本 PR 复核确认无残留。