### PR TITLE
fix(psophliteos): 概览内存情况 DDR整体 改名为 内存整体

### DIFF
--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/overview.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/overview.ts
@@ -75,7 +75,7 @@ export default {
   vpssMemory: 'VPSS内存',
   diskLayout: '硬盘情况',
   emmcOverall: 'eMMC整体',
-  ddrOverall: 'DDR整体',
+  ddrOverall: '内存整体',
   systemPartition: '系统分区',
   dataPartition: '/data分区',
   // theoretialCalculationCapacity: '',


### PR DESCRIPTION
## 变更内容

`sophliteos` 前端概览 → 内存情况 → 汇总行标签从「DDR整体」改名为「内存整体」（`ddrOverall` 键，中文语言包）。

仅改中文文案，未动逻辑/样式；英文「DDR Overall」保持不变。

## 修改文件

- `source/psophliteos/frontend/src/locales/lang/zh-CN/overview.ts`：`ddrOverall` 文案改为「内存整体」

## 测试

- 改动为纯文案键值，`MemoryLayout.vue` 中通过 `t('overview.ddrOverall')` 引用，key 未变，无运行时影响
- 前端构建在本地验证通过