### PR TITLE
fix(pqt): 消除重复产物 — AppImage/exe 各只产出一份

### DIFF
--- a/docker/pqt/build-pqt.sh
+++ b/docker/pqt/build-pqt.sh
@@ -151,6 +151,14 @@ build_linux() {
 build_windows() {
   echo "==> windows 端交叉编译..."
   prepare_memory_edit_tarxz
+  # 产物基线名（无版本号）：裸名 exe 由 CMake install(TARGETS) 生成，是中间产物；
+  # 最终交付的是带版本号的 <basename>_<ver>.exe，收拢时只保留后者。
+  local exe_basename
+  case "$PROJECT" in
+    pqt_memory_edit) exe_basename="qt_mem_edit.exe" ;;
+    pqt_batch_deployment) exe_basename="qt_batch_deployment.exe" ;;
+    *) exe_basename="" ;;
+  esac
   local qt_prefix="${QT_PREFIX:-/opt/qt-mingw}"
   # 确保 Qt mingw 静态库存在
   if [[ ! -f "${qt_prefix}/lib/libQt5Widgets.a" ]]; then
@@ -194,9 +202,10 @@ TOOL
     make install
     echo "==> windows exe 产物:"
     find . -maxdepth 3 -name '*.exe' | head -5
-    # 收拢最终 exe 到 OUTPUT_DIR 根，清理构建中间产物（先 cd 出去再删，避免删除当前工作目录）
+    # 收拢最终 exe 到 OUTPUT_DIR 根（只留带版本号的 exe，排除裸名中间产物），
+    # 清理构建中间产物（先 cd 出去再删，避免删除当前工作目录）
     local out_root="${wdir%/.build-win}"
-    find . -maxdepth 3 -name '*.exe' -exec cp -f {} "${out_root}"/ \;
+    find . -maxdepth 3 -name '*.exe' ! -name "${exe_basename}" -exec cp -f {} "${out_root}"/ \;
     cd "${out_root}"
     rm -rf "${wdir}" 2>/dev/null || sudo rm -rf "${wdir}" 2>/dev/null || true
     return 0
@@ -213,6 +222,7 @@ TOOL
     -v "${qt_prefix}":/opt/qt-mingw \
     -e PQT_WIN_OUT="/pqt-win-output" \
     -e PQT_VERSION="${VERSION}" \
+    -e EXE_BASENAME="${exe_basename}" \
     "${image}" bash -c '
       set -e
       export DEBIAN_FRONTEND=noninteractive
@@ -253,9 +263,10 @@ TOOL
       make install
       echo "==> windows exe 产物:"
       find . -maxdepth 3 -name '*.exe' | head -5
-      # 收拢最终 exe 到输出根目录（挂载的 /pqt-out-root = OUTPUT_DIR），构建中间产物留在 .build-win
+      # 收拢最终 exe 到输出根目录（挂载的 /pqt-out-root = OUTPUT_DIR），
+      # 只留带版本号的 exe，排除裸名中间产物；构建中间产物留在 .build-win
       mkdir -p /pqt-out-root
-      find . -maxdepth 3 -name '*.exe' -exec cp -f {} /pqt-out-root/ \;
+      find . -maxdepth 3 -name '*.exe' ! -name "${EXE_BASENAME}" -exec cp -f {} /pqt-out-root/ \;
     '
 
   # 构建中间产物（.build-win）留在宿主 wdir，构建完成后清理

--- a/source/pqt_batch_deployment/linux_release.sh
+++ b/source/pqt_batch_deployment/linux_release.sh
@@ -66,11 +66,11 @@ pushd bintools/linuxdeployqt-continuous >/dev/null
 qmake -config release
 make -j"$(nproc)"
 popd >/dev/null # linuxdeployqt-continuous
-# linuxdeployqt -appimage 会调用 PATH 里的 appimagetool；容器内可能缺失，失败时容忍
-# （打包由下方手动 appimagetool 完成，与原脚本行为一致）
+# linuxdeployqt 用 -bundle-non-qt-libs 只做依赖收集（不 -appimage 打包），
+# 避免同一 AppDir 被打出多份 AppImage（-appimage 会附加 git hash 到文件名）。
+# 最终 AppImage 由下方手动 appimagetool 一次性生成（no_ui 不作为独立产物，见 MYSWY 决定）。
 export PATH="$WORK_DIR/build/bintools:$PATH"
