### PR TITLE
feat: sophliteos AI Agent 功能 + pbmssm LLM API 转发

### DIFF
--- a/source/pbmssm/config/bmssm.yaml
+++ b/source/pbmssm/config/bmssm.yaml
@@ -42,3 +42,11 @@ firewall:
 software:
   autoRunScript: false   # 默认 false：禁止自动执行包内脚本（tar.gz/zip 的 install.sh、
                          # .deb 的 dpkg 维护脚本），防上传即 root RCE；需安装软件时置 true
+
+# LLM API 转发（OpenAI 兼容）：独立 HTTP server，仅绑定本机。
+# 客户端以 model=devproxy 请求，转发时替换为配置的目标模型名。
+# 上游 api_base/key/目标模型由 /api/v1/llm-proxy/config 接口管理（sqlite 持久化）。
+llm-proxy:
+  enabled: true          # 总开关
+  port: 18080            # 转发 server 端口（默认）
+  listenIP: 127.0.0.1    # 仅本机可访问

--- a/source/pbmssm/config/config.go
+++ b/source/pbmssm/config/config.go
@@ -89,6 +89,12 @@ func LoadFromDir(dir string) bool {
 	v.SetDefault("metrics.archive.maxSizeMB", 100)
 	v.SetDefault("metrics.archive.channelBufferSize", 16)
 
+	// LLM API 转发（OpenAI 兼容）：独立 HTTP server，仅绑定本机。
+	// port 默认 18080；listenIP 默认 127.0.0.1（仅本机可访问）。
+	v.SetDefault("llm-proxy.enabled", true)
+	v.SetDefault("llm-proxy.port", 18080)
+	v.SetDefault("llm-proxy.listenIP", "127.0.0.1")
+
 	v.AddConfigPath(dir)
 	v.SetConfigName("bmssm")
 	v.SetConfigType("yaml")

--- a/source/pbmssm/initialization/init.go
+++ b/source/pbmssm/initialization/init.go
@@ -9,6 +9,7 @@ import (
 	"bmssm/global"
 	"bmssm/logger"
 	mwalarm "bmssm/mvc/alarm"
+	"bmssm/mvc/llmproxy"
 	mwuser "bmssm/mvc/user"
 	"bmssm/pkg/alarm"
 	"bmssm/pkg/auth"
@@ -89,6 +90,11 @@ func InitBase() {
 		ChipType:  global.ModuleType,
 		BoardType: global.ModuleTypeEx,
 	})
+
+	// LLM API 转发 server：迁移旧表结构、读取已存配置启动（或禁用）。
+	// 配置保存接口会热更新。
+	llmproxy.Migrate(database.DB())
+	llmproxy.StartServer(llmproxy.NewService(database.DB()).LoadConfig())
 }
 
 // createDefaultAdmin 在 user 表为空时插入默认 admin 用户。

