### PR TITLE
feat(bmssm): 适配 CV84X2（cv84x6）芯片

### DIFF
--- a/source/pbmssm/pkg/device/devinfo.go
+++ b/source/pbmssm/pkg/device/devinfo.go
@@ -125,13 +125,19 @@ func LoadFromOEM(path string) {
 // readSnFromRaw 按 CPU 型号从原始设备路径读 SN，覆盖 OEMconfig 解析值（仅成功覆盖）。
 // 与 get_info.sh 的 SN 分支一致：
 //
-//	bm1688/cv186ah → /dev/mmcblk0boot1 offset 0/32
+//	bm1688/cv186ah/cv84x6 → /dev/mmcblk0boot1 offset 0/32
 //	bm1684x/bm1684 → nvmem offset 0/512
 func readSnFromRaw() {
-	cm := ReadCpuModel(CpuInfoPath)
+	readSnFromRawWithPaths(CpuInfoPath, Mmcblk0Boot1Path, NvmemSnPath)
+}
+
+// readSnFromRawWithPaths 接受注入路径的 readSnFromRaw 实现（测试用）。
+// CV84X2 与 bm1688 布局一致，SN 从 mmcblk0boot1 读取。
+func readSnFromRawWithPaths(cpuinfo, boot1, nvmem string) {
+	cm := ReadCpuModel(cpuinfo)
 	switch {
-	case cm == "bm1688" || cm == "cv186ah":
-		if chip, dev := readSnFromMmcblkBoot1(Mmcblk0Boot1Path); chip != "" || dev != "" {
+	case cm == "bm1688" || cm == "cv186ah" || cm == "cv84x6":
+		if chip, dev := readSnFromMmcblkBoot1(boot1); chip != "" || dev != "" {
 			if chip != "" {
 				ChipSn = chip
 			}
@@ -140,7 +146,7 @@ func readSnFromRaw() {
 			}
 		}
 	case cm == "bm1684x" || cm == "bm1684":
-		if chip, dev := readSnFromNvmem(NvmemSnPath); chip != "" || dev != "" {
+		if chip, dev := readSnFromNvmem(nvmem); chip != "" || dev != "" {
 			if chip != "" {
 				ChipSn = chip
 			}

--- a/source/pbmssm/pkg/device/devinfo_test.go
+++ b/source/pbmssm/pkg/device/devinfo_test.go
@@ -442,3 +442,37 @@ Features : fp asimd`
 		t.Errorf("cpuModel=%q, want bm1688", got)
 	}
 }
+
+// TestReadSnFromRawCv84x6 CV84X2 芯片型号 cv84x6 时，SN 应从 mmcblk0boot1 offset 0/32 读取
+// （与 bm1688 布局一致），而非 nvmem。
+func TestReadSnFromRawCv84x6(t *testing.T) {
+	dir := t.TempDir()
+
+	// 模拟 /proc/cpuinfo 为 cv84x6
+	cpuinfo := filepath.Join(dir, "cpuinfo")
+	if err := os.WriteFile(cpuinfo, []byte("model name : cv84x6\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 模拟 mmcblk0boot1：offset 0 chipSn，offset 32 deviceSn
+	boot1 := filepath.Join(dir, "boot1")
+	buf := make([]byte, 64)
+	copy(buf[0:], []byte("CV84X6CHIPSN001"))
+	copy(buf[32:], []byte("CV84X6DEVSN001"))
+	if err := os.WriteFile(boot1, buf, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// nvmem 路径不存在——若误走 nvmem 分支则 SN 为空
+	nvmem := filepath.Join(dir, "no-such-nvmem")
+
+	resetGlobals()
+	readSnFromRawWithPaths(cpuinfo, boot1, nvmem)
+
+	if ChipSn != "CV84X6CHIPSN001" {
+		t.Errorf("ChipSn=%q, want CV84X6CHIPSN001", ChipSn)
+	}
+	if DeviceSnEx != "CV84X6DEVSN001" {
+		t.Errorf("DeviceSnEx=%q, want CV84X6DEVSN001", DeviceSnEx)
+	}
+}

--- a/source/pbmssm/pkg/metrics/accelerator.go
+++ b/source/pbmssm/pkg/metrics/accelerator.go
@@ -31,7 +31,7 @@ func (c *Collector) VPUUsage() (enc, dec, encLinks, decLinks int64, ok bool) {
 	switch chip {
 	case "bm1684", "bm1684x":
 		path = vpuInfoPath
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		path = vpuInfoSophPath
 	default:
 		return 0, 0, 0, 0, false
@@ -64,7 +64,7 @@ func (c *Collector) VPUUsage() (enc, dec, encLinks, decLinks int64, ok bool) {
 			decLinks = links[0] + links[1]
 			ok = true
 		}
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		if len(percents) == 3 && len(links) == 3 {
 			enc = percents[0]
 			dec = (percents[1] + percents[2]) / 2
@@ -98,7 +98,7 @@ func (c *Collector) vppInfoPath() string {
 	switch c.ChipType() {
 	case "bm1684", "bm1684x":
 		return vppInfoPath
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		return vppInfoSophPath
 	}
 	return ""
@@ -108,7 +108,7 @@ func (c *Collector) jpuInfoPath() string {
 	switch c.ChipType() {
 	case "bm1684", "bm1684x":
 		return jpuInfoPath
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		return jpuInfoSophPath
 	}
 	return ""
@@ -135,14 +135,17 @@ func (c *Collector) parsePipePercent(path string) int64 {
 const (
 	tpuClkPathBm1684 = "/sys/kernel/debug/clk/tpll_clock/clk_rate"
 	tpuClkPathBm1688 = "/sys/kernel/debug/clk/clk_tpll/clk_rate"
+	tpuClkPathCv84x6 = "/sys/kernel/debug/clk/clk_tpu_ip/clk_rate"
 	vpuClkPathBm1684 = "/sys/kernel/debug/clk/clk_gate_axi10/clk_rate"
 	vpuClkPathBm1688 = "/sys/kernel/debug/clk/clk_cam0pll/clk_rate"
+	vpuClkPathCv84x6 = "/sys/kernel/debug/clk/clk_ve_axi/clk_rate"
 	cpuClkPathBm1684 = "/sys/kernel/debug/clk/clk_div_a53_1/clk_rate"
 	cpuClkPathBm1688 = "/sys/kernel/debug/clk/clk_a53pll/clk_rate"
+	cpuClkPathCv84x6 = "/sys/kernel/debug/clk/clk_ap_ca55/clk_rate"
 )
 
 // TPUFrequencyClk 读取 TPU 时钟频率 (Hz → MHz)。
-// 对齐 pget_info TPU_CLK。
+// 对齐 pget_info TPU_CLK。CV84X2 时钟名为 clk_tpu_ip。
 func (c *Collector) TPUFrequencyClk() int64 {
 	chip := c.ChipType()
 	var path string
@@ -151,6 +154,8 @@ func (c *Collector) TPUFrequencyClk() int64 {
 		path = tpuClkPathBm1684
 	case "bm1688", "cv186ah":
 		path = tpuClkPathBm1688
+	case "cv84x6":
+		path = tpuClkPathCv84x6
 	default:
 		return 0
 	}
@@ -158,7 +163,8 @@ func (c *Collector) TPUFrequencyClk() int64 {
 }
 
 // VPUFrequency 读取 VPU 时钟频率 (Hz → MHz)。
-// 对齐 pget_info VPU_CLK。bm1688/cv186ah 需 /2。
+// 对齐 pget_info VPU_CLK。bm1688/cv186ah 需 /2；CV84X2 的 clk_ve_axi 是 AXI 总线时钟，
+// 语义不同不除（真机实测核对后可调整）。
 func (c *Collector) VPUFrequency() int64 {
 	chip := c.ChipType()
 	var path string
@@ -167,6 +173,8 @@ func (c *Collector) VPUFrequency() int64 {
 		path = vpuClkPathBm1684
 	case "bm1688", "cv186ah":
 		path = vpuClkPathBm1688
+	case "cv84x6":
+		path = vpuClkPathCv84x6
 	default:
 		return 0
 	}
@@ -180,6 +188,7 @@ func (c *Collector) VPUFrequency() int64 {
 // CPUFrequencyClk 读取 CPU 时钟频率 (Hz → MHz)，sysfs 方式。
 // 与 cpuFrequency 不同，此方法读 debugfs clk 而非 cpuinfo/scaling_cur_freq。
 // 互补：scaling_cur_freq 反映实际频率，debugfs clk 反映基础时钟。
+// CV84X2 时钟名为 clk_ap_ca55。
 func (c *Collector) CPUFrequencyClk() int64 {
 	chip := c.ChipType()
 	var path string
@@ -188,6 +197,8 @@ func (c *Collector) CPUFrequencyClk() int64 {
 		path = cpuClkPathBm1684
 	case "bm1688", "cv186ah":
 		path = cpuClkPathBm1688
+	case "cv84x6":
+		path = cpuClkPathCv84x6
 	default:
 		return 0
 	}

--- a/source/pbmssm/pkg/metrics/accelerator_test.go
+++ b/source/pbmssm/pkg/metrics/accelerator_test.go
@@ -2,6 +2,82 @@ package metrics
 
 import "testing"
 
+func TestVPUUsageCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/proc/soph/vpuinfo": `{"enc": {"link_num":3, "usage":40%}
+{"dec_0": {"link_num":2, "usage":50%}
+{"dec_1": {"link_num":4, "usage":60%}`,
+	}}
+	c := NewCollector(fr, nil)
+	enc, dec, encLinks, decLinks, ok := c.VPUUsage()
+	if !ok {
+		t.Fatal("VPUUsage() returned ok=false for cv84x6")
+	}
+	if enc != 40 || dec != 55 {
+		t.Errorf("VPUUsage enc=%d dec=%d, want 40/55", enc, dec)
+	}
+	if encLinks != 3 || decLinks != 6 {
+		t.Errorf("VPUUsage links enc=%d dec=%d, want 3/6", encLinks, decLinks)
+	}
+}
+
+func TestVPUUsageCv84x6SophInfo(t *testing.T) {
+	// 对齐方案 §4.4：vc_drv 输出 JSON 行，字段名不敏感，仅 link_num/usage 正则参与解析。
+	// 行数要求与 bm1688 分支一致（3 行：enc + 2 dec），enc 在首行。
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/proc/soph/vpuinfo": `{"venc_coreid":0, "link_num":3, "usage(instant|long)":40%|10%, "fps":30, "status:Engaged"}
+{"vdec_coreid":1, "link_num":2, "usage(instant|long)":50%|20%, "fps":30, "status:IDLE"}
+{"vdec_coreid":2, "link_num":4, "usage(instant|long)":60%|30%, "fps":30, "status:IDLE"}`,
+	}}
+	c := NewCollector(fr, nil)
+	enc, dec, encLinks, decLinks, ok := c.VPUUsage()
+	if !ok {
+		t.Fatal("VPUUsage() returned ok=false for cv84x6 soph format")
+	}
+	if enc != 40 || dec != 55 {
+		t.Errorf("VPUUsage enc=%d dec=%d, want enc=40 dec=55", enc, dec)
+	}
+	if encLinks != 3 || decLinks != 6 {
+		t.Errorf("VPUUsage links enc=%d dec=%d, want 3/6", encLinks, decLinks)
+	}
+}
+
+func TestTPUFrequencyClkCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/sys/kernel/debug/clk/clk_tpu_ip/clk_rate": "1000000000\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.TPUFrequencyClk(); got != 1000 {
+		t.Errorf("TPUFrequencyClk() = %d, want 1000 MHz", got)
+	}
+}
+
+func TestVPUFrequencyCv84x6(t *testing.T) {
+	// clk_ve_axi 是 AXI 总线时钟，语义与 bm1688 cam0pll 不同，不 ÷2。
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/sys/kernel/debug/clk/clk_ve_axi/clk_rate": "500000000\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.VPUFrequency(); got != 500 {
+		t.Errorf("VPUFrequency() = %d, want 500 MHz (no /2)", got)
+	}
+}
+
+func TestCPUFrequencyClkCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/sys/kernel/debug/clk/clk_ap_ca55/clk_rate": "1500000000\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.CPUFrequencyClk(); got != 1500 {
+		t.Errorf("CPUFrequencyClk() = %d, want 1500 MHz", got)
+	}
+}
+
 func TestVPUUsageBM1684X(t *testing.T) {
 	// BM1684X: 3 entries, enc at index 2 (last). Rust: enc=percentages[2], dec=avg([0..2]).
 	fr := &fakeFileReader{files: map[string]string{

--- a/source/pbmssm/pkg/metrics/chip_capacity.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity.go
@@ -8,6 +8,7 @@ import "strings"
 //
 //	BM1684X (0x1686)      → 32 TOPS, chipType 2
 //	BM1688  (0x1688)      → 16 TOPS, chipType 3
+//	CV84X6  (0x1694)      → 16 TOPS, chipType 3  (占位，对齐 BM1688 档位；真机确认后修正)
 //	BM1684  (non-X)       → 16 TOPS, chipType 1
 //	unknown / empty       → 16 TOPS, chipType 1  (bmssm default branch)
 //
@@ -15,6 +16,8 @@ import "strings"
 func ChipCapacity(chipModel string) (calcCapacity float64, chipType int) {
 	upper := strings.ToUpper(chipModel)
 	switch {
+	case strings.Contains(upper, "84X6"):
+		return 16, 3
 	case strings.Contains(upper, "1686") || strings.Contains(upper, "1684X"):
 		return 32, 2
 	case strings.Contains(upper, "1688"):

--- a/source/pbmssm/pkg/metrics/chip_capacity_test.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity_test.go
@@ -69,6 +69,24 @@ func TestChipCapacity(t *testing.T) {
 			wantCalcCapacity: 32,
 			wantChipType:     2,
 		},
+		{
+			name:             "CV84X6",
+			chipModel:        "CV84X6",
+			wantCalcCapacity: 16,
+			wantChipType:     3,
+		},
+		{
+			name:             "lowercase cv84x6",
+			chipModel:        "cv84x6",
+			wantCalcCapacity: 16,
+			wantChipType:     3,
+		},
+		{
+			name:             "84X6 substring",
+			chipModel:        "CV84X6-PROD",
+			wantCalcCapacity: 16,
+			wantChipType:     3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/source/pbmssm/pkg/metrics/ion_memory.go
+++ b/source/pbmssm/pkg/metrics/ion_memory.go
@@ -15,7 +15,7 @@ const (
 )
 
 // ChipType 读取 /proc/cpuinfo 的 model name，返回小写芯片型号。
-// "bm1684x", "bm1684", "bm1688", "cv186ah"，失败返空串。
+// "bm1684x", "bm1684", "bm1688", "cv186ah", "cv84x6"，失败返空串。
 func (c *Collector) ChipType() string {
 	content := c.readStr(cpuInfoPath)
 	if content == "" {
@@ -31,27 +31,42 @@ func (c *Collector) ChipType() string {
 		return "bm1684"
 	case strings.Contains(s, "cv186ah"):
 		return "cv186ah"
+	case strings.Contains(s, "cv84x6"):
+		return "cv84x6"
 	default:
 		return ""
 	}
 }
 
+// chipFamily 归一化芯片家族：bm1684（含 bm1684x）/ cv（bm1688、cv186ah、cv84x6）。
+// 用于选择"是否走 bm1688 路径"（SN、ion heap、vpuinfo、SDK 版本等）。
+// 时钟路径不能按家族共享（CV84X2 时钟名与 bm1688 不同），需按芯片特判。
+func chipFamily(chip string) string {
+	switch chip {
+	case "bm1684", "bm1684x":
+		return "bm1684"
+	case "bm1688", "cv186ah", "cv84x6":
+		return "cv"
+	}
+	return ""
+}
+
 // VppMemory 读取 VPP 堆内存（bytes）。对齐 Rust parse_memory_from_command：
 //
 //	BM1684/BM1684X → ionVppHeapV1 [1]行
-//	BM1688/CV186AH → ionVppHeapV2 [1]行
+//	BM1688/CV186AH/CV84X2 → ionVppHeapV2 [1]行
 //	不支持芯片 → 0,0
 func (c *Collector) VppMemory(chip string) (total, used int64) {
 	switch chip {
 	case "bm1684x", "bm1684":
 		return c.parseIonHeapLine(ionVppHeapV1, "[1]")
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		return c.parseIonHeapLine(ionVppHeapV2, "[1]")
 	}
 	return 0, 0
 }
 
-// VpuMemory 读取 VPU 堆内存（bytes）。仅 BM1684/BM1684X 支持（BM1688/CV186AH 无 vpu heap）。
+// VpuMemory 读取 VPU 堆内存（bytes）。仅 BM1684/BM1684X 支持（BM1688/CV186AH/CV84X2 无 vpu heap）。
 // 读 bm_vpu_heap_dump/summary 的 [2] 行（曾误读 vpp heap，已修正）。
 func (c *Collector) VpuMemory(chip string) (total, used int64) {
 	switch chip {
@@ -64,12 +79,12 @@ func (c *Collector) VpuMemory(chip string) (total, used int64) {
 // TpuMemory 读取 TPU 堆内存（bytes）。
 //
 //	BM1684/BM1684X → ionNpuHeapV1 [0]行
-//	BM1688/CV186AH → ionNpuHeapV2 [0]行
+//	BM1688/CV186AH/CV84X2 → ionNpuHeapV2 [0]行
 func (c *Collector) TpuMemory(chip string) (total, used int64) {
 	switch chip {
 	case "bm1684x", "bm1684":
 		return c.parseIonHeapLine(ionNpuHeapV1, "[0]")
-	case "bm1688", "cv186ah":
+	case "bm1688", "cv186ah", "cv84x6":
 		return c.parseIonHeapLine(ionNpuHeapV2, "[0]")
 	}
 	return 0, 0

--- a/source/pbmssm/pkg/metrics/ion_memory_test.go
+++ b/source/pbmssm/pkg/metrics/ion_memory_test.go
@@ -26,6 +26,42 @@ func TestChipTypeBM1688(t *testing.T) {
 	}
 }
 
+func TestChipTypeCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.ChipType(); got != "cv84x6" {
+		t.Errorf("ChipType() = %q, want cv84x6", got)
+	}
+}
+
+func TestChipTypeCv84x6Uppercase(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: CV84X6\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.ChipType(); got != "cv84x6" {
+		t.Errorf("ChipType() = %q, want cv84x6 (case-insensitive)", got)
+	}
+}
+
+func TestChipFamily(t *testing.T) {
+	cases := []struct{ chip, want string }{
+		{"bm1684x", "bm1684"},
+		{"bm1684", "bm1684"},
+		{"bm1688", "cv"},
+		{"cv186ah", "cv"},
+		{"cv84x6", "cv"},
+		{"", ""},
+	}
+	for _, tt := range cases {
+		if got := chipFamily(tt.chip); got != tt.want {
+			t.Errorf("chipFamily(%q) = %q, want %q", tt.chip, got, tt.want)
+		}
+	}
+}
+
 func TestChipTypeUnknown(t *testing.T) {
 	fr := &fakeFileReader{files: map[string]string{
 		"/proc/cpuinfo": "model name	: Intel(R) Xeon(R)\n",
@@ -77,6 +113,28 @@ func TestVppMemoryBM1688(t *testing.T) {
 	total, used := c.VppMemory("bm1688")
 	if total != 419430400 || used != 209715200 {
 		t.Errorf("VppMemory() = (%d, %d), want (419430400, 209715200)", total, used)
+	}
+}
+
+func TestVppMemoryCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/sys/kernel/debug/ion/cvi_vpp_heap_dump/summary": realDeviceIonSummary("[1]", "vpp", 419430400, 209715200),
+	}}
+	c := NewCollector(fr, nil)
+	total, used := c.VppMemory("cv84x6")
+	if total != 419430400 || used != 209715200 {
+		t.Errorf("VppMemory() = (%d, %d), want (419430400, 209715200)", total, used)
+	}
+}
+
+func TestTpuMemoryCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/sys/kernel/debug/ion/cvi_npu_heap_dump/summary": realDeviceIonSummary("[0]", "npu", 4141875200, 2070937600),
+	}}
+	c := NewCollector(fr, nil)
+	total, used := c.TpuMemory("cv84x6")
+	if total != 4141875200 || used != 2070937600 {
+		t.Errorf("TpuMemory() = (%d, %d), want (4141875200, 2070937600)", total, used)
 	}
 }
 
@@ -226,5 +284,30 @@ func TestMemoryLayoutBM1688(t *testing.T) {
 	}
 	if lay.VPU.TotalMB != 0 || lay.VPU.UsedMB != 0 || lay.VPU.UsagePct != 0 {
 		t.Errorf("VPU = %+v, want all 0 on BM1688", lay.VPU)
+	}
+}
+
+// TestMemoryLayoutCv84x6 CV84X2 内存布局：cvi_ ion heap + chipType 识别为 cv84x6。
+func TestMemoryLayoutCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name\t: cv84x6\n",
+		"/proc/meminfo": "MemTotal:       4096000 kB\nMemFree:        2048000 kB\nMemAvailable:   3000000 kB\n",
+		"/sys/kernel/debug/ion/cvi_npu_heap_dump/summary": realDeviceIonSummary("[0]", "npu", 1610612736, 0),
+		"/sys/kernel/debug/ion/cvi_vpp_heap_dump/summary": realDeviceIonSummary("[1]", "vpp", 4290772992, 0),
+	}}
+	c := NewCollector(fr, nil)
+	lay := c.MemoryLayout()
+
+	if lay.ChipType != "cv84x6" {
+		t.Fatalf("ChipType = %q, want cv84x6", lay.ChipType)
+	}
+	if !approxEqual(lay.TPU.TotalMB, 1536, 0.01) {
+		t.Errorf("TPU.TotalMB = %v, want 1536", lay.TPU.TotalMB)
+	}
+	if !approxEqual(lay.VPP.TotalMB, 4092, 0.5) {
+		t.Errorf("VPP.TotalMB = %v, want ~4092", lay.VPP.TotalMB)
+	}
+	if lay.VPU.TotalMB != 0 || lay.VPU.UsedMB != 0 || lay.VPU.UsagePct != 0 {
+		t.Errorf("VPU = %+v, want all 0 on CV84X2", lay.VPU)
 	}
 }

--- a/source/pbmssm/pkg/metrics/os.go
+++ b/source/pbmssm/pkg/metrics/os.go
@@ -89,6 +89,7 @@ var socModels = map[string]bool{
 	"bm1684":  true,
 	"bm1688":  true,
 	"cv186ah": true,
+	"cv84x6":  true, // CV84X2
 }
 
 // SdkVersion 获取 SophonSDK 版本（对齐 pget_info get_info.sh 的决策树）。
@@ -118,7 +119,7 @@ func (c *Collector) SdkVersion() string {
 			} else if strings.HasPrefix(kernel, "4.9.") {
 				return c.buildInfoVersion()
 			}
-		case "bm1688", "cv186ah":
+		case "bm1688", "cv186ah", "cv84x6":
 			// 新格式 "SophonSDK(BM1688) 2.1" 优先；旧格式 "Gemini_SDK: x.y" 次之；
 			// 都缺失（如老固件无 bm_version 或输出异常）→ 回退 LIBSOPHON_VERSION
 			if v := c.bmVersionSophonSDK(); v != "" {

--- a/source/pbmssm/pkg/metrics/os_test.go
+++ b/source/pbmssm/pkg/metrics/os_test.go
@@ -194,6 +194,28 @@ func TestSdkVersionSOC186ah(t *testing.T) {
 
 // TestSdkVersionSOC1688NewFormat 锁定新格式 bm_version 首行 "SophonSDK(BM1688) 2.1"。
 // SE9 实测 bm_version 输出此格式（无 Gemini_SDK 行），SDK 版本取 ')' 之后的 "2.1"。
+// TestSdkVersionSOCCv84x6 覆盖 CV84X2（cv84x6）芯片：model name 识别为 cv84x6 时
+// 走 bm1688/cv186ah 同款 SophonSDK 首行解析（"SophonSDK(cv84x6) 2.1" → "2.1"）。
+func TestSdkVersionSOCCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name : cv84x6\n",
+	}}
+	cmd := &fakeCmdRunner{responses: map[string]cmdResp{
+		"uname": {"5.10.5\n", nil},
+		"/usr/sbin/bm_version": {
+			"SophonSDK(cv84x6) 2.1\n" +
+				"sophon-soc-libsophon : 0.4.13\n",
+			nil,
+		},
+	}}
+	c := NewCollector(fr, cmd)
+	got := c.SdkVersion()
+	want := "2.1"
+	if got != want {
+		t.Errorf("SdkVersion() cv84x6 = %q, want %q", got, want)
+	}
+}
+
 func TestSdkVersionSOC1688NewFormat(t *testing.T) {
 	fr := &fakeFileReader{files: map[string]string{
 		"/proc/cpuinfo": "model name : bm1688\n",

--- a/source/pbmssm/pkg/metrics/thermal.go
+++ b/source/pbmssm/pkg/metrics/thermal.go
@@ -10,7 +10,8 @@ const (
 	chipTempPath  = "/sys/class/thermal/thermal_zone0/temp" // 芯片温度（milli-celsius）
 	boardTempPath = "/sys/class/thermal/thermal_zone1/temp" // 板温（milli-celsius）
 	npuUsagePath  = "/sys/class/bm-tpu/bm-tpu0/device/npu_usage"
-	tpuMemPath    = "/sys/kernel/debug/ion/bm_npu_heap_dump/total_mem" // 需 root
+	tpuMemPath    = "/sys/kernel/debug/ion/bm_npu_heap_dump/total_mem"  // 需 root（bm1684/bm1684x）
+	tpuMemPathV2  = "/sys/kernel/debug/ion/cvi_npu_heap_dump/total_mem" // 需 root（cv 家族：bm1688/cv186ah/cv84x6）
 )
 
 // ChipTemp 读取芯片温度（thermal_zone0），milli-celsius → 整数 ℃。
@@ -95,11 +96,16 @@ func (c *Collector) TpuMemUsage() int {
 	return int(float64(used)*100.0/float64(total) + 0.5)
 }
 
-// 源：/sys/kernel/debug/ion/bm_npu_heap_dump/total_mem（字节，需 root）。
+// 源：/sys/kernel/debug/ion/bm_npu_heap_dump/total_mem 或 cvi_npu_heap_dump/total_mem（字节，需 root）。
 // 对齐 pget_info：TPU_MEM(MiB) = total_mem/1024/1024。
+// cv 家族（bm1688/cv186ah/cv84x6）走 cvi_ 前缀路径；bm1684/bm1684x 走 bm_ 前缀。
 // 非 root 读不到 debugfs，降级返 0。
 func (c *Collector) TPUMem() float64 {
-	s := c.readStr(tpuMemPath)
+	path := tpuMemPath
+	if chipFamily(c.ChipType()) == "cv" {
+		path = tpuMemPathV2
+	}
+	s := c.readStr(path)
 	if s == "" {
 		return 0
 	}

--- a/source/pbmssm/pkg/metrics/thermal_test.go
+++ b/source/pbmssm/pkg/metrics/thermal_test.go
@@ -113,6 +113,35 @@ func TestTPUMemMissing(t *testing.T) {
 	}
 }
 
+// TestTPUMemCv84x6 CV84X2 的 ion heap 前缀为 cvi_（cvi_npu_heap_dump/total_mem），
+// 而非 bm_ 前缀。值 4141875200 B = 3950 MiB。
+func TestTPUMemCv84x6(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		"/sys/kernel/debug/ion/cvi_npu_heap_dump/total_mem": "4141875200\n",
+	}}
+	c := NewCollector(fr, nil)
+	got := c.TPUMem()
+	want := 3950.0
+	if got != want {
+		t.Errorf("TPUMem() = %v, want %v", got, want)
+	}
+}
+
+// TestTPUMemCv84x6BmPathAbsent CV84X2 上 bm_ 前缀路径不存在时仍应正确降级返 0，
+// 而非因误读 bm_ 路径得到异常值。
+func TestTPUMemCv84x6BmPathAbsent(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: cv84x6\n",
+		// 仅提供 cvi_ 路径，bm_ 路径缺失
+		"/sys/kernel/debug/ion/cvi_npu_heap_dump/total_mem": "0\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.TPUMem(); got != 0 {
+		t.Errorf("TPUMem() = %v, want 0 when cvi total_mem is 0", got)
+	}
+}
+
 // ---------------------------------------------------------------
 // TPUAverageUsage — avusage: 字段
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- bmssm（Sophon System Management 服务，Go 实现）新增 CV84X2（SDK 标识 `cv84x6`）芯片支持。
- CV84X2 与 bm1688/cv186ah 同属 CV 系，绝大多数芯片分支（SN 读取、ION heap、vpuinfo、温度、SDK 版本）直接复用 bm1688 分支；真正需新增 `cv84x6` 分支的 6 处已补齐。
- 完整方案见父任务《方案：bmssm 适配 CV84X2》(MYS-117)。

## 改动点

| 文件 | 改动 |
|---|---|
| `pkg/metrics/os.go` | `socModels` 白名单加 `cv84x6`；`SdkVersion` 走 bm1688/cv186ah 同款 `SophonSDK(...)` 首行解析 |
| `pkg/device/devinfo.go` | `readSnFromRaw` 识别 `cv84x6` 走 `/dev/mmcblk0boot1`（与 bm1688 布局一致，offset 0/32） |
| `pkg/metrics/ion_memory.go` | `ChipType` 识别 `cv84x6`；新增 `chipFamily()`（bm1684/cv 家族）；cvi_ ion heap（Vpp/Vpu/Tpu）复用 |
| `pkg/metrics/thermal.go` | `TPUMem()` 按家族切 `cvi_npu_heap_dump/total_mem` 路径 |
| `pkg/metrics/accelerator.go` | TPU/VPU/CPU 时钟新增 `cv84x6` 分支：`clk_tpu_ip` / `clk_ve_axi` / `clk_ap_ca55` |
| `pkg/metrics/chip_capacity.go` | `CV84X6` → 16 TOPS / chipType 3（占位，对齐 BM1688 档位，真机确认后修正） |

## 关键决策

- **VPU 频率不 ÷2**：cv84x6 的 `clk_ve_axi` 是 AXI 总线时钟，语义与 bm1688 的 `clk_cam0pll`（PLL 2 倍频）不同，真机实测后可调整。
- **`model name` 识别风险**：CV84X2 内核 64 位下可能无 `model name` 行或输出 `null`，若识别失败 metrics 降级为 0；方案已注明星型值确认与兜底（ModuleType/OEMconfig）建议。

## Test plan

- [x] `go test ./...` 全绿（含新增 cv84x6 单测夹具）
- [x] `go vet ./...` 通过
- [x] arm64 musl 静态交叉编译通过（`bash build/build-bmssm-arm64.sh` + `bash release.sh arm64`，产物 `statically linked`）
- [ ] CV84X2 真机验证（待设备就绪）

🤖 Generated with [Claude Code](https://claude.com/claude-code)