-./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment_no_ui.desktop -appimage -verbose=2 || true
-./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment.desktop -appimage -verbose=2 || true
+./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_batch_deployment.desktop -bundle-non-qt-libs -verbose=2 || true
 sed -i "s/Exec=qt_batch_deployment/Exec=qt_batch_deployment_run.sh/" Appdir/qt_batch_deployment.desktop
 rm Appdir/qt_batch_deployment_no_ui.desktop
 rm Appdir/qt_batch_deployment_no_ui.png

--- a/source/pqt_memory_edit/linux_release.sh
+++ b/source/pqt_memory_edit/linux_release.sh
@@ -54,10 +54,12 @@ tar -xaf "$WORK_DIR/appimage/bintools/linuxdeployqt.tar.gz" -C "$WORK_DIR/appima
 
 pushd "$WORK_DIR/appimage" >/dev/null
 # linuxdeployqt 为源码包，需现场 qmake+make；编译/运行失败即退出，
-# 否则 AppImage 缺 Qt 库且不报错（依赖库收集由它完成）
+# 否则 AppImage 缺 Qt 库且不报错（依赖库收集由它完成）。
+# 用 -bundle-non-qt-libs 只做依赖收集（不 -appimage 打包），
+# 最终 AppImage 由下方手动 appimagetool 一次性生成，避免同一 AppDir 打出两份。
 (cd bintools/linuxdeployqt-continuous && qmake linuxdeployqt.pro && make -j"$(nproc)")
 export PATH="$PWD/bintools:$PATH"
-./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_mem_edit.desktop -appimage -verbose=2
+./bintools/linuxdeployqt-continuous/bin/linuxdeployqt Appdir/qt_mem_edit.desktop -bundle-non-qt-libs -verbose=2
 ./bintools/appimagetool --comp xz Appdir
 cp ./*.AppImage "$WORK_DIR"/
 popd >/dev/null # appimage


### PR DESCRIPTION
## Summary

修复 pqt 两项目（pqt_memory_edit / pqt_batch_deployment）一键编译后产物重复的问题。

## 根因

- **linux AppImage**：`linux_release.sh` 对同一 AppDir 打两次包——
  1. `linuxdeployqt -appimage`（内部调 `appimagetool -g`，从 git HEAD 附加 hash）→ `qt_*_<ver>-<hash>_<arch>.AppImage`
  2. 手动 `appimagetool --comp xz Appdir` → `qt_*_<ver>_<arch>.AppImage`
  → 两份 AppImage，大小不同。
- **windows exe**：CMakeLists 静态分支 `install(CODE)` 生成带版本名 `<name>_<ver>.exe`，通用 `install(TARGETS)` 又生成裸名 `<name>.exe` → 两个 exe。

## 修复

- `linux_release.sh`（两项目）：`linuxdeployqt -appimage` → `-bundle-non-qt-libs`（只做依赖收集，不打包），最终 AppImage 只由手动 `appimagetool` 生成一次
- batch 的 no_ui **不作为独立产物**（no_ui 二进制仍含于 GUI AppImage，由 run.sh 按参数分派）
- `build-pqt.sh`：windows 收拢排除裸名 exe（`install(TARGETS)` 中间产物），只保留带版本号的最终 exe

## 验证（unified-v1.1.0 实测）

| 项目 | 修复前 | 修复后 |
|---|---|---|
| pqt_batch_deployment | 5 个（2 GUI AppImage + no_ui + 2 exe） | `qt_batch_deployment_1.4.1.exe` + `qt_batch_deployment_1.4.1-x86_64.AppImage` |
| pqt_memory_edit | 重复 AppImage + 2 exe | `qt_mem_edit_2.12.1.exe` + `qt_mem_edit_V2.12.1-x86_64.AppImage` |

AppImage 内仍含 no_ui 二进制与 run.sh 分派，功能完整。