### PR TITLE
docs(readme): 删除「是否支持一键编译」列，统一编译环境已就位

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,24 +11,24 @@
 
 ## 子项目介绍
 
-| 子项目名称 | 源码路径 | 是否支持一键编译 | 简介 |
-| --- | --- | --- | --- |
-| [bmsec](./source/pbmsec) | source/pbmsec | 是 | 用于SE6/8高密度服务器的易用性命令行工具 |
-| [socbak](./source/psocbak)   | source/psocbak | 是 | 用于BM1684/BM1684X/BM1688/CV186AH芯片刷机包打包 |
-| [get_info](./source/pget_info) | source/pget_info | 是 | 用于获取BM1684/BM1684X/BM1688/CV186AH芯片的性能指标 |
-| [memory_edit](./source/pmemory_edit) | source/pmemory_edit | 是 | 用于修改BM1684/BM1684X/BM1688/CV186AH的设备内存布局 |
-| [qt_memory_edit](./source/pqt_memory_edit) | source/pqt_memory_edit | 否 | 图形化的远程修改设备内存布局的工具 |
-| [qt_batch_deployment](./source/pqt_batch_deployment) | source/pqt_batch_deployment | 否 | 基于SSH的批量部署工具 |
-| [dfss_cpp](./source/pdfss_cpp) | source/pdfss_cpp | 否 | DFSS工具CPP工程 |
-| [spacc_efuse_demo](./source/pspacc_efuse_demo) | source/pspacc_efuse_demo | 否 | efuse+spacc加解密Demo |
-| [SophUI](./source/pSophUI) | source/pSophUI | 否 | HDMI配网页面工程 |
-| [ota_update](./source/pota_update) | source/pota_update | 是 | OTA远程刷机工具 |
-| [mem_aging_test](./source/pmem_aging_test) | source/pmem_aging_test | 是 | DDR压测工具 |
-| [autotelecomm](./source/pautotelecomm) | source/pautotelecomm | 是 | 4G/5G自动拨号工具 |
-| [bm_set_ip](./source/pbm_set_ip) | source/pbm_set_ip | 否 | 配网工具 |
-| [phytool](./source/psoph_phytool) | source/psoph_phytool | 是 | 网口 PHY 寄存器读写工具（纯脚本，无编译） |
-| [bmssm](./source/pbmssm) | source/pbmssm | 否 | 设备端后端（:9779）：鉴权/硬件指标/systemd/端口/网络/OTA/文件。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
-| [sophliteos](./source/psophliteos) | source/psophliteos | 否 | 算力设备管理 Web 平台（Go+Vue，:8080），反代 bmssm。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
+| 子项目名称 | 源码路径 | 简介 |
+| --- | --- | --- |
+| [bmsec](./source/pbmsec) | source/pbmsec | 用于SE6/8高密度服务器的易用性命令行工具 |
+| [socbak](./source/psocbak)   | source/psocbak | 用于BM1684/BM1684X/BM1688/CV186AH芯片刷机包打包 |
+| [get_info](./source/pget_info) | source/pget_info | 用于获取BM1684/BM1684X/BM1688/CV186AH芯片的性能指标 |
+| [memory_edit](./source/pmemory_edit) | source/pmemory_edit | 用于修改BM1684/BM1684X/BM1688/CV186AH的设备内存布局 |
+| [qt_memory_edit](./source/pqt_memory_edit) | source/pqt_memory_edit | 图形化的远程修改设备内存布局的工具 |
+| [qt_batch_deployment](./source/pqt_batch_deployment) | source/pqt_batch_deployment | 基于SSH的批量部署工具 |
+| [dfss_cpp](./source/pdfss_cpp) | source/pdfss_cpp | DFSS工具CPP工程 |
+| [spacc_efuse_demo](./source/pspacc_efuse_demo) | source/pspacc_efuse_demo | efuse+spacc加解密Demo |
+| [SophUI](./source/pSophUI) | source/pSophUI | HDMI配网页面工程 |
+| [ota_update](./source/pota_update) | source/pota_update | OTA远程刷机工具 |
+| [mem_aging_test](./source/pmem_aging_test) | source/pmem_aging_test | DDR压测工具 |
+| [autotelecomm](./source/pautotelecomm) | source/pautotelecomm | 4G/5G自动拨号工具 |
+| [bm_set_ip](./source/pbm_set_ip) | source/pbm_set_ip | 配网工具 |
+| [phytool](./source/psoph_phytool) | source/psoph_phytool | 网口 PHY 寄存器读写工具（纯脚本，无编译） |
+| [bmssm](./source/pbmssm) | source/pbmssm | 设备端后端（:9779）：鉴权/硬件指标/systemd/端口/网络/OTA/文件。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
+| [sophliteos](./source/psophliteos) | source/psophliteos | 算力设备管理 Web 平台（Go+Vue，:8080），反代 bmssm。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
 
 ## 编译方式
 