--- a/source/pbmssm/mvc/llmproxy/controller.go
+++ b/source/pbmssm/mvc/llmproxy/controller.go
@@ -1,0 +1,94 @@
+package llmproxy
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"bmssm/database"
+	"bmssm/pkg/response"
+)
+
+// Controller LLM 转发配置管理 handler 集合。
+type Controller struct {
+	svc *Service
+}
+
+// DefaultController 使用 database.DB() 构建默认控制器。
+func DefaultController() *Controller {
+	return &Controller{svc: NewService(database.DB())}
+}
+
+// GetConfig GET /api/v1/llm-proxy/config
+// 返回已存配置（LLM/VLM 各 key 脱敏；ForwardKey 明文）。
+func (ctrl *Controller) GetConfig(c *gin.Context) {
+	cfg := ctrl.svc.LoadConfig()
+	written := ctrl.svc.ForwardKeyWritten()
+	c.JSON(http.StatusOK, response.OK(cfg.ToResponse(written)))
+}
+
+// SaveConfig PUT /api/v1/llm-proxy/config
+// 保存 LLM/VLM 两套配置并热更新转发 server。
+func (ctrl *Controller) SaveConfig(c *gin.Context) {
+	var req SaveRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
+		return
+	}
+	cfg, err := ctrl.svc.SaveConfig(req)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, response.Fail("save failed: "+err.Error()))
+		return
+	}
+	// 热更新转发 server（不重启 bmssm）
+	UpdateServer(cfg)
+	c.JSON(http.StatusOK, response.OK(cfg.ToResponse(ctrl.svc.ForwardKeyWritten())))
+}
+
+// ResetForwardKey POST /api/v1/llm-proxy/forward-key/reset
+// 重置转发 key（生成新 key 并落库；不自动写入 picoclaw）。
+func (ctrl *Controller) ResetForwardKey(c *gin.Context) {
+	key, err := ctrl.svc.ResetForwardKey()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, response.Fail("reset failed: "+err.Error()))
+		return
+	}
+	// 热更新配置（转发 key 变化）
+	UpdateServer(ctrl.svc.LoadConfig())
+	c.JSON(http.StatusOK, response.OK(gin.H{"forwardKey": key}))
+}
+
+// WriteForwardKey POST /api/v1/llm-proxy/forward-key/write-picoclaw
+// 把当前转发 key 写入本地 picoclaw devproxy.key 并重启 gateway。
+func (ctrl *Controller) WriteForwardKey(c *gin.Context) {
+	cfg := ctrl.svc.LoadConfig()
+	if cfg.ForwardKey == "" {
+		c.JSON(http.StatusBadRequest, response.Fail("forward key not generated"))
+		return
+	}
+	if err := WriteForwardKeyToPicoclaw(cfg.ForwardKey); err != nil {
+		c.JSON(http.StatusInternalServerError, response.Fail("write failed: "+err.Error()))
+		return
+	}
+	ctrl.svc.SetForwardKeyWritten()
+	c.JSON(http.StatusOK, response.OK(gin.H{"ok": true}))
+}
+
+// ListModels GET /api/v1/llm-proxy/models?kind=llm|vlm
+// 从对应供应商的 openai 接口拉取模型列表（供前端弹窗选择）。
+func (ctrl *Controller) ListModels(c *gin.Context) {
+	cfg := ctrl.svc.LoadConfig()
+	kind := Provider(strings.ToLower(c.Query("kind")))
+	prov := cfg.Provider(kind)
+	if prov.ApiBase == "" || prov.ApiKey == "" {
+		c.JSON(http.StatusBadRequest, response.Fail("upstream not configured for "+string(kind)))
+		return
+	}
+	models, err := fetchModels(prov)
+	if err != nil {
+		c.JSON(http.StatusBadGateway, response.Fail("fetch models failed: "+err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, response.OK(gin.H{"models": models}))
+}

--- a/source/pbmssm/mvc/llmproxy/imagecache.go
+++ b/source/pbmssm/mvc/llmproxy/imagecache.go
@@ -1,0 +1,126 @@
+package llmproxy
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// imageCache 图片描述缓存：以图片数据哈希为 key，缓存 VLM 生成的描述。
+// LRU 淘汰 + 总字节数上限（默认 10MB），避免内存无限增长。
+type imageCache struct {
+	mu       sync.Mutex
+	maxBytes int64
+	curBytes int64
+	ll       *list.List               // 元素为 *cacheEntry（队首=最近使用）
+	items    map[string]*list.Element // hash -> list element
+}
+
+type cacheEntry struct {
+	key     string
+	value   string
+	bytes   int64
+	expires time.Time
+}
+
+// newImageCache 创建图片描述缓存，maxBytes 为总占用上限（字节）。
+func newImageCache(maxBytes int64) *imageCache {
+	if maxBytes <= 0 {
+		maxBytes = 10 << 20 // 默认 10MB
+	}
+	return &imageCache{
+		maxBytes: maxBytes,
+		ll:       list.New(),
+		items:    make(map[string]*list.Element),
+	}
+}
+
+// Get 按图片哈希取描述；命中且未过期返回描述，否则返回空。
+func (c *imageCache) Get(hash string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[hash]
+	if !ok {
+		return ""
+	}
+	entry := el.Value.(*cacheEntry)
+	if time.Now().After(entry.expires) {
+		// 过期：移除
+		c.removeLocked(el)
+		return ""
+	}
+	// LRU：移到队首
+	c.ll.MoveToFront(el)
+	return entry.value
+}
+
+// Set 缓存图片描述。若总占用超上限，从队尾淘汰最久未用项。
+func (c *imageCache) Set(hash, desc string, ttl time.Duration) {
+	if hash == "" || desc == "" {
+		return
+	}
+	if ttl <= 0 {
+		ttl = 24 * time.Hour // 默认 TTL 24h
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// 已存在：更新值并移到队首
+	if el, ok := c.items[hash]; ok {
+		entry := el.Value.(*cacheEntry)
+		c.curBytes += int64(len(desc)) - int64(len(entry.value))
+		entry.value = desc
+		entry.bytes = int64(len(desc))
+		entry.expires = time.Now().Add(ttl)
+		c.ll.MoveToFront(el)
+		c.evictLocked()
+		return
+	}
+
+	entry := &cacheEntry{
+		key:     hash,
+		value:   desc,
+		bytes:   int64(len(desc)),
+		expires: time.Now().Add(ttl),
+	}
+	el := c.ll.PushFront(entry)
+	c.items[hash] = el
+	c.curBytes += entry.bytes
+	c.evictLocked()
+}
+
+// Len 返回缓存条目数（测试用）。
+func (c *imageCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.ll.Len()
+}
+
+// CurBytes 返回当前占用字节数（测试用）。
+func (c *imageCache) CurBytes() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.curBytes
+}
+
+// evictLocked 从队尾淘汰直到占用不超上限。
+func (c *imageCache) evictLocked() {
+	for c.curBytes > c.maxBytes && c.ll.Len() > 0 {
+		back := c.ll.Back()
+		if back == nil {
+			return
+		}
+		c.removeLocked(back)
+	}
+}
+
+// removeLocked 从链表与 map 移除条目并扣减字节。
+func (c *imageCache) removeLocked(el *list.Element) {
+	entry := el.Value.(*cacheEntry)
+	c.ll.Remove(el)
+	delete(c.items, entry.key)
+	c.curBytes -= entry.bytes
+}
+
+// globalImageCache 全局图片描述缓存（bmssm 进程级）。
+var globalImageCache = newImageCache(10 << 20)

--- a/source/pbmssm/mvc/llmproxy/init.go
+++ b/source/pbmssm/mvc/llmproxy/init.go
@@ -1,0 +1,7 @@
+package llmproxy
+
+import "bmssm/database"
+
+func init() {
+	database.RegisterModel(&Config{})
+}

--- a/source/pbmssm/mvc/llmproxy/migrate.go
+++ b/source/pbmssm/mvc/llmproxy/migrate.go
@@ -1,0 +1,51 @@
+package llmproxy
+
+import (
+	"github.com/jinzhu/gorm"
+
+	"bmssm/logger"
+)
+
+// Migrate 对 llm_proxy_config 表做显式迁移：gorm v1 AutoMigrate 对 sqlite
+// 已有表加新列不可靠，这里用 ALTER TABLE 补齐旧版本缺的列。
+// 在 bmssm 启动（InitBase）时调用一次。
+func Migrate(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	if !db.HasTable(&Config{}) {
+		// 表不存在由 AutoMigrate 创建（含全部新列）
+		return
+	}
+	cols := []struct {
+		name string
+		typ  string
+	}{
+		{"llm_api_base", "text"},
+		{"llm_api_key", "text"},
+		{"llm_model", "text"},
+		{"llm_enabled", "bool"},
+		{"vlm_api_base", "text"},
+		{"vlm_api_key", "text"},
+		{"vlm_model", "text"},
+		{"vlm_enabled", "bool"},
+		{"forward_key", "text"},
+		{"forward_key_written", "bool"},
+	}
+	for _, c := range cols {
+		if db.Dialect().HasColumn("llm_proxy_config", c.name) {
+			continue
+		}
+		sql := "ALTER TABLE llm_proxy_config ADD COLUMN " + c.name + " " + c.typ
+		if err := db.Exec(sql).Error; err != nil {
+			logger.Warn("llmproxy migrate add %s failed: %v", c.name, err)
+		} else {
+			logger.Info("llmproxy migrate: added column %s", c.name)
+		}
+	}
+	// 旧版本字段迁移到新结构（旧 api_base/api_key/target_model/enabled → llm_*）
+	db.Exec("UPDATE llm_proxy_config SET llm_api_base = api_base WHERE llm_api_base IS NULL AND api_base IS NOT NULL")
+	db.Exec("UPDATE llm_proxy_config SET llm_api_key = api_key WHERE llm_api_key IS NULL AND api_key IS NOT NULL")
+	db.Exec("UPDATE llm_proxy_config SET llm_model = target_model WHERE llm_model IS NULL AND target_model IS NOT NULL")
+	db.Exec("UPDATE llm_proxy_config SET llm_enabled = enabled WHERE llm_enabled IS NULL")
+}

--- a/source/pbmssm/mvc/llmproxy/models.go
+++ b/source/pbmssm/mvc/llmproxy/models.go
@@ -1,0 +1,50 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// fetchModels 从上游 openai 兼容接口拉取模型列表（GET /models）。
+func fetchModels(prov ProviderConfig) ([]ModelInfo, error) {
+	if prov.ApiBase == "" {
+		return nil, fmt.Errorf("api_base empty")
+	}
+	upstreamURL := strings.TrimRight(prov.ApiBase, "/") + "/models"
+	req, err := http.NewRequest(http.MethodGet, upstreamURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	if prov.ApiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+prov.ApiKey)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("upstream %s returned %d: %s", upstreamURL, resp.StatusCode, truncate(string(body), 200))
+	}
+	var out struct {
+		Data []ModelInfo `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Data, nil
+}
+
+// truncate 截断过长的错误信息。
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/source/pbmssm/mvc/llmproxy/server.go
+++ b/source/pbmssm/mvc/llmproxy/server.go
@@ -1,0 +1,528 @@
+package llmproxy
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"bmssm/config"
+	"bmssm/logger"
+)
+
+// server 状态：配置变更时通过 UpdateServer 热更新（替换原子指针）。
+var (
+	mu        sync.RWMutex
+	startMu   sync.Mutex
+	activeSrv *http.Server
+	activeCfg Config
+)
+
+// StartServer 启动（或刷新）LLM 转发 server。
+// 首次调用启动 goroutine；后续调用热更新配置（上游地址/key/目标模型）。
+// initializer 在 bmssm 启动时调用一次；配置保存接口也会调用。
+func StartServer(cfg Config) {
+	UpdateServer(cfg)
+}
+
+// UpdateServer 更新配置并应用。若 server 未启动则启动（绑定配置的 listenIP:port）。
+// enabled=false 时停止 server（若在运行）。串行化启动避免并发 double-start。
+func UpdateServer(cfg Config) {
+	mu.Lock()
+	activeCfg = cfg
+	// 任一上游启用即启动转发 server
+	enabled := cfg.LLMEnabled || cfg.VLMEnabled
+	needStart := activeSrv == nil && enabled
+	needStop := activeSrv != nil && !enabled
+	mu.Unlock()
+
+	if needStop {
+		stopServer()
+		return
+	}
+	if !needStart {
+		logger.Info("llm proxy config updated: llm=%s vlm=%s", cfg.LLMModel, cfg.VLMModel)
+		return
+	}
+
+	// 需要启动：加锁并二次检查（另一 goroutine 可能已启动）
+	startMu.Lock()
+	defer startMu.Unlock()
+	mu.RLock()
+	already := activeSrv != nil
+	mu.RUnlock()
+	if already {
+		logger.Info("llm proxy config updated: llm=%s vlm=%s", cfg.LLMModel, cfg.VLMModel)
+		return
+	}
+	startServer(cfg)
+}
+
+// startServer 在独立 goroutine 启动转发 server。
+func startServer(cfg Config) {
+	conf := &config.Conf
+	conf.RLock()
+	listenIP := conf.GetViper().GetString("llm-proxy.listenIP")
+	if listenIP == "" {
+		listenIP = "127.0.0.1"
+	}
+	port := conf.GetViper().GetInt("llm-proxy.port")
+	if port == 0 {
+		port = 18080
+	}
+	conf.RUnlock()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/chat/completions", handleChatCompletions)
+	mux.HandleFunc("/v1/models", handleModels)
+
+	addr := net.JoinHostPort(listenIP, strconv.Itoa(port))
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+
+	mu.Lock()
+	activeSrv = srv
+	mu.Unlock()
+
+	logger.Info("llm proxy server listening on %s (llm=%s vlm=%s)",
+		addr, cfg.LLMModel, cfg.VLMModel)
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			logger.Error("llm proxy server failed: %v", err)
+		}
+	}()
+}
+
+// stopServer 停止转发 server（若有）。
+func stopServer() {
+	mu.Lock()
+	srv := activeSrv
+	activeSrv = nil
+	mu.Unlock()
+	if srv != nil {
+		logger.Info("stopping llm proxy server on %s", srv.Addr)
+		_ = srv.Close()
+	}
+}
+
+// currentConfig 返回当前生效配置（原子读）。
+func currentConfig() Config {
+	mu.RLock()
+	defer mu.RUnlock()
+	return activeCfg
+}
+
+// handleModels GET /v1/models —— 返回当前配置的 LLM/VLM 模型名。
+func handleModels(w http.ResponseWriter, r *http.Request) {
+	cfg := currentConfig()
+	models := []map[string]interface{}{}
+	if cfg.LLMModel != "" {
+		models = append(models, map[string]interface{}{"id": cfg.LLMModel, "object": "model", "owned_by": "bmssm-llm-proxy"})
+	}
+	if cfg.VLMModel != "" {
+		models = append(models, map[string]interface{}{"id": cfg.VLMModel, "object": "model", "owned_by": "bmssm-llm-proxy"})
+	}
+	if len(models) == 0 {
+		models = append(models, map[string]interface{}{"id": "devproxy", "object": "model", "owned_by": "bmssm-llm-proxy"})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{"object": "list", "data": models})
+}
+
+// handleChatCompletions POST /v1/chat/completions —— OpenAI 兼容转发。
+// 流程（图片描述化，防止含图历史进入 VLM 导致推理质量下滑）：
+//  1. 校验入站 Authorization: Bearer <forward_key>（不匹配 → 401）
+//  2. 遍历所有 messages 的 content：
+//     - 文本块 → 保留
+//     - 图片块（image_url/image）→ 提取图片数据 → 哈希查缓存：
+//         * 命中 → 复用描述
+//         * 未命中 → 调 VLM 生成详细描述 → 缓存
+//       用文本块替换图片块：{type:text, text:"这里有一个 image，其内容如下：<描述>"}
+//  3. 所有请求统一路由到 LLM（替换 model 为 LLM model_name）
+//  4. 用 bmssm 内部存储的 LLM 上游 key 向供应商转发
+func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
+	cfg := currentConfig()
+
+	// 1. 转发 key 校验
+	if cfg.ForwardKey == "" || !validForwardKey(r, cfg.ForwardKey) {
+		http.Error(w, "unauthorized: invalid forward key", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	r.Body.Close()
+	if err != nil {
+		http.Error(w, "read body failed", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. 解析请求体
+	var req map[string]interface{}
+	if err := json.Unmarshal(body, &req); err != nil || req == nil {
+		http.Error(w, "invalid request body: expected JSON", http.StatusBadRequest)
+		return
+	}
+
+	// 3. 核心转发：图片描述化 + 替换 model + 调 LLM
+	llm := cfg.LLM()
+	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
+		http.Error(w, "llm upstream not configured", http.StatusServiceUnavailable)
+		return
+	}
+	respBody, statusCode, err := forwardLLM(r.Context(), req, llm, cfg.VLM())
+	if err != nil {
+		logger.Error("forward failed: %v", err)
+		http.Error(w, "forward failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	// 4. 透传响应
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(respBody)
+}
+
+// validForwardKey 校验请求携带的转发 key 与配置一致（Bearer <key>）。
+func validForwardKey(r *http.Request, want string) bool {
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, "Bearer ") {
+		return false
+	}
+	got := strings.TrimSpace(strings.TrimPrefix(h, "Bearer "))
+	return got != "" && got == want
+}
+
+// describeImagesInRequest 遍历所有 message，把图片块替换为文本描述块。
+// 返回错误时请求体可能被部分修改（调用方直接放弃）。
+func describeImagesInRequest(req map[string]interface{}, vlm ProviderConfig) error {
+	messages, ok := req["messages"].([]interface{})
+	if !ok {
+		return nil
+	}
+	for _, m := range messages {
+		msg, ok := m.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if err := describeContent(msg["content"], vlm); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// describeContent 递归处理 content：文本保留，图片块替换为文本描述块。
+func describeContent(content interface{}, vlm ProviderConfig) error {
+	blocks, ok := content.([]interface{})
+	if !ok {
+		return nil
+	}
+	for i, block := range blocks {
+		b, ok := block.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if isImageBlock(b) {
+			desc, err := describeImageBlock(b, vlm)
+			if err != nil {
+				return err
+			}
+			// 用文本块替换图片块
+			blocks[i] = map[string]interface{}{
+				"type": "text",
+				"text": "这里有一个 image，其内容如下：" + desc,
+			}
+			continue
+		}
+		// 嵌套 content（tool_result 等）
+		if nested, ok := b["content"]; ok {
+			if err := describeContent(nested, vlm); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// describeImageBlock 对单个图片块生成文本描述：
+//  1. 提取图片数据（data URL 解码 / http 拉取）
+//  2. 计算 sha256 哈希，查缓存；命中直接复用
+//  3. 未命中：构造 VLM 请求（含图 + 描述 prompt），解析响应
+//  4. 缓存描述并返回
+func describeImageBlock(b map[string]interface{}, vlm ProviderConfig) (string, error) {
+	imgData, err := extractImageData(b)
+	if err != nil {
+		return "", err
+	}
+	hash := hashImage(imgData)
+
+	// 缓存命中
+	if desc := globalImageCache.Get(hash); desc != "" {
+		logger.Info("image cache hit: hash=%s", hash[:12])
+		return desc, nil
+	}
+
+	// 未命中：调 VLM
+	if !vlm.Enabled || vlm.ApiBase == "" || vlm.ModelName == "" {
+		return "", fmt.Errorf("vlm upstream not configured for image description")
+	}
+	desc, err := callVLMDescribe(vlm, imgData)
+	if err != nil {
+		return "", err
+	}
+	desc = strings.TrimSpace(desc)
+	if desc == "" {
+		desc = "(无法识别图片内容)"
+	}
+	globalImageCache.Set(hash, desc, 24*time.Hour)
+	logger.Info("image described: hash=%s len=%d", hash[:12], len(desc))
+	return desc, nil
+}
+
+// extractImageData 从图片块提取原始字节：
+//   - image_url.url 为 data URL（data:image/...;base64,xxx）→ base64 解码
+//   - image_url.url 为 http(s) URL → 拉取
+//   - image 块的 source.data 为 base64
+func extractImageData(b map[string]interface{}) ([]byte, error) {
+	if b["type"] == "image" {
+		// Anthropic 格式：source.data (base64)
+		if src, ok := b["source"].(map[string]interface{}); ok {
+			if data, ok := src["data"].(string); ok {
+				return base64.StdEncoding.DecodeString(data)
+			}
+		}
+	}
+	// OpenAI 格式：image_url.url
+	iu, ok := b["image_url"].(map[string]interface{})
+	if !ok {
+		// 兼容 string 形式
+		if s, ok := b["image_url"].(string); ok {
+			iu = map[string]interface{}{"url": s}
+		} else {
+			return nil, fmt.Errorf("image block missing image_url")
+		}
+	}
+	urlStr, _ := iu["url"].(string)
+	if urlStr == "" {
+		return nil, fmt.Errorf("image_url missing url")
+	}
+	if strings.HasPrefix(urlStr, "data:") {
+		// data URL: data:[mime];base64,<data>
+		comma := strings.Index(urlStr, ",")
+		if comma < 0 {
+			return nil, fmt.Errorf("invalid data URL")
+		}
+		return base64.StdEncoding.DecodeString(urlStr[comma+1:])
+	}
+	// http(s) URL：拉取
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("fetch image url: %w", err)
+	}
+	defer resp.Body.Close()
+	return io.ReadAll(resp.Body)
+}
+
+// hashImage 计算图片数据 sha256。
+func hashImage(data []byte) string {
+	h := sha256.Sum256(data)
+	return hex.EncodeToString(h[:])
+}
+
+// callVLMDescribe 调用 VLM 上游生成图片描述（OpenAI 兼容 /chat/completions）。
+func callVLMDescribe(vlm ProviderConfig, imgData []byte) (string, error) {
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	body := map[string]interface{}{
+		"model": vlm.ModelName,
+		"messages": []map[string]interface{}{
+			{
+				"role": "user",
+				"content": []map[string]interface{}{
+					{"type": "text", "text": "请用中文详细描述这张图片的内容，包括物体、场景、文字等细节。只输出描述，不要其他内容。"},
+					{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+				},
+			},
+		},
+		"max_tokens": 800,
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	upstreamURL := strings.TrimRight(vlm.ApiBase, "/") + "/chat/completions"
+	req, err := http.NewRequest(http.MethodPost, upstreamURL, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if vlm.ApiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+vlm.ApiKey)
+	}
+
+	client := &http.Client{Timeout: 120 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("vlm request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		rb, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("vlm returned %d: %s", resp.StatusCode, truncate(string(rb), 200))
+	}
+	var out struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("vlm response parse: %w", err)
+	}
+	if len(out.Choices) == 0 {
+		return "", fmt.Errorf("vlm returned no choices")
+	}
+	return out.Choices[0].Message.Content, nil
+}
+
+// isImageBlock 判断 block 是否图片块。
+func isImageBlock(b map[string]interface{}) bool {
+	switch b["type"] {
+	case "image", "image_url":
+		return true
+	}
+	return false
+}
+
+// --- 写入本地 picoclaw -------------------------------------------------------
+
+// devproxyKeyPath 返回 picoclaw devproxy.key 路径。
+// 优先 SOPHON_PICOCLAW_HOME，其次 /home/*/picoclaw-deploy 探测，最后当前用户主目录。
+func devproxyKeyPath() (string, error) {
+	var home string
+	if h := os.Getenv("SOPHON_PICOCLAW_HOME"); h != "" {
+		home = h
+	} else if entries, err := os.ReadDir("/home"); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				candidate := filepath.Join("/home", e.Name(), ".picoclaw")
+				if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+					home = filepath.Dir(candidate)
+					break
+				}
+			}
+		}
+	}
+	if home == "" {
+		return "", fmt.Errorf("cannot locate picoclaw home")
+	}
+	return filepath.Join(home, ".picoclaw", "devproxy.key"), nil
+}
+
+// WriteForwardKeyToPicoclaw 把转发 key 写入 /home/<user>/.picoclaw/devproxy.key，
+// 并重启 picoclaw gateway（及 launcher，若在运行）。
+func WriteForwardKeyToPicoclaw(key string) error {
+	path, err := devproxyKeyPath()
+	if err != nil {
+		return err
+	}
+	// 写文件（0600）
+	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
+		return fmt.Errorf("write devproxy.key: %w", err)
+	}
+	// 重启 gateway：picoclaw gateway restart（若 launcher 在运行则先重启 launcher）
+	restartPicoclaw()
+	return nil
+}
+
+// restartPicoclaw 重启 picoclaw：先重启 launcher（触发 gateway 随启），
+// 若无 launcher 则直接重启 gateway 进程。
+func restartPicoclaw() {
+	// 1. 尝试 pkill picoclaw-launcher（SIGTERM）
+	if out, err := exec.Command("pkill", "-TERM", "-f", "picoclaw-launcher").CombinedOutput(); err == nil {
+		logger.Info("picoclaw-launcher stopped: %s", string(out))
+	}
+	// 2. 尝试 pkill gateway
+	if out, err := exec.Command("pkill", "-TERM", "-f", "picoclaw gateway").CombinedOutput(); err == nil {
+		logger.Info("picoclaw gateway stopped: %s", string(out))
+	}
+	// 3. 等待端口释放
+	waitPortRelease(18790, 10*time.Second)
+	waitPortRelease(18800, 10*time.Second)
+	// 4. 若存在 launcher 则重新拉起
+	home := picoclawHomeDir()
+	if home != "" {
+		launcher := filepath.Join(home, "picoclaw-deploy", "picoclaw-launcher")
+		if st, err := os.Stat(launcher); err == nil && !st.IsDir() {
+			cmd := exec.Command(launcher, "-public", "-no-browser")
+			cmd.Dir = filepath.Dir(launcher)
+			cmd.Env = append(os.Environ(), "HOME="+home)
+			if err := cmd.Start(); err == nil {
+				_ = cmd.Process.Release()
+				logger.Info("picoclaw-launcher restarted (pid=%d)", cmd.Process.Pid)
+				return
+			}
+		}
+	}
+	logger.Warn("picoclaw launcher not found; gateway restart may be required manually")
+}
+
+// picoclawHomeDir 返回 picoclaw 主目录（/home/<user>）。
+func picoclawHomeDir() string {
+	if h := os.Getenv("SOPHON_PICOCLAW_HOME"); h != "" {
+		return h
+	}
+	if entries, err := os.ReadDir("/home"); err == nil {
+		for _, e := range entries {
+			if e.IsDir() {
+				candidate := filepath.Join("/home", e.Name(), "picoclaw-deploy")
+				if st, err := os.Stat(candidate); err == nil && st.IsDir() {
+					return filepath.Join("/home", e.Name())
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// waitPortRelease 轮询等待端口不再监听。
+func waitPortRelease(port int, timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+	addr := fmt.Sprintf("127.0.0.1:%d", port)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
+		if err != nil {
+			return
+		}
+		conn.Close()
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// flushWriter SSE 透传用：每次 Write 后 Flush。
+type flushWriter struct {
+	w http.ResponseWriter
+	f http.Flusher
+}
+
+func (fw *flushWriter) Write(p []byte) (int, error) {
+	n, err := fw.w.Write(p)
+	if fw.f != nil {
+		fw.f.Flush()
+	}
+	return n, err
+}

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -1,0 +1,396 @@
+package llmproxy
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"bmssm/database"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+// setupTestDB 建临时 sqlite，注册模型并迁移。
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&Config{}).Error; err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	database.SetDB(db)
+	return db
+}
+
+// setActive 注入当前配置到全局（避免真实 server 端口）。
+func setActive(cfg Config) {
+	mu.Lock()
+	activeCfg = cfg
+	mu.Unlock()
+}
+
+func TestServiceLLMAndVLMConfig(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+
+	// 默认配置
+	cfg := svc.LoadConfig()
+	if cfg.LLMApiBase != "https://www.sophnet.com/api/open-apis/v1" {
+		t.Errorf("default llmApiBase = %q", cfg.LLMApiBase)
+	}
+	if cfg.LLMModel != "sophnet-deepseek" {
+		t.Errorf("default llmModel = %q", cfg.LLMModel)
+	}
+	if cfg.VLMModel != "sophnet-vl-flash" {
+		t.Errorf("default vlmModel = %q", cfg.VLMModel)
+	}
+	if cfg.ForwardKey == "" {
+		t.Error("forward key should be auto-generated")
+	}
+
+	// 保存 LLM/VLM 两套
+	llmOn, vlmOn := true, true
+	saved, err := svc.SaveConfig(SaveRequest{
+		LLMApiBase: "https://llm.example.com/v1",
+		LLMApiKey:  "llm-key",
+		LLMModel:   "llm-model",
+		LLMEnabled: &llmOn,
+		VLMApiBase: "https://vlm.example.com/v1",
+		VLMApiKey:  "vlm-key",
+		VLMModel:   "vlm-model",
+		VLMEnabled: &vlmOn,
+	})
+	if err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if saved.LLMApiKey != "llm-key" || saved.VLMApiKey != "vlm-key" {
+		t.Errorf("saved keys = %q/%q", saved.LLMApiKey, saved.VLMApiKey)
+	}
+	fk := saved.ForwardKey
+
+	// 读取回填
+	got := svc.LoadConfig()
+	if got.LLMModel != "llm-model" || got.VLMModel != "vlm-model" {
+		t.Errorf("loaded = %+v", got)
+	}
+	if got.ForwardKey != fk {
+		t.Error("forward key should persist across loads")
+	}
+
+	// key 空串 → 保留原值
+	saved2, _ := svc.SaveConfig(SaveRequest{LLMApiKey: "", VLMApiKey: ""})
+	if saved2.LLMApiKey != "llm-key" || saved2.VLMApiKey != "vlm-key" {
+		t.Errorf("empty keys should keep old: %q/%q", saved2.LLMApiKey, saved2.VLMApiKey)
+	}
+}
+
+func TestServiceLoadWhenDBEmpty(t *testing.T) {
+	database.SetDB(nil)
+	svc := NewService(nil)
+	cfg := svc.LoadConfig()
+	if cfg.LLMModel == "" || cfg.VLMModel == "" {
+		t.Error("nil db should return defaults")
+	}
+}
+
+func TestForwardKeyAuth(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: "http://127.0.0.1:1/v1", LLMApiKey: "k", LLMModel: "m",
+		VLMApiBase: "http://127.0.0.1:1/v1", VLMApiKey: "k", VLMModel: "m",
+	})
+	// 强制设一个已知转发 key
+	cfg.ForwardKey = "test-forward-key"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "test-forward-key").Error
+	setActive(svc.LoadConfig())
+
+	body, _ := json.Marshal(map[string]interface{}{"model": "x", "messages": []interface{}{}})
+
+	// 无 key → 401
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no key: status = %d, want 401", rec.Code)
+	}
+
+	// 错误 key → 401
+	req = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer wrong-key")
+	rec = httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("wrong key: status = %d, want 401", rec.Code)
+	}
+}
+
+// TestImageDescribeRouting 验证：纯文本走 LLM；含图请求图片块被 VLM 描述并替换为文本，整体仍走 LLM。
+func TestImageDescribeRouting(t *testing.T) {
+	var gotLLMModel string
+	var gotLLMBody map[string]interface{}
+	vlmCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		// 区分 VLM 上游（路径 /vlm）与 LLM 上游（路径 /llm）
+		if strings.HasPrefix(r.URL.Path, "/vlm") {
+			vlmCalls++
+			// VLM 返回固定描述
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"一只猫在沙发上"}}]}`))
+			return
+		}
+		gotLLMModel, _ = req["model"].(string)
+		gotLLMBody = req
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+
+	// 纯文本 → LLM，无 VLM 调用
+	body, _ := json.Marshal(map[string]interface{}{
+		"model": "devproxy",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "hello"},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer fk")
+	rec := httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("text: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if gotLLMModel != "llm-target" {
+		t.Errorf("text routed model = %q, want llm-target", gotLLMModel)
+	}
+	if vlmCalls != 0 {
+		t.Errorf("text should not call VLM, calls = %d", vlmCalls)
+	}
+
+	// 含图 → 图片块被描述替换为文本，整体走 LLM
+	imgData := []byte("fake-png-bytes-123")
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	body, _ = json.Marshal(map[string]interface{}{
+		"model": "devproxy",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{
+				{"type": "text", "text": "what is this"},
+				{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+			}},
+		},
+	})
+	req = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer fk")
+	rec = httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("image: status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	// 整体走 LLM
+	if gotLLMModel != "llm-target" {
+		t.Errorf("image request should route to LLM, got model = %q", gotLLMModel)
+	}
+	// VLM 被调用一次生成描述
+	if vlmCalls != 1 {
+		t.Errorf("VLM should be called once, calls = %d", vlmCalls)
+	}
+	// 图片块被替换为文本块
+	msgs := gotLLMBody["messages"].([]interface{})
+	m0 := msgs[0].(map[string]interface{})
+	content := m0["content"].([]interface{})
+	foundDesc := false
+	for _, c := range content {
+		block := c.(map[string]interface{})
+		if block["type"] == "text" && strings.Contains(block["text"].(string), "这里有一个 image") {
+			foundDesc = true
+			if !strings.Contains(block["text"].(string), "一只猫在沙发上") {
+				t.Errorf("description not embedded: %v", block["text"])
+			}
+		}
+		if block["type"] == "image_url" {
+			t.Error("image_url block should be replaced by text")
+		}
+	}
+	if !foundDesc {
+		t.Errorf("image description text block not found: %v", content)
+	}
+}
+
+// TestImageCache 验证图片描述缓存：相同图片第二次不调 VLM。
+func TestImageCache(t *testing.T) {
+	vlmCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if strings.HasPrefix(r.URL.Path, "/vlm") {
+			vlmCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"相同图片描述"}}]}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+
+	// 清空缓存
+	globalImageCache = newImageCache(10 << 20)
+
+	imgData := []byte("same-image-bytes")
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	mkBody := func() []byte {
+		b, _ := json.Marshal(map[string]interface{}{
+			"model": "devproxy",
+			"messages": []map[string]interface{}{
+				{"role": "user", "content": []map[string]interface{}{
+					{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+				}},
+			},
+		})
+		return b
+	}
+	send := func() {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(mkBody()))
+		req.Header.Set("Authorization", "Bearer fk")
+		rec := httptest.NewRecorder()
+		handleChatCompletions(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	send() // 第一次：调 VLM
+	if vlmCalls != 1 {
+		t.Fatalf("first: VLM calls = %d, want 1", vlmCalls)
+	}
+	send() // 第二次：缓存命中，不调 VLM
+	if vlmCalls != 1 {
+		t.Errorf("second: VLM calls = %d, want 1 (cache hit)", vlmCalls)
+	}
+}
+
+// TestImageCacheLRUEvict 验证缓存超上限时淘汰最久未用项。
+func TestImageCacheLRUEvict(t *testing.T) {
+	c := newImageCache(100) // 上限 100 字节
+	c.Set("a", strings.Repeat("x", 40), time.Hour)
+	c.Set("b", strings.Repeat("y", 40), time.Hour)
+	c.Set("c", strings.Repeat("z", 40), time.Hour)
+	// 3*40=120 > 100，应淘汰最早插入的 a（LRU）
+	if c.Get("a") != "" {
+		t.Error("a should be evicted")
+	}
+	if c.Get("b") == "" || c.Get("c") == "" {
+		t.Error("b and c should remain")
+	}
+}
+
+// TestImageCacheTTL 验证缓存过期后重新调用。
+func TestImageCacheTTL(t *testing.T) {
+	c := newImageCache(10 << 20)
+	c.Set("k", "desc", time.Millisecond) // 1ms 后过期
+	if c.Get("k") != "desc" {
+		t.Fatal("entry should be present before expiry")
+	}
+	time.Sleep(5 * time.Millisecond)
+	if c.Get("k") != "" {
+		t.Error("expired entry should not be returned")
+	}
+}
+
+func mustJSON(v interface{}) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}
+
+// TestModelsEndpoint 验证 /v1/models 返回 LLM/VLM 模型名。
+func TestModelsEndpoint(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: "http://x/v1", LLMApiKey: "k", LLMModel: "llm-a",
+		VLMApiBase: "http://x/v1", VLMApiKey: "k", VLMModel: "vlm-b",
+	})
+	setActive(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	rec := httptest.NewRecorder()
+	handleModels(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	data := out["data"].([]interface{})
+	ids := map[string]bool{}
+	for _, d := range data {
+		ids[d.(map[string]interface{})["id"].(string)] = true
+	}
+	if !ids["llm-a"] || !ids["vlm-b"] {
+		t.Errorf("models = %v, want llm-a and vlm-b", ids)
+	}
+}
+
+// TestDisabledLLMReturns503 验证 LLM/VLM 都 disabled 时转发返回 503。
+func TestDisabledReturns503(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	off := false
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: "http://x/v1", LLMApiKey: "k", LLMModel: "m", LLMEnabled: &off,
+		VLMApiBase: "http://x/v1", VLMApiKey: "k", VLMModel: "m", VLMEnabled: &off,
+	})
+	cfg.ForwardKey = "fk"
+	setActive(cfg)
+
+	body, _ := json.Marshal(map[string]interface{}{"model": "x", "messages": []interface{}{}})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer fk")
+	rec := httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}

