### PR TITLE
feat(sophliteos): 适配 CV84X2（cv84x6）芯片

### DIFF
--- a/source/psophliteos/frontend/src/store/modules/overview.ts
+++ b/source/psophliteos/frontend/src/store/modules/overview.ts
@@ -23,7 +23,7 @@ enum deviceRunningSatus {
 export const useDeviceInfo = defineStore({
   id: 'app-device-info',
   state: () => ({
-    singleBoardArr: ['se5', 'se7', 'se9'],
+    singleBoardArr: ['se5', 'se7', 'se9', 'cv84x6', 'cv186ah', '84x6', 'cv84x2', '84x2'],
     deviceInfo: {
       deviceName: '',
       deviceSn: '',
@@ -188,12 +188,8 @@ export const useDeviceInfo = defineStore({
             );
             this.deviceInfo[key] = { total, used, unit: 'MB' };
           } else if (key === 'temperature') {
-            // SE5/SE7/SE9 取 chip[0].temperature，否则 board[0].temperature
-            if (
-              deviceType === 'SE5' ||
-              deviceType === 'SE7' ||
-              deviceType === 'SE9'
-            ) {
+            // 单板设备（SE5/SE7/SE9/CV84X2 等）取 chip[0].temperature，多板取 board[0].temperature
+            if (this.isSingleBoard) {
               this.deviceInfo[key] =
                 result?.coreComputingUnit?.board?.[0]?.chip?.[0]?.temperature ?? 0;
             } else {

--- a/source/psophliteos/frontend/src/views/overview/components/MemoryLayout.vue
+++ b/source/psophliteos/frontend/src/views/overview/components/MemoryLayout.vue
@@ -34,7 +34,9 @@
 
   const props = defineProps<{ layout: MemoryLayout | null | undefined }>();
 
-  const isVPSS = (chip: string) => chip === 'bm1688' || chip === 'cv186ah';
+  // CV 家族（bm1688/cv186ah/cv84x6）的 VPP 分区实际对应 VPSS，用"VPSS内存"标签贴合硬件命名
+  const isVPSS = (chip: string) =>
+    ['bm1688', 'cv186ah', 'cv84x6'].includes(chip);
 
   const regions = computed(() => {
     const lay = props.layout;

--- a/source/psophliteos/frontend/src/views/overview/detail.vue
+++ b/source/psophliteos/frontend/src/views/overview/detail.vue
@@ -267,10 +267,15 @@
     return result;
   });
   const computePower = computed(() => {
-    const computingPowerList = {
+    const computingPowerList: Record<string, string> = {
       SE6: 'INT8 17.6TOPS',
       SE8: 'INT8 32.0TOPS',
     };
+    // 未知型号从 chip[0].calculationCapacityInt8 动态取，避免 undefined
+    const chip0 = originData.value?.coreComputingUnit?.board?.[0]?.chip?.[0];
+    if (chip0?.calculationCapacityInt8) {
+      return `INT8 ${chip0.calculationCapacityInt8}TOPS`;
+    }
     return computingPowerList[deviceInfo.value.deviceType];
   });
   const { width } = useWindowSize();


### PR DESCRIPTION
## Summary
- sophliteos（Web 层）本身几乎不含芯片型号逻辑——通过 `/api/v1/*` 反代 bmssm 透传芯片信息，主体适配已在 bmssm 侧完成（PR #56）
- 本次前端 4 处最小改动，配合 bmssm `ChipType()` 新增 `cv84x6` 识别后的数据形态

## 改动点
1. **单板判定**（`overview.ts`）：`singleBoardArr` 纳入 `cv84x6/cv186ah/84x6/cv84x2/84x2`，CV84X2 首台单板设备（无核心板）走 `detail-se5` 单板概览视图
2. **温度取数**（`overview.ts`）：由 `deviceType==='SE5/SE7/SE9'` 字面量枚举改为按 `isSingleBoard` 判定，单板一律取 `chip[0].temperature`（bmssm `ChipTemp`=thermal_zone0），避免取到板温
3. **MemoryLayout 标签**（`MemoryLayout.vue`）：`isVPSS` 纳入 cv 家族（`bm1688/cv186ah/cv84x6`），`cv84x6` chipType 下 VPP 分区显示"VPSS内存"
4. **算力兜底**（`detail.vue`）：未知型号从 `chip[0].calculationCapacityInt8` 动态取，避免多板形态下 TPU 卡片算力文案 `undefined`

## 验证
- 前端 `pnpm run build`（vite build + postBuild）通过，`dist/index.html` 产出
- 后端 `go build ./...` + `go vet ./...` 通过
- arm64 deb 构建通过（`bash release.sh arm64 2.1.0`）：`sophliteos_soc_2.1.0.deb` 5.2M，Architecture=arm64，二进制静态链接（aarch64 musl），前端 dist 完整嵌入
- `vue-tsc` 基线 1887 错误（与 base 完全一致，改动文件未新增类型错误；该项目实际构建门禁是 vite build）

## Test plan
- [ ] CV84X2 真机部署后核对：单板视图渲染、MemoryLayout 标签"VPSS内存"、温度取 chip[0]（thermal_zone0）、TPU 算力文案
- [ ] bm1688/SE9 设备回归：单板视图、历史指标、软件更新流程不回退

🤖 Generated with [Claude Code](https://claude.com/claude-code)