@@ -70,10 +70,10 @@ bash release.sh --project pqt_memory_edit   # 宿主执行（pqt 系列在统一
 
 ### 传统方式（单子项目）
 
-1. 支持一键编译的子项目在本目录下执行 `release.sh` 后会将成果输出到 `output` 目录
-2. 不支持一键编译的子项目请参考源码目录中的 `readme.md` 自行准备环境编译
+在子项目源码目录下执行 `release.sh`（由统一 Docker 镜像 `sophon-tools-build` 在容器内编译），
+成果输出到 `output` 目录。需要自行准备环境时，参考源码目录中的 `readme.md`。
 
-## 一键编译的子项目的编译依赖
+## 编译依赖
 
 * 编译主机架构:amd64
 * 7z/zip

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,14 +42,14 @@ bash docker/build.sh --with-dfss-toolchains --with-qt-mingw --with-sophui-toolch
 dfss 下载细节：
 
 - dfss 文件名约定 `<镜像名>-<tag>.tar.zst`（冒号不适合文件路径，用 `-` 分隔）
-- 默认 dfss 路径前缀 `open@sophgo.com:/`，可用环境变量 `DFSS_IMAGE_BASE` 覆盖：
+- 默认 dfss 路径前缀 `open@sophgo.com:/toolchains/sophon-tools/`，可用环境变量 `DFSS_IMAGE_BASE` 覆盖：
   `DFSS_IMAGE_BASE=open@sophgo.com:/some/path bash docker/build.sh --from-dfss`
 - 依赖 `python3 -m dfss`（dfss-cpp 客户端），从 sophgo sftp 服务器下载
 
 ### 手动拉取（等价命令）
 
 ```bash
-python3 -m dfss --url=open@sophgo.com:/sophon-tools-build-unified-v1.1.0.tar.zst
+python3 -m dfss --url=open@sophgo.com:/toolchains/sophon-tools/sophon-tools-build-unified-v1.1.0.tar.zst
 docker load -i sophon-tools-build-unified-v1.1.0.tar.zst
 # 加载后镜像 tag: sophon-tools-build:unified-v1.1.0
 ```

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -58,7 +58,7 @@ FULL_IMAGE="${IMAGE_NAME}:${TAG}"
 # ---- 从 dfss 服务器拉取已构建镜像 ----
 # dfss 文件名为 <image>-<tag>.tar.zst（冒号不适合文件路径，用 - 分隔）
 DFSS_FILE="${IMAGE_NAME}-${TAG}.tar.zst"
-DFSS_IMAGE_PATH="${DFSS_IMAGE_PATH:-${DFSS_IMAGE_BASE:-open@sophgo.com:/}${DFSS_FILE}}"
+DFSS_IMAGE_PATH="${DFSS_IMAGE_PATH:-${DFSS_IMAGE_BASE:-open@sophgo.com:/toolchains/sophon-tools/}${DFSS_FILE}}"
 
 fetch_from_dfss() {
   echo "==> 从 dfss 拉取已构建镜像 ${FULL_IMAGE} ..."


### PR DESCRIPTION
## Summary

16 个子项目已全部接入统一 Docker 构建镜像 `sophon-tools-build` 的 `release.sh`（M1~M4 统一编译工程），
README 子项目表格中「是否支持一键编译」的「是/否」区分已完全过时。本次删除该列并收敛相关描述：

- **子项目介绍表格**：删除「是否支持一键编译」整列（表头 + 16 行值）
- **传统方式（单子项目）**：删掉按「支持/不支持」区分的旧表述，统一为各子项目均有 `release.sh`（Docker 内编译）
- **小节标题**：「一键编译的子项目的编译依赖」→「编译依赖」

## 背景

统一编译工程下所有子项目都提供 `release.sh` 统一接口，由统一镜像在容器内完成编译，
「不支持一键编译」的子项目已不存在。