--- a/source/pbmssm/mvc/llmproxy/service.go
+++ b/source/pbmssm/mvc/llmproxy/service.go
@@ -1,0 +1,172 @@
+package llmproxy
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/jinzhu/gorm"
+)
+
+// Service 封装 LLM 转发配置的读写（不依赖 gin）。
+type Service struct {
+	db *gorm.DB
+}
+
+// NewService 创建 Service。
+func NewService(db *gorm.DB) *Service { return &Service{db: db} }
+
+// LoadConfig 读取已存配置；无记录返回默认配置（并确保生成转发 key）。
+// DB 为空时也返回默认配置（bmssm DB 初始化失败的非致命降级路径）。
+func (s *Service) LoadConfig() Config {
+	def := DefaultConfig()
+	if s == nil || s.db == nil {
+		def.ForwardKey = s.ensureForwardKey(def)
+		return def
+	}
+	var c Config
+	if err := s.db.First(&c, 1).Error; err != nil {
+		// 无记录：写入默认配置（含新生成的转发 key）
+		c = def
+		c.ID = 1
+		c.ForwardKey = GenerateForwardKey()
+		c.UpdatedAt = time.Now()
+		if err := s.db.Save(&c).Error; err == nil {
+			return c
+		}
+		return c
+	}
+	c.normalizeDefaults()
+	if c.ForwardKey == "" {
+		c.ForwardKey = GenerateForwardKey()
+		_ = s.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", c.ForwardKey).Error
+	}
+	return c
+}
+
+// ensureForwardKey 保证配置带转发 key；有则复用，无则生成并落库。
+func (s *Service) ensureForwardKey(c Config) string {
+	if c.ForwardKey != "" {
+		return c.ForwardKey
+	}
+	key := GenerateForwardKey()
+	if s != nil && s.db != nil {
+		// 尝试落库（失败不阻断，内存态仍有效）
+		_ = s.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", key).Error
+	}
+	return key
+}
+
+// GenerateForwardKey 生成随机转发 key（32 字节 base64url，无填充）。
+func GenerateForwardKey() string {
+	buf := make([]byte, 32)
+	_, _ = rand.Read(buf)
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// SaveConfig 保存配置（upsert 到 ID=1）。
+// 各 key 为空时保留原值（前端脱敏不回传）。
+func (s *Service) SaveConfig(req SaveRequest) (Config, error) {
+	cur := s.LoadConfig()
+	enabled := func(v *bool, def bool) bool {
+		if v != nil {
+			return *v
+		}
+		return def
+	}
+	c := Config{
+		ID:         1,
+		LLMApiBase: nonEmpty(req.LLMApiBase, cur.LLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
+		LLMApiKey:  nonEmpty(req.LLMApiKey, cur.LLMApiKey, ""),
+		LLMModel:   nonEmpty(req.LLMModel, cur.LLMModel, "sophnet-deepseek"),
+		LLMEnabled: enabled(req.LLMEnabled, cur.LLMEnabled),
+		VLMApiBase: nonEmpty(req.VLMApiBase, cur.VLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
+		VLMApiKey:  nonEmpty(req.VLMApiKey, cur.VLMApiKey, ""),
+		VLMModel:   nonEmpty(req.VLMModel, cur.VLMModel, "sophnet-vl-flash"),
+		VLMEnabled: enabled(req.VLMEnabled, cur.VLMEnabled),
+		ForwardKey: cur.ForwardKey,
+		UpdatedAt:  time.Now(),
+	}
+	if s == nil || s.db == nil {
+		return c, errors.New("database unavailable")
+	}
+	if err := s.db.Save(&c).Error; err != nil {
+		return Config{}, err
+	}
+	return c, nil
+}
+
+// ResetForwardKey 重置转发 key（生成新的并落库）。
+func (s *Service) ResetForwardKey() (string, error) {
+	if s == nil || s.db == nil {
+		return "", errors.New("database unavailable")
+	}
+	key := GenerateForwardKey()
+	if err := s.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", key).Error; err != nil {
+		return "", err
+	}
+	return key, nil
+}
+
+// SetForwardKeyWritten 标记转发 key 已写入本地 picoclaw。
+func (s *Service) SetForwardKeyWritten() {
+	if s != nil && s.db != nil {
+		_ = s.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key_written", true).Error
+	}
+}
+
+// ForwardKeyWritten 查询转发 key 是否已写入本地 picoclaw。
+func (s *Service) ForwardKeyWritten() bool {
+	if s == nil || s.db == nil {
+		return false
+	}
+	var written bool
+	_ = s.db.Model(&Config{}).Where("id = ?", 1).Pluck("forward_key_written", &written).Error
+	return written
+}
+
+// ToResponse 构造响应（脱敏 key；ForwardKey 明文）。
+func (c Config) ToResponse(written bool) ConfigResponse {
+	return ConfigResponse{
+		LLMApiBase:      c.LLMApiBase,
+		LLMModel:        c.LLMModel,
+		LLMEnabled:      c.LLMEnabled,
+		LLMHasKey:       c.LLMApiKey != "",
+		VLMApiBase:      c.VLMApiBase,
+		VLMModel:        c.VLMModel,
+		VLMEnabled:      c.VLMEnabled,
+		VLMHasKey:       c.VLMApiKey != "",
+		ForwardKey:      c.ForwardKey,
+		ForwardKeyReady: written,
+		UpdatedAt:       c.UpdatedAt,
+	}
+}
+
+// normalizeDefaults 补齐默认值（兼容旧表结构缺字段）。
+func (c *Config) normalizeDefaults() {
+	def := DefaultConfig()
+	if strings.TrimSpace(c.LLMApiBase) == "" {
+		c.LLMApiBase = def.LLMApiBase
+	}
+	if strings.TrimSpace(c.LLMModel) == "" {
+		c.LLMModel = def.LLMModel
+	}
+	if strings.TrimSpace(c.VLMApiBase) == "" {
+		c.VLMApiBase = def.VLMApiBase
+	}
+	if strings.TrimSpace(c.VLMModel) == "" {
+		c.VLMModel = def.VLMModel
+	}
+}
+
+// nonEmpty 取第一个非空值；全部为空时回退 fallback。
+func nonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
+}

--- a/source/pbmssm/mvc/llmproxy/test.go
+++ b/source/pbmssm/mvc/llmproxy/test.go
@@ -1,0 +1,159 @@
+package llmproxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"bmssm/pkg/response"
+)
+
+// TestResult 单项测试结果。
+type TestResult struct {
+	Name    string `json:"name"`    // 测试项名称
+	OK      bool   `json:"ok"`      // 是否通过
+	Message string `json:"message"` // 详情/错误信息
+}
+
+// TestResponse 一键测试响应。
+type TestResponse struct {
+	Results []TestResult `json:"results"`
+	AllOK   bool         `json:"allOk"`
+}
+
+// RunTest POST /api/v1/llm-proxy/test
+// 一键测试两项：
+//  1. 带图分发：构造含图请求 → 图片经 VLM 描述 → 文本插入 → 走 LLM，验证分发链路
+//  2. LLM 推理：纯文本请求走 LLM，验证推理链路
+func (tc *Controller) RunTest(c *gin.Context) {
+	cfg := tc.svc.LoadConfig()
+	results := []TestResult{
+		testImageDispatch(c.Request.Context(), cfg),
+		testLLMInference(c.Request.Context(), cfg),
+	}
+	allOK := true
+	for _, r := range results {
+		if !r.OK {
+			allOK = false
+		}
+	}
+	c.JSON(http.StatusOK, response.OK(TestResponse{Results: results, AllOK: allOK}))
+}
+
+// testImageDispatch 测试带图分发：图片描述化 + LLM 转发。
+func testImageDispatch(ctx context.Context, cfg Config) TestResult {
+	name := "带图分发"
+	llm := cfg.LLM()
+	vlm := cfg.VLM()
+	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
+		return TestResult{Name: name, OK: false, Message: "LLM 上游未配置或未启用"}
+	}
+
+	// 构造含图请求（内嵌一张 1x1 PNG 测试图）。
+	// 注意：messages 必须用 []interface{} 构造（与 JSON 反序列化后类型一致），
+	// 否则 describeImagesInRequest 的 []interface{} 类型断言会失败，图片不会被描述化。
+	png := testPNG()
+	b64 := base64.StdEncoding.EncodeToString(png)
+	req := map[string]interface{}{
+		"model": "devproxy",
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "请用一句话描述这张图片"},
+					map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "data:image/png;base64," + b64}},
+				},
+			},
+		},
+	}
+	body, statusCode, err := forwardLLM(ctx, req, llm, vlm)
+	if err != nil {
+		return TestResult{Name: name, OK: false, Message: "转发失败: " + err.Error()}
+	}
+	if statusCode != http.StatusOK {
+		return TestResult{Name: name, OK: false, Message: fmt.Sprintf("上游返回 %d: %s", statusCode, truncate(string(body), 200))}
+	}
+	return TestResult{Name: name, OK: true, Message: "图片描述化 + LLM 转发成功: " + truncate(string(body), 200)}
+}
+
+// testLLMInference 测试纯文本 LLM 推理。
+func testLLMInference(ctx context.Context, cfg Config) TestResult {
+	name := "LLM 推理"
+	llm := cfg.LLM()
+	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
+		return TestResult{Name: name, OK: false, Message: "LLM 上游未配置或未启用"}
+	}
+	req := map[string]interface{}{
+		"model": "devproxy",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": "请回复：OK"},
+		},
+	}
+	body, statusCode, err := forwardLLM(ctx, req, llm, Config{}.VLM())
+	if err != nil {
+		return TestResult{Name: name, OK: false, Message: "转发失败: " + err.Error()}
+	}
+	if statusCode != http.StatusOK {
+		return TestResult{Name: name, OK: false, Message: fmt.Sprintf("上游返回 %d: %s", statusCode, truncate(string(body), 200))}
+	}
+	return TestResult{Name: name, OK: true, Message: "LLM 推理成功: " + truncate(string(body), 200)}
+}
+
+// forwardLLM 核心转发：图片描述化（可选）+ 替换 model + 调 LLM 上游，返回响应体与状态码。
+// 供 handleChatCompletions 与测试接口共用。
+func forwardLLM(ctx context.Context, req map[string]interface{}, llm, vlm ProviderConfig) ([]byte, int, error) {
+	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
+		return nil, 0, fmt.Errorf("llm upstream not configured")
+	}
+	// 图片描述化（若含图）
+	if err := describeImagesInRequest(req, vlm); err != nil {
+		return nil, 0, fmt.Errorf("image describe failed: %w", err)
+	}
+	// 替换 model 为 LLM 模型名
+	req["model"] = llm.ModelName
+	body, _ := json.Marshal(req)
+
+	upstreamURL := strings.TrimRight(llm.ApiBase, "/") + "/chat/completions"
+	proxyReq, err := http.NewRequestWithContext(ctx, http.MethodPost, upstreamURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, 0, err
+	}
+	proxyReq.Header.Set("Content-Type", "application/json")
+	if llm.ApiKey != "" {
+		proxyReq.Header.Set("Authorization", "Bearer "+llm.ApiKey)
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DisableCompression:    true,
+			ResponseHeaderTimeout: 60 * time.Second,
+		},
+		Timeout: 120 * time.Second,
+	}
+	resp, err := client.Do(proxyReq)
+	if err != nil {
+		return nil, 0, fmt.Errorf("upstream request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return respBody, resp.StatusCode, nil
+}
+
+// testPNG 返回一张 128x128 纯色 PNG（测试用，满足 VLM 最小尺寸限制）。
+func testPNG() []byte {
+	// 128x128 纯蓝 PNG（base64）
+	const b64 = "iVBORw0KGgoAAAANSUhEUgAAAIAAAACACAIAAABMXPacAAAA+UlEQVR4nO3RQQ0AIAzAwAlDDmKRhYw9ekkFNLk592mxWT+IBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtAABoBwBAOwAA2gEA0A4AgHYAALQDAKAdAADtPm23BUfg9BCFAAAAAElFTkSuQmCC"
+	data, _ := base64.StdEncoding.DecodeString(b64)
+	return data
+}

--- a/source/pbmssm/mvc/llmproxy/test_test.go
+++ b/source/pbmssm/mvc/llmproxy/test_test.go
@@ -1,0 +1,115 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// setupTestController 建临时 db + mock 上游 + 返回 Controller 与上游调用记录。
+func setupTestController(t *testing.T) (*Controller, *httptest.Server) {
+	t.Helper()
+	db := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 区分 VLM 与 LLM 上游
+		if strings.HasPrefix(r.URL.Path, "/vlm") {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"测试图片描述"}}]}`))
+			return
+		}
+		// LLM 上游
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"测试回复"}}]}`))
+	}))
+	t.Cleanup(upstream.Close)
+
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	setActive(cfg)
+	return &Controller{svc: svc}, upstream
+}
+
+// TestRunTestAllOK 验证一键测试两个场景都通过。
+func TestRunTestAllOK(t *testing.T) {
+	ctrl, _ := setupTestController(t)
+	// 清空图片缓存，确保描述走 VLM
+	globalImageCache = newImageCache(10 << 20)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm-proxy/test", nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+	ctrl.RunTest(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Result TestResponse `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Result.AllOK {
+		t.Errorf("allOk = false, results = %+v", out.Result.Results)
+	}
+	if len(out.Result.Results) != 2 {
+		t.Fatalf("results count = %d, want 2", len(out.Result.Results))
+	}
+	names := map[string]bool{}
+	for _, r := range out.Result.Results {
+		names[r.Name] = true
+		if !r.OK {
+			t.Errorf("test %q failed: %s", r.Name, r.Message)
+		}
+	}
+	if !names["带图分发"] || !names["LLM 推理"] {
+		t.Errorf("missing tests, names = %v", names)
+	}
+}
+
+// TestRunTestLLMDisabled 验证 LLM 未配置时两项测试都失败（信息明确）。
+func TestRunTestLLMDisabled(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	off := false
+	svc := NewService(db)
+	_, _ = svc.SaveConfig(SaveRequest{
+		LLMApiBase: "http://x/v1", LLMApiKey: "k", LLMModel: "m", LLMEnabled: &off,
+		VLMApiBase: "http://x/v1", VLMApiKey: "k", VLMModel: "m",
+	})
+	ctrl := &Controller{svc: svc}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm-proxy/test", nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+	ctrl.RunTest(ctx)
+
+	var out struct {
+		Result TestResponse `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Result.AllOK {
+		t.Error("allOk should be false when LLM disabled")
+	}
+	for _, r := range out.Result.Results {
+		if r.OK {
+			t.Errorf("test %q should fail when LLM disabled", r.Name)
+		}
+		if !strings.Contains(r.Message, "未配置") && !strings.Contains(r.Message, "未启用") {
+			t.Errorf("test %q message = %q, want 未配置/未启用 hint", r.Name, r.Message)
+		}
+	}
+}

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -1,0 +1,116 @@
+// Package llmproxy 提供 LLM API 转发（OpenAI 兼容版）。
+//
+// 转发逻辑参考 llm-proxy（https://github.com/zzttzzmyswy/llm-proxy）：
+// 客户端（如 PicoClaw）以任意模型名请求本模块内置的 OpenAI 兼容端点，
+// 代理检测请求中是否含 image_url 分流到 VLM / LLM 配置的上游，
+// 并将 model 替换为对应配置的模型名后转发到上游 api_base。
+//
+// 入站请求需携带转发 key（Authorization: Bearer <forward_key>），
+// 校验通过后才用 bmssm 内部存储的上游 key 向供应商转发。
+package llmproxy
+
+import "time"
+
+// ProviderConfig 单套上游模型配置（LLM / VLM 各一份）。
+type ProviderConfig struct {
+	ApiBase   string `json:"apiBase"`   // OpenAI 兼容 base，转发时拼 /chat/completions
+	ApiKey    string `json:"-"`         // 上游供应商 key（不输出）
+	ModelName string `json:"modelName"` // 目标模型名
+	Enabled   bool   `json:"enabled"`
+}
+
+// Config 数据库模型：LLM 转发配置（单例，ID 固定为 1）。
+// LLM/VLM 各自独立的上游配置；ForwardKey 是客户端调用代理的凭据（独立于上游 key）。
+type Config struct {
+	ID          uint      `gorm:"column:id;primary_key" json:"-"`
+	LLMApiBase  string    `gorm:"column:llm_api_base" json:"llmApiBase"`
+	LLMApiKey   string    `gorm:"column:llm_api_key" json:"-"`
+	LLMModel    string    `gorm:"column:llm_model" json:"llmModel"`
+	LLMEnabled  bool      `gorm:"column:llm_enabled" json:"llmEnabled"`
+	VLMApiBase  string    `gorm:"column:vlm_api_base" json:"vlmApiBase"`
+	VLMApiKey   string    `gorm:"column:vlm_api_key" json:"-"`
+	VLMModel    string    `gorm:"column:vlm_model" json:"vlmModel"`
+	VLMEnabled  bool      `gorm:"column:vlm_enabled" json:"vlmEnabled"`
+	ForwardKey  string    `gorm:"column:forward_key" json:"-"`
+	ForwardKeyWritten bool `gorm:"column:forward_key_written" json:"-"`
+	UpdatedAt   time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+// TableName 指定表名。
+func (Config) TableName() string { return "llm_proxy_config" }
+
+// DefaultConfig 返回默认配置（sophnet 上游：LLM=deepseek，VLM=vl-flash）。
+// ApiBase 为 OpenAI 兼容 base（转发时直接拼 /chat/completions）。
+func DefaultConfig() Config {
+	return Config{
+		ID:         1,
+		LLMApiBase: "https://www.sophnet.com/api/open-apis/v1",
+		LLMModel:   "sophnet-deepseek",
+		LLMEnabled: true,
+		VLMApiBase: "https://www.sophnet.com/api/open-apis/v1",
+		VLMModel:   "sophnet-vl-flash",
+		VLMEnabled: true,
+	}
+}
+
+// Provider 标识上游模型类型。
+type Provider string
+
+const (
+	ProviderLLM Provider = "llm"
+	ProviderVLM Provider = "vlm"
+)
+
+// LLM 返回 LLM 上游配置。
+func (c Config) LLM() ProviderConfig {
+	return ProviderConfig{ApiBase: c.LLMApiBase, ApiKey: c.LLMApiKey, ModelName: c.LLMModel, Enabled: c.LLMEnabled}
+}
+
+// VLM 返回 VLM 上游配置。
+func (c Config) VLM() ProviderConfig {
+	return ProviderConfig{ApiBase: c.VLMApiBase, ApiKey: c.VLMApiKey, ModelName: c.VLMModel, Enabled: c.VLMEnabled}
+}
+
+// Provider 按类型取上游配置。
+func (c Config) Provider(kind Provider) ProviderConfig {
+	if kind == ProviderVLM {
+		return c.VLM()
+	}
+	return c.LLM()
+}
+
+// SaveRequest 保存配置请求体。
+// 各 key 为空表示不修改（保留原值，前端脱敏不回传全量 key）。
+type SaveRequest struct {
+	LLMApiBase  string `json:"llmApiBase"`
+	LLMApiKey   string `json:"llmApiKey"`
+	LLMModel    string `json:"llmModel"`
+	LLMEnabled  *bool  `json:"llmEnabled"`
+	VLMApiBase  string `json:"vlmApiBase"`
+	VLMApiKey   string `json:"vlmApiKey"`
+	VLMModel    string `json:"vlmModel"`
+	VLMEnabled  *bool  `json:"vlmEnabled"`
+}
+
+// ConfigResponse 配置响应（各 key 脱敏为 hasKey 布尔；ForwardKey 明文返回供前端展示）。
+type ConfigResponse struct {
+	LLMApiBase      string    `json:"llmApiBase"`
+	LLMModel        string    `json:"llmModel"`
+	LLMEnabled      bool      `json:"llmEnabled"`
+	LLMHasKey       bool      `json:"llmHasKey"`
+	VLMApiBase      string    `json:"vlmApiBase"`
+	VLMModel        string    `json:"vlmModel"`
+	VLMEnabled      bool      `json:"vlmEnabled"`
+	VLMHasKey       bool      `json:"vlmHasKey"`
+	ForwardKey      string    `json:"forwardKey"`
+	ForwardKeyReady bool      `json:"forwardKeyReady"` // 是否已写入本地 picoclaw
+	UpdatedAt       time.Time `json:"updatedAt"`
+}
+
+// ModelInfo 模型列表条目（供应商 openai 接口返回）。
+type ModelInfo struct {
+	ID string `json:"id"`
+}
+
+// DevProxyModel 兼容别名：客户端可用该名请求，代理不限制入站 model 名。
+const DevProxyModel = "devproxy"

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -16,6 +16,7 @@ import (
 	"bmssm/mvc/hardware"
 	"bmssm/mvc/health"
 	"bmssm/mvc/logs"
+	llmproxyCtrl "bmssm/mvc/llmproxy"
 	metricsCtrl "bmssm/mvc/metrics"
 	"bmssm/mvc/network"
 	portsCtrl "bmssm/mvc/ports"
@@ -49,6 +50,7 @@ func Register(r *gin.Engine) {
 	systemdC := systemdCtrl.DefaultController()
 	portsC := portsCtrl.DefaultController()
 	fwCtrl := firewallCtrl.DefaultController()
+	llmproxyCtrl := llmproxyCtrl.DefaultController()
 
 	// 公开：仅 login（含独立防爆破限流，约 5 次/12s/IP）
 	public := r.Group("/api/v1")
@@ -108,6 +110,11 @@ func Register(r *gin.Engine) {
 		// 端口状态
 		api.GET("/ports/listening", portsC.Listening)
 
+		// LLM 转发配置（读）
+		api.GET("/llm-proxy/config", llmproxyCtrl.GetConfig)
+		// 模型列表（从供应商拉取，供前端弹窗选择）
+		api.GET("/llm-proxy/models", llmproxyCtrl.ListModels)
+
 		// Docker
 		api.GET("/docker/container", dockerCtrl.ListContainers)
 		api.GET("/docker/image", dockerCtrl.ListImages)
@@ -156,6 +163,12 @@ func Register(r *gin.Engine) {
 		admin.POST("/docker/container/:name/stop", dockerCtrl.StopContainer)
 		admin.DELETE("/docker/container/:name", dockerCtrl.RemoveContainer)
 		admin.DELETE("/docker/image/:id", dockerCtrl.RemoveImage)
+
+		// LLM 转发配置（写）
+		admin.PUT("/llm-proxy/config", llmproxyCtrl.SaveConfig)
+		admin.POST("/llm-proxy/forward-key/reset", llmproxyCtrl.ResetForwardKey)
+		admin.POST("/llm-proxy/forward-key/write-picoclaw", llmproxyCtrl.WriteForwardKey)
+		admin.POST("/llm-proxy/test", llmproxyCtrl.RunTest)
 
 		// 软件/OTA（写）
 		admin.POST("/software/install", softwareCtrl.Install)

--- a/source/pbmssm/router/router_test.go
+++ b/source/pbmssm/router/router_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"bmssm/config"
 	"bmssm/global"
 )
 
@@ -54,5 +55,31 @@ func TestHealthz(t *testing.T) {
 	}
 	if body["uptime"] == "" {
 		t.Fatalf("uptime empty")
+	}
+}
+
+// TestLlmProxyRoutes 验证 llm-proxy 配置路由已注册：
+// 无 token 时 GET/PUT 均返回 401（Auth 中间件），而非 404。
+func TestLlmProxyRoutes(t *testing.T) {
+	gin.SetMode(gin.ReleaseMode)
+	// Auth 中间件读取 config.Conf；测试需先初始化（用默认值即可）
+	config.LoadFromDir(t.TempDir())
+	r := gin.New()
+	Register(r)
+
+	// GET 无 token → 401（路由存在且被 Auth 拦截）
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/llm-proxy/config", nil)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("GET config without token = %d, want 401", w.Code)
+	}
+
+	// PUT 无 token → 401
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPut, "/api/v1/llm-proxy/config", nil)
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("PUT config without token = %d, want 401", w2.Code)
 	}
 }

--- a/source/psophliteos/api/v1/system/enter.go
+++ b/source/psophliteos/api/v1/system/enter.go
@@ -5,4 +5,5 @@ type ApiGroup struct {
 	VersionApi
 	UpgradeApi
 	MetricsSelApi
+	AiAgentApi
 }

--- a/source/psophliteos/api/v1/system/sys_ai_agent.go
+++ b/source/psophliteos/api/v1/system/sys_ai_agent.go
@@ -1,0 +1,74 @@
+package system
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"sophliteos/logger"
+	mvc "sophliteos/mvc/core"
+
+	"github.com/gin-gonic/gin"
+)
+
+// AiAgentApi AI Agent 功能：picoclaw web 端口探测与转发、本地模型样例。
+// LLM/VLM API 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（sophliteos 不再刷新 picoclaw）。
+type AiAgentApi struct{}
+
+const defaultPicoclawPort = 18800 // picoclaw web 默认端口
+
+// detectPicoclawPort 探测 picoclaw web 端口：默认 18800，若不可用则探测候选端口。
+func detectPicoclawPort() int {
+	candidates := []int{defaultPicoclawPort}
+	for _, p := range []int{18790, 8081, 18801} {
+		if p != defaultPicoclawPort {
+			candidates = append(candidates, p)
+		}
+	}
+	for _, p := range candidates {
+		if picoclawWebUp(p) {
+			return p
+		}
+	}
+	return defaultPicoclawPort
+}
+
+// picoclawWebUp 探测端口上是否为 picoclaw web（GET / 返回 2xx/3xx 即视为 up）。
+func picoclawWebUp(port int) bool {
+	client := &http.Client{Timeout: 3 * time.Second}
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode >= 200 && resp.StatusCode < 400
+}
+
+// Port GET 返回探测到的 picoclaw web 端口。
+func (a *AiAgentApi) Port(c *gin.Context) {
+	c.JSON(http.StatusOK, mvc.Success(gin.H{"port": detectPicoclawPort()}))
+}
+
+// Proxy 反向代理 picoclaw web（保留路径与查询串；供 iframe 同源访问使用）。
+func (a *AiAgentApi) Proxy(c *gin.Context) {
+	port := detectPicoclawPort()
+	target, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
+	if err != nil {
+		c.JSON(http.StatusOK, mvc.Fail(-1, "proxy target error"))
+		return
+	}
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	originalDirector := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		originalDirector(req)
+		req.Host = target.Host
+	}
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, e error) {
+		logger.Error("picoclaw 代理错误 %s %s: %v", r.Method, r.URL.Path, e)
+		w.WriteHeader(http.StatusBadGateway)
+	}
+	proxy.ServeHTTP(c.Writer, c.Request)
+}

--- a/source/psophliteos/frontend/pnpm-lock.yaml
+++ b/source/psophliteos/frontend/pnpm-lock.yaml
@@ -4,11 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  bin-wrapper: npm:bin-wrapper-china
-  rollup: ^2.56.3
-  gifsicle: 5.2.0
-
 importers:
 
   .:
@@ -288,7 +283,7 @@ importers:
         specifier: ^3.0.2
         version: 3.0.2
       rollup:
-        specifier: ^2.56.3
+        specifier: ^2.70.2
         version: 2.80.0
       rollup-plugin-visualizer:
         specifier: ^5.6.0
@@ -1424,7 +1419,7 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
       '@types/babel__core': ^7.1.9
-      rollup: ^2.56.3
+      rollup: ^1.20.0||^2.0.0
     peerDependenciesMeta:
       '@types/babel__core':
         optional: true
@@ -1433,18 +1428,18 @@ packages:
     resolution: {integrity: sha512-yc2n43jcqVyGE2sqV5/YCmocy9ArjVAP/BeXyTtADTBBX6V0e5UMqwO8CdQ0kzjb6zu5P1qMzsScCMRvE9OlVg==}
     engines: {node: '>= 10.0.0'}
     peerDependencies:
-      rollup: ^2.56.3
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/plugin-replace@2.4.2':
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
-      rollup: ^2.56.3
+      rollup: ^1.20.0 || ^2.0.0
 
   '@rollup/pluginutils@3.1.0':
     resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
     engines: {node: '>= 8.0.0'}
     peerDependencies:
-      rollup: ^2.56.3
+      rollup: ^1.20.0||^2.0.0
 
   '@rollup/pluginutils@4.2.1':
     resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
@@ -2136,17 +2131,13 @@ packages:
     resolution: {integrity: sha512-Mkfm4iE1VFt4xd4vH+gx+0/71esbfus2LsnCGe8Pi4mndSPyT+NGES/Eg99jx8/lUGWfu3z2yuB/bt5UB+iVbQ==}
     engines: {node: '>=6'}
 
-  bin-wrapper-china@0.1.0:
-    resolution: {integrity: sha512-1UCm17WYEbgry50tup+AQN+JGVEVzoW4f8HMl899k1lvuFxWKGZXl/G2fgxQxAckRjnloO3ijLVVEsv8zescUg==}
-    engines: {node: '>=8.3'}
-    hasBin: true
+  bin-wrapper@4.1.0:
+    resolution: {integrity: sha512-hfRmo7hWIXPkbpi0ZltboCMVrU+0ClXR/JgbCKKjlDjQf6igXa7OwdqNcFWQZPZTgiY7ZpzE3+LjjkLiTN2T7Q==}
+    engines: {node: '>=6'}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  binary-mirror-config@1.41.0:
-    resolution: {integrity: sha512-ZiIhR1s6Sv1Fv6qCQqfPjx0Cj86BgFlhqNxZgHkQOWcxJcMbO3mj1iqsuVjowYqJqeZL8e52+IEv7IRnSX6T6w==}
 
   bl@1.2.3:
     resolution: {integrity: sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==}
@@ -2623,6 +2614,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -3871,6 +3863,10 @@ packages:
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
+    engines: {node: '>=6'}
+
+  import-lazy@3.1.0:
+    resolution: {integrity: sha512-8/gvXvX2JMn0F+CDlSC4l6kOmVaLOO3XLkksI7CI3Ud95KDYJuYur2b9P/PUt/i/pDAMd/DulQsNbbbmRRsDIQ==}
     engines: {node: '>=6'}
 
   import-lazy@4.0.0:
@@ -5609,7 +5605,7 @@ packages:
     resolution: {integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-terser
     peerDependencies:
-      rollup: ^2.56.3
+      rollup: ^2.0.0
 
   rollup-plugin-visualizer@5.14.0:
     resolution: {integrity: sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==}
@@ -5617,12 +5613,17 @@ packages:
     hasBin: true
     peerDependencies:
       rolldown: 1.x
-      rollup: ^2.56.3
+      rollup: 2.x || 3.x || 4.x
     peerDependenciesMeta:
       rolldown:
         optional: true
       rollup:
         optional: true
+
+  rollup@2.77.3:
+    resolution: {integrity: sha512-/qxNTG7FbmefJWoeeYJFbHehJ2HNWnjkAFRKzWN/45eNBBF/r8lo992CwcJXEzyVxs5FmfId+vTSTQDb+bxA+g==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
 
   rollup@2.80.0:
     resolution: {integrity: sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==}
@@ -6665,7 +6666,7 @@ packages:
     engines: {node: '>=10.4'}
 
   webworkify-webpack@https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef:
-    resolution: {tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/xqq/webworkify-webpack/tar.gz/24d1e719b4a6cac37a518b2bb10fe124527ef4ef}
     version: 2.1.5
 
   whatwg-encoding@1.0.5:
@@ -9045,19 +9046,16 @@ snapshots:
       execa: 1.0.0
       find-versions: 3.2.0
 
-  bin-wrapper-china@0.1.0:
+  bin-wrapper@4.1.0:
     dependencies:
       bin-check: 4.1.0
       bin-version-check: 4.0.0
-      binary-mirror-config: 1.41.0
       download: 7.1.0
-      import-lazy: 4.0.0
+      import-lazy: 3.1.0
       os-filter-obj: 2.0.0
       pify: 4.0.1
 
   binary-extensions@2.3.0: {}
-
-  binary-mirror-config@1.41.0: {}
 
   bl@1.2.3:
     dependencies:
@@ -9664,7 +9662,7 @@ snapshots:
   cwebp-bin@6.1.2:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
 
   cz-git@1.13.1: {}
 
@@ -10721,7 +10719,7 @@ snapshots:
   gifsicle@5.2.0:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
       execa: 5.1.1
       logalot: 2.1.0
 
@@ -11081,6 +11079,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  import-lazy@3.1.0: {}
 
   import-lazy@4.0.0: {}
 
@@ -11804,13 +11804,13 @@ snapshots:
   jpegtran-bin@5.0.2:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
       logalot: 2.1.0
 
   jpegtran-bin@6.0.1:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
 
   js-base64@2.6.4: {}
 
@@ -12284,7 +12284,7 @@ snapshots:
   mozjpeg@7.1.1:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
 
   mpegts.js@1.8.0:
     dependencies:
@@ -12467,7 +12467,7 @@ snapshots:
   optipng-bin@7.0.1:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
 
   ora@5.4.1:
     dependencies:
@@ -12686,7 +12686,7 @@ snapshots:
   pngquant-bin@6.0.1:
     dependencies:
       bin-build: 3.0.0
-      bin-wrapper: bin-wrapper-china@0.1.0
+      bin-wrapper: 4.1.0
       execa: 4.1.0
 
   posix-character-classes@0.1.1: {}
@@ -13066,6 +13066,10 @@ snapshots:
       yargs: 17.7.3
     optionalDependencies:
       rollup: 2.80.0
+
+  rollup@2.77.3:
+    optionalDependencies:
+      fsevents: 2.3.3
 
   rollup@2.80.0:
     optionalDependencies:
@@ -14168,7 +14172,7 @@ snapshots:
       esbuild: 0.14.54
       postcss: 8.5.16
       resolve: 1.22.12
-      rollup: 2.80.0
+      rollup: 2.77.3
     optionalDependencies:
       fsevents: 2.3.3
       less: 4.6.7

--- a/source/psophliteos/frontend/pnpm-workspace.yaml
+++ b/source/psophliteos/frontend/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+allowBuilds:
+  core-js: true
+  cwebp-bin: true
+  esbuild: true
+  gifsicle: true
+  jpegtran-bin: true
+  mozjpeg: true
+  optipng-bin: true
+  pngquant-bin: true
+  vue-demi: true

--- a/source/psophliteos/frontend/src/api/aiAgent/index.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/index.ts
@@ -1,0 +1,164 @@
+import { defHttp } from '/@/utils/http/axios';
+
+// Agent 配置相关接口。
+// - LLM/VLM 配置 + 转发 key 管理：走 bmssm /api/v1/llm-proxy/*（经 sophliteos 反代）
+// - 端口探测/转发：sophliteos 本地端点 /api/device/ai-agent/*
+// defHttp 自动加 /api 前缀。
+enum Api {
+  LlmProxyConfig = '/v1/llm-proxy/config',
+  LlmProxyModels = '/v1/llm-proxy/models',
+  ForwardKeyReset = '/v1/llm-proxy/forward-key/reset',
+  ForwardKeyWrite = '/v1/llm-proxy/forward-key/write-picoclaw',
+  LlmProxyTest = '/v1/llm-proxy/test',
+  Port = '/device/ai-agent/port',
+}
+
+export interface TestResult {
+  name: string;
+  ok: boolean;
+  message: string;
+}
+
+export interface TestResponse {
+  results: TestResult[];
+  allOk: boolean;
+}
+
+export interface AgentConfig {
+  llmApiBase: string;
+  llmModel: string;
+  llmEnabled: boolean;
+  llmHasKey: boolean;
+  vlmApiBase: string;
+  vlmModel: string;
+  vlmEnabled: boolean;
+  vlmHasKey: boolean;
+  forwardKey: string;
+  forwardKeyReady: boolean;
+  updatedAt?: string;
+}
+
+// 读取已存配置（bmssm）；无则返回 null。
+export async function getAgentConfig(): Promise<AgentConfig | null> {
+  try {
+    const res = await defHttp.get<AgentConfig>(
+      { url: Api.LlmProxyConfig },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    return data && typeof data === 'object' && 'llmApiBase' in data ? (data as AgentConfig) : null;
+  } catch {
+    return null;
+  }
+}
+
+// 保存 LLM/VLM 配置（key 为空表示不修改）。
+export async function saveAgentConfig(cfg: {
+  llmApiBase: string;
+  llmApiKey: string;
+  llmModel: string;
+  llmEnabled: boolean;
+  vlmApiBase: string;
+  vlmApiKey: string;
+  vlmModel: string;
+  vlmEnabled: boolean;
+}): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const res = await defHttp.put(
+      { url: Api.LlmProxyConfig, data: cfg },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && 'llmApiBase' in data) {
+      return { ok: true };
+    }
+    return { ok: false, message: (res as any)?.error_message || (res as any)?.msg || '保存失败' };
+  } catch (e: any) {
+    return { ok: false, message: e?.message || '保存失败' };
+  }
+}
+
+// 从供应商拉取模型列表（kind=llm|vlm）。
+export async function getProviderModels(kind: 'llm' | 'vlm'): Promise<string[]> {
+  try {
+    const res = await defHttp.get<{ models: { id: string }[] }>(
+      { url: Api.LlmProxyModels, params: { kind } },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    const list = data?.models;
+    return Array.isArray(list) ? list.map((m: any) => m?.id ?? m).filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+// 重置转发 key。
+export async function resetForwardKey(): Promise<{ ok: boolean; key?: string; message?: string }> {
+  try {
+    const res = await defHttp.post(
+      { url: Api.ForwardKeyReset },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && data.forwardKey) {
+      return { ok: true, key: data.forwardKey };
+    }
+    return { ok: false, message: (res as any)?.error_message || '重置失败' };
+  } catch (e: any) {
+    return { ok: false, message: e?.message || '重置失败' };
+  }
+}
+
+// 写入本地 picoclaw。
+export async function writeForwardKeyToPicoclaw(): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const res = await defHttp.post(
+      { url: Api.ForwardKeyWrite },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && data.ok) {
+      return { ok: true };
+    }
+    return { ok: false, message: (res as any)?.error_message || '写入失败' };
+  } catch (e: any) {
+    return { ok: false, message: e?.message || '写入失败' };
+  }
+}
+
+// 探测 picoclaw web 端口（本地端点）。
+export async function detectPicoclawPort(): Promise<number | null> {
+  try {
+    const res = await defHttp.get<{ port: number }>(
+      { url: Api.Port },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && typeof data.port === 'number') {
+      return data.port;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// 一键测试：带图分发 + LLM 推理。
+export async function testAgentConfig(): Promise<{ ok: boolean; data?: TestResponse; message?: string }> {
+  try {
+    const res = await defHttp.post<TestResponse>(
+      { url: Api.LlmProxyTest },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && 'allOk' in data) {
+      return { ok: true, data: data as TestResponse };
+    }
+    return { ok: false, message: (res as any)?.error_message || '测试失败' };
+  } catch (e: any) {
+    return { ok: false, message: e?.message || '测试失败' };
+  }
+}
+
+export { Api as AgentConfigApi };

--- a/source/psophliteos/frontend/src/locales/lang/en/routes/dashboard.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/routes/dashboard.ts
@@ -26,6 +26,9 @@ export default {
   serviceManage: 'Service Management',
   portStatus: 'Port Status',
   firewall: 'Firewall',
+  aiAgent: 'AI Agent',
+  aiAgentApiConfig: 'Agent Config',
+  aiAgentAgent: 'Agent',
   content: {
     sysContent:
       'System OTA upgrade, suitable for version upgrade, does not support downgrade and cross version upgrade, otherwise it may cause system damage.',

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/routes/dashboard.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/routes/dashboard.ts
@@ -26,6 +26,9 @@ export default {
   serviceManage: '服务管理',
   portStatus: '端口状态',
   firewall: '防火墙',
+  aiAgent: 'AI Agent',
+  aiAgentApiConfig: 'Agent 配置',
+  aiAgentAgent: 'Agent',
   content: {
     sysContent: '系统OTA升级,适用于版本升级,不支持降级和跨版本升级,否则可能导致系统损坏。',
     ssmContent:

--- a/source/psophliteos/frontend/src/router/routes/modules/aiAgent.ts
+++ b/source/psophliteos/frontend/src/router/routes/modules/aiAgent.ts
@@ -1,0 +1,36 @@
+import type { AppRouteModule } from '/@/router/types';
+
+import { LAYOUT } from '/@/router/constant';
+import { t } from '/@/hooks/web/useI18n';
+
+const aiAgent: AppRouteModule = {
+  path: '/ai-agent',
+  name: 'AiAgent',
+  component: LAYOUT,
+  redirect: '/ai-agent/apiConfig',
+  meta: {
+    orderNo: 4,
+    icon: 'bx:bot',
+    title: t('routes.dashboard.aiAgent'),
+  },
+  children: [
+    {
+      path: 'apiConfig',
+      name: 'AiAgentApiConfig',
+      component: () => import('/@/views/ai-agent/apiConfig/index.vue'),
+      meta: {
+        title: t('routes.dashboard.aiAgentApiConfig'),
+      },
+    },
+    {
+      path: 'agent',
+      name: 'AiAgentAgent',
+      component: () => import('/@/views/ai-agent/agent/index.vue'),
+      meta: {
+        title: t('routes.dashboard.aiAgentAgent'),
+      },
+    },
+  ],
+};
+
+export default aiAgent;

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/index.vue
@@ -1,0 +1,78 @@
+<template>
+  <div class="p-4">
+    <a-card :bordered="false">
+      <template #title>
+        <a-space>
+          <span>AI Agent</span>
+          <a-tag v-if="port" color="green">端口 {{ port }}</a-tag>
+          <a-tag v-else color="orange">端口探测中</a-tag>
+        </a-space>
+      </template>
+      <template #extra>
+        <a-space>
+          <a-button size="small" :loading="detecting" @click="init">重新探测</a-button>
+        </a-space>
+      </template>
+
+      <div v-if="!ready" class="flex items-center justify-center" style="min-height: 200px">
+        <a-spin :spinning="detecting" size="large">
+          <div class="text-gray-400">正在探测 picoclaw 服务…</div>
+        </a-spin>
+      </div>
+
+      <div v-else-if="frameSrc" class="overflow-hidden rounded border border-gray-200">
+        <iframe
+          :src="frameSrc"
+          class="w-full"
+          style="height: calc(100vh - 260px); border: none"
+          frameborder="0"
+        ></iframe>
+      </div>
+
+      <a-alert
+        v-else
+        type="warning"
+        show-icon
+        message="未检测到 picoclaw 服务"
+        description="请确认设备上 picoclaw 已启动（默认端口 18800），或先到「API 配置」页保存配置。"
+      />
+    </a-card>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  // @ts-nocheck
+  import { ref, onMounted } from 'vue';
+  import { Card, Space, Tag, Button, Spin, Alert } from 'ant-design-vue';
+  import { detectPicoclawPort } from '/@/api/aiAgent';
+
+  const ACard = Card;
+  const ASpace = Space;
+  const ATag = Tag;
+  const AButton = Button;
+  const ASpin = Spin;
+  const AAlert = Alert;
+
+  const port = ref<number | null>(null);
+  const detecting = ref(false);
+  const ready = ref(false);
+
+  const frameSrc = ref('');
+
+  async function init() {
+    detecting.value = true;
+    ready.value = false;
+    const p = await detectPicoclawPort();
+    port.value = p;
+    ready.value = true;
+    if (p) {
+      // iframe 直连 picoclaw web（/api 绝对路径前端，端口可直连；优先于同源反代）
+      frameSrc.value = `http://${window.location.hostname}:${p}/`;
+    } else {
+      frameSrc.value = '';
+    }
+    detecting.value = false;
+  }
+
+  onMounted(init);
+</script>

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -1,0 +1,494 @@
+<template>
+  <div class="p-4">
+    <a-card :bordered="false" title="Agent 配置">
+      <!-- 页选框：LLM / VLM -->
+      <a-radio-group v-model:value="activeKey" button-style="solid" class="mb-4">
+        <a-radio-button value="llm">LLM 模型</a-radio-button>
+        <a-radio-button value="vlm">VLM 模型</a-radio-button>
+      </a-radio-group>
+
+      <!-- LLM 配置（仅选中时渲染） -->
+      <a-form
+        v-if="activeKey === 'llm'"
+        :label-col="{ span: 5 }"
+        :wrapper-col="{ span: 16 }"
+        class="max-w-2xl"
+      >
+        <a
+          href="https://sophnet.com/"
+          target="_blank"
+          rel="noopener"
+          class="sophnet-promo my-5 block no-underline"
+        >
+          <div class="flex items-baseline gap-3">
+            <span class="sophnet-promo-title">Sophnet</span>
+            <span class="sophnet-promo-text">专为开发者打造的 AI 工具平台，让 AI 集成变得简单高效</span>
+          </div>
+        </a>
+        <a-form-item label="API Base URL">
+          <a-select
+            v-model:value="form.llmApiBaseType"
+            style="width: 100%"
+            :options="apiBaseOptions"
+            @change="onApiBaseChange('llm', $event)"
+          />
+        </a-form-item>
+        <a-form-item label="API Key">
+          <a-input-password
+            v-model:value="form.llmApiKey"
+            :placeholder="form.llmHasKey ? '已配置（留空保持不变）' : '请输入上游 API Key'"
+            autocomplete="new-password"
+          />
+        </a-form-item>
+        <a-form-item label="模型名称">
+          <a-input-group compact>
+            <a-input v-model:value="form.llmModel" style="width: 60%" placeholder="sophnet-deepseek" />
+            <a-button style="width: 20%" @click="openModelPicker('llm')">选择</a-button>
+          </a-input-group>
+        </a-form-item>
+        <a-form-item label="启用">
+          <a-switch v-model:checked="form.llmEnabled" />
+        </a-form-item>
+      </a-form>
+
+      <!-- VLM 配置（仅选中时渲染） -->
+      <a-form
+        v-else-if="activeKey === 'vlm'"
+        :label-col="{ span: 5 }"
+        :wrapper-col="{ span: 16 }"
+        class="max-w-2xl"
+      >
+        <a
+          href="https://sophnet.com/"
+          target="_blank"
+          rel="noopener"
+          class="sophnet-promo my-5 block no-underline"
+        >
+          <div class="flex items-baseline gap-3">
+            <span class="sophnet-promo-title">Sophnet</span>
+            <span class="sophnet-promo-text">专为开发者打造的 AI 工具平台，让 AI 集成变得简单高效</span>
+          </div>
+        </a>
+        <a-form-item label="API Base URL">
+          <a-select
+            v-model:value="form.vlmApiBaseType"
+            style="width: 100%"
+            :options="apiBaseOptions"
+            @change="onApiBaseChange('vlm', $event)"
+          />
+        </a-form-item>
+        <a-form-item label="API Key">
+          <a-input-password
+            v-model:value="form.vlmApiKey"
+            :placeholder="form.vlmHasKey ? '已配置（留空保持不变）' : '请输入上游 API Key'"
+            autocomplete="new-password"
+          />
+        </a-form-item>
+        <a-form-item label="模型名称">
+          <a-input-group compact>
+            <a-input v-model:value="form.vlmModel" style="width: 60%" placeholder="sophnet-vl-flash" />
+            <a-button style="width: 20%" @click="openModelPicker('vlm')">选择</a-button>
+          </a-input-group>
+        </a-form-item>
+        <a-form-item label="启用">
+          <a-switch v-model:checked="form.vlmEnabled" />
+        </a-form-item>
+      </a-form>
+
+      <!-- 保存 + 测试 -->
+      <div class="mt-4 flex items-center gap-2">
+        <a-button type="primary" :loading="saving" @click="handleSave">保存配置</a-button>
+        <a-button :loading="testing" @click="handleTest">测试</a-button>
+      </div>
+
+      <!-- 测试结果 -->
+      <div v-if="testResults.length" class="mt-3 max-w-2xl">
+        <a-alert
+          :type="testAllOK ? 'success' : 'error'"
+          show-icon
+          :message="testAllOK ? '测试全部通过' : '部分测试未通过'"
+          class="mb-2"
+        />
+        <div v-for="(r, idx) in testResults" :key="idx" class="mb-2">
+          <div class="font-medium">
+            <a-tag :color="r.ok ? 'green' : 'red'">{{ r.ok ? '通过' : '失败' }}</a-tag>
+            {{ r.name }}
+          </div>
+          <div class="text-sm text-gray-600 break-all">{{ r.message }}</div>
+        </div>
+      </div>
+
+      <a-divider />
+
+      <!-- 转发 key 管理 -->
+      <div class="mt-4">
+        <div class="font-medium mb-2">转发 Key（客户端调用代理的凭据）</div>
+        <a-alert
+          v-if="form.forwardKeyReady"
+          type="success"
+          show-icon
+          message="已写入本地 picoclaw（devproxy.key）"
+          class="mb-2"
+        />
+        <a-input-group compact class="max-w-xl">
+          <a-input
+            v-model:value="form.forwardKey"
+            read-only
+            style="width: 60%"
+            placeholder="转发 key 尚未生成"
+          />
+          <a-button style="width: 12%" @click="copyForwardKey">拷贝</a-button>
+          <a-button style="width: 12%" :loading="resetting" @click="handleResetKey">重置</a-button>
+          <a-button
+            style="width: 16%"
+            type="primary"
+            :loading="writing"
+            @click="handleWriteKey"
+            >写入本地</a-button
+          >
+        </a-input-group>
+        <div class="text-gray-400 text-xs mt-1">
+          重置会生成新 key；「写入本地」将覆盖 /home/linaro/.picoclaw/devproxy.key 并重启 picoclaw
+        </div>
+      </div>
+    </a-card>
+
+    <!-- 模型选择弹窗 -->
+    <a-modal
+      v-model:open="picker.visible"
+      :title="`选择 ${picker.kind === 'llm' ? 'LLM' : 'VLM'} 模型`"
+      @ok="applyPickedModel"
+      :ok-button-props="{ disabled: !picker.selected }"
+    >
+      <div class="mb-3">
+        <a-input-search
+          v-model:value="picker.custom"
+          placeholder="或手动输入模型名，回车确认"
+          enter-button="使用"
+          @search="applyCustomModel"
+        />
+      </div>
+      <a-select
+        v-model:value="picker.selected"
+        style="width: 100%"
+        placeholder="从供应商拉取模型列表"
+        :loading="picker.loading"
+        :options="picker.options"
+        @dropdown-visible-change="loadModels"
+        allow-clear
+      />
+    </a-modal>
+  </div>
+</template>
+
+<script lang="ts" setup>
+  // @ts-nocheck
+  import { reactive, ref, onMounted } from 'vue';
+  import {
+    Card,
+    Radio,
+    Form,
+    Input,
+    Button,
+    Space,
+    Switch,
+    Divider,
+    Alert,
+    Modal,
+    Select,
+    Tag,
+    message,
+  } from 'ant-design-vue';
+  import {
+    getAgentConfig,
+    saveAgentConfig,
+    getProviderModels,
+    resetForwardKey,
+    writeForwardKeyToPicoclaw,
+    testAgentConfig,
+    type AgentConfig,
+    type TestResult,
+  } from '/@/api/aiAgent';
+
+  const ACard = Card;
+  const ARadioGroup = Radio.Group;
+  const ARadioButton = Radio.Button;
+  const AForm = Form;
+  const AFormItem = Form.Item;
+  const AInput = Input;
+  const AInputPassword = Input.Password;
+  const AInputGroup = Input.Group;
+  const AInputSearch = Input.Search;
+  const AButton = Button;
+  const ASpace = Space;
+  const ASwitch = Switch;
+  const ADivider = Divider;
+  const AAlert = Alert;
+  const AModal = Modal;
+  const ASelect = Select;
+  const ATag = Tag;
+
+  const activeKey = ref('llm');
+  const saving = ref(false);
+  const resetting = ref(false);
+  const writing = ref(false);
+  const testing = ref(false);
+  const testResults = ref<TestResult[]>([]);
+  const testAllOK = ref(true);
+
+  // API Base URL 预设
+  const SOPHNET_API_BASE = 'https://www.sophnet.com/api/open-apis/v1';
+  const LOCAL_API_BASE = 'http://127.0.0.1:8000/v1';
+  const apiBaseOptions = [
+    { label: 'Sophnet', value: 'sophnet' },
+    { label: '本地模型', value: 'local' },
+  ];
+  const apiBaseByType: Record<string, string> = {
+    sophnet: SOPHNET_API_BASE,
+    local: LOCAL_API_BASE,
+  };
+
+  const form = reactive({
+    llmApiBase: '',
+    llmApiBaseType: 'sophnet',
+    llmApiKey: '',
+    llmModel: '',
+    llmEnabled: true,
+    llmHasKey: false,
+    vlmApiBase: '',
+    vlmApiBaseType: 'sophnet',
+    vlmApiKey: '',
+    vlmModel: '',
+    vlmEnabled: true,
+    vlmHasKey: false,
+    forwardKey: '',
+    forwardKeyReady: false,
+  });
+
+  // 根据已存 apiBase 推断类型（匹配预设则对应类型，否则兜底 sophnet）
+  function inferApiBaseType(apiBase: string): string {
+    for (const [type, url] of Object.entries(apiBaseByType)) {
+      if (apiBase && apiBase === url) {
+        return type;
+      }
+    }
+    return 'sophnet';
+  }
+
+  // 下拉切换：自动填充对应 URL（sophnet 固定，不允许自定义）
+  function onApiBaseChange(kind: 'llm' | 'vlm', type: string) {
+    const url = apiBaseByType[type] || SOPHNET_API_BASE;
+    if (kind === 'llm') {
+      form.llmApiBase = url;
+    } else {
+      form.vlmApiBase = url;
+    }
+  }
+
+  const picker = reactive({
+    visible: false,
+    kind: 'llm' as 'llm' | 'vlm',
+    options: [] as { label: string; value: string }[],
+    selected: undefined as string | undefined,
+    custom: '',
+    loading: false,
+  });
+
+  async function init() {
+    const cfg: AgentConfig | null = await getAgentConfig();
+    if (cfg) {
+      form.llmApiBase = cfg.llmApiBase || SOPHNET_API_BASE;
+      form.llmApiBaseType = inferApiBaseType(cfg.llmApiBase || '');
+      form.llmModel = cfg.llmModel || '';
+      form.llmEnabled = cfg.llmEnabled !== false;
+      form.llmHasKey = !!cfg.llmHasKey;
+      form.vlmApiBase = cfg.vlmApiBase || SOPHNET_API_BASE;
+      form.vlmApiBaseType = inferApiBaseType(cfg.vlmApiBase || '');
+      form.vlmModel = cfg.vlmModel || '';
+      form.vlmEnabled = cfg.vlmEnabled !== false;
+      form.vlmHasKey = !!cfg.vlmHasKey;
+      form.forwardKey = cfg.forwardKey || '';
+      form.forwardKeyReady = !!cfg.forwardKeyReady;
+    }
+  }
+
+  async function handleSave() {
+    if (!form.llmApiBase.trim() && !form.vlmApiBase.trim()) {
+      message.warning('LLM 或 VLM 至少配置一个 API Base URL');
+      return;
+    }
+    saving.value = true;
+    const res = await saveAgentConfig({
+      llmApiBase: form.llmApiBase.trim(),
+      llmApiKey: form.llmApiKey,
+      llmModel: form.llmModel.trim() || 'sophnet-deepseek',
+      llmEnabled: form.llmEnabled,
+      vlmApiBase: form.vlmApiBase.trim(),
+      vlmApiKey: form.vlmApiKey,
+      vlmModel: form.vlmModel.trim() || 'sophnet-vl-flash',
+      vlmEnabled: form.vlmEnabled,
+    });
+    saving.value = false;
+    if (res.ok) {
+      message.success('配置已保存，转发服务已生效');
+      form.llmApiKey = '';
+      form.vlmApiKey = '';
+      form.llmHasKey = true;
+      form.vlmHasKey = true;
+    } else {
+      message.error(res.message || '保存失败');
+    }
+  }
+
+  async function handleTest() {
+    testing.value = true;
+    testResults.value = [];
+    const res = await testAgentConfig();
+    testing.value = false;
+    if (res.ok && res.data) {
+      testResults.value = res.data.results || [];
+      testAllOK.value = !!res.data.allOk;
+    } else {
+      testAllOK.value = false;
+      testResults.value = [
+        { name: '测试', ok: false, message: res.message || '测试请求失败' },
+      ];
+    }
+  }
+
+  // --- 模型选择弹窗 ---
+  function openModelPicker(kind: 'llm' | 'vlm') {
+    picker.kind = kind;
+    picker.selected = undefined;
+    picker.custom = '';
+    picker.options = [];
+    picker.visible = true;
+  }
+
+  async function loadModels(open: boolean) {
+    if (!open || picker.options.length) return;
+    picker.loading = true;
+    const ids = await getProviderModels(picker.kind);
+    picker.options = ids.map((id) => ({ label: id, value: id }));
+    picker.loading = false;
+  }
+
+  function applyCustomModel() {
+    const v = picker.custom.trim();
+    if (!v) return;
+    applyModel(v);
+  }
+
+  function applyPickedModel() {
+    if (picker.selected) {
+      applyModel(picker.selected);
+    }
+  }
+
+  function applyModel(name: string) {
+    if (picker.kind === 'llm') {
+      form.llmModel = name;
+    } else {
+      form.vlmModel = name;
+    }
+    picker.visible = false;
+    message.success(`已选择模型 ${name}`);
+  }
+
+  // --- 转发 key 操作 ---
+  async function copyForwardKey() {
+    if (!form.forwardKey) {
+      message.warning('转发 key 尚未生成');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(form.forwardKey);
+      message.success('已拷贝到剪贴板');
+    } catch {
+      // 兼容非 https 环境
+      const ta = document.createElement('textarea');
+      ta.value = form.forwardKey;
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+      message.success('已拷贝到剪贴板');
+    }
+  }
+
+  async function handleResetKey() {
+    resetting.value = true;
+    const res = await resetForwardKey();
+    resetting.value = false;
+    if (res.ok && res.key) {
+      form.forwardKey = res.key;
+      form.forwardKeyReady = false;
+      message.success('转发 key 已重置（尚未写入本地 picoclaw）');
+    } else {
+      message.error(res.message || '重置失败');
+    }
+  }
+
+  async function handleWriteKey() {
+    if (!form.forwardKey) {
+      message.warning('转发 key 尚未生成');
+      return;
+    }
+    writing.value = true;
+    const res = await writeForwardKeyToPicoclaw();
+    writing.value = false;
+    if (res.ok) {
+      form.forwardKeyReady = true;
+      message.success('已写入本地 picoclaw 并重启');
+    } else {
+      message.error(res.message || '写入失败');
+    }
+  }
+
+  onMounted(init);
+</script>
+
+<style lang="less" scoped>
+  .sophnet-promo {
+    // 横幅与上下元素之间留白（my-5 已设 margin，这里定义内边距与视觉）
+    padding: 14px 20px;
+    border-radius: 10px;
+    border: 1px solid #d6e4ff;
+    background: linear-gradient(120deg, #eef4ff, #dceaff, #eef4ff);
+    background-size: 200% 100%;
+    animation: sophnet-gradient 8s ease infinite;
+    box-shadow: 0 1px 4px rgba(26, 115, 232, 0.08);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+  }
+
+  .sophnet-promo:hover {
+    box-shadow: 0 2px 10px rgba(26, 115, 232, 0.18);
+    border-color: #b6d0ff;
+  }
+
+  .sophnet-promo-title {
+    font-size: 18px;
+    font-weight: 700;
+    color: #1a73e8;
+    white-space: nowrap;
+  }
+
+  .sophnet-promo-text {
+    font-size: 15px;
+    color: #3c5a8f;
+    line-height: 1.5;
+  }
+
+  @keyframes sophnet-gradient {
+    0% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+    100% {
+      background-position: 0% 50%;
+    }
+  }
+</style>

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -97,6 +97,7 @@ func Routers() *gin.Engine {
 		systemRouter.InitVersionRouter(LocalGroup)
 		systemRouter.InitUpgradeRouter(LocalGroup)
 		systemRouter.InitMetricsSelRouter(LocalGroup)
+		systemRouter.InitAiAgentRouter(LocalGroup)
 	}
 
 	logger.Info("Router Init Ok")

--- a/source/psophliteos/router/system/enter.go
+++ b/source/psophliteos/router/system/enter.go
@@ -5,4 +5,5 @@ type RouterGroup struct {
 	VersionRouter
 	UpgradeRouter
 	MetricsSelRouter
+	AiAgentRouter
 }

--- a/source/psophliteos/router/system/sys_ai_agent.go
+++ b/source/psophliteos/router/system/sys_ai_agent.go
@@ -1,0 +1,25 @@
+package system
+
+import (
+	v1 "sophliteos/api/v1"
+	"sophliteos/global"
+	"sophliteos/middleware"
+
+	"github.com/gin-gonic/gin"
+)
+
+type AiAgentRouter struct{}
+
+// InitAiAgentRouter 注册 AI Agent 本地端点（不经 bmssm 反代）。
+// LLM/VLM 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（经 /api/v1/* 反代），
+// 此处仅保留 picoclaw 端口探测、本地模型样例与页面转发。
+func (s *AiAgentRouter) InitAiAgentRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
+	agentRouter := Router.Group("api/device/ai-agent", middleware.TimeoutMiddleware(global.TimeOut))
+	api := v1.ApiGroupApp.SystemApiGroup.AiAgentApi
+	{
+		agentRouter.GET("port", api.Port)
+		// picoclaw web 反代（iframe 同源访问）
+		agentRouter.Any("proxy/*any", api.Proxy)
+	}
+	return agentRouter
+}


### PR DESCRIPTION
## Summary

- **pbmssm** 新增 `mvc/llmproxy` 模块：LLM/VLM 双配置、转发 key 校验与写入 picoclaw、图片描述化转发（VLM 描述 + 哈希缓存 + 全走 LLM）、`/api/v1/llm-proxy/*` 管理接口
- **sophliteos** 前端新增 AI Agent 菜单（Agent 配置 / Agent 转发）：LLM/VLM 分栏、API Base URL 下拉（Sophnet/本地模型）、模型选择弹窗、转发 key 管理、一键测试、Sophnet 推广横幅
- **sophliteos** 后端保留 picoclaw 端口探测与 iframe 转发，LLM/VLM 配置交由 bmssm 管理

## Key Features

- LLM 转发：OpenAI 兼容 `/v1/chat/completions`，model=devproxy 替换为目标模型，SSE 流式透传
- 图片描述化：含图请求先经 VLM 生成描述，以文本插入原文位置后走 LLM，避免含图历史进入 VLM 降低推理质量；图片哈希缓存（LRU + TTL + 10MB 上限）
- 转发 key：独立于上游 key，校验入站请求；可重置/拷贝/显示/写入本地 picoclaw（devproxy.key）
- Agent 配置页：LLM/VLM 分栏、Sophnet/本地模型下拉、模型列表拉取/手动填写、一键测试带图分发 + LLM 推理

## Test plan

- pbmssm 单测覆盖：配置读写、转发 key 校验、图片描述化、缓存、路由
- 测试机（172.26.166.185）端到端：`/api/v1/llm-proxy/test` 全部通过（带图分发 + LLM 推理返回真实回复）；Agent 配置页保存/测试/转发 key 写入 picoclaw 全链路验证
- deb 产物：`bmssm_2.1.x_arm64.deb`、`sophliteos_soc_2.1.x.deb`