### PR TITLE
feat(bmssm): llm-proxy 去除转发 key 与 model 名称限制（MYS-171）

### DIFF
--- a/source/pbmssm/mvc/llmproxy/server.go
+++ b/source/pbmssm/mvc/llmproxy/server.go
@@ -147,22 +147,25 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 
 // handleChatCompletions POST /v1/chat/completions —— OpenAI 兼容转发。
 // 流程（图片描述化，防止含图历史进入 VLM 导致推理质量下滑）：
-//  1. 校验入站 Authorization: Bearer <forward_key>（不匹配 → 401）
+//  1. 转发 key 校验（MYS-171 放宽）：仅配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
+//     未配置 / 未携带 / 不匹配均放行，不强制拦截。
 //  2. 遍历所有 messages 的 content：
 //     - 文本块 → 保留
 //     - 图片块（image_url/image）→ 提取图片数据 → 哈希查缓存：
 //         * 命中 → 复用描述
 //         * 未命中 → 调 VLM 生成详细描述 → 缓存
 //       用文本块替换图片块：{type:text, text:"这里有一个 image，其内容如下：<描述>"}
-//  3. 所有请求统一路由到 LLM（替换 model 为 LLM model_name）
+//  3. 转发到 LLM：请求带非空 model 则保留，否则替换为配置的 LLM model_name
 //  4. 用 bmssm 内部存储的 LLM 上游 key 向供应商转发
 func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	cfg := currentConfig()
 
-	// 1. 转发 key 校验
-	if cfg.ForwardKey == "" || !validForwardKey(r, cfg.ForwardKey) {
-		http.Error(w, "unauthorized: invalid forward key", http.StatusUnauthorized)
-		return
+	// 1. 转发 key 校验（MYS-171：放宽策略，不做强制拦截）。
+	//    仅当配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
+	//    key 未配置 / 请求未携带 / 不匹配均放行（本地回环代理，暴露面可控）。
+	//    兼容旧 picoclaw 链路：其携带匹配 key 的请求行为不变。
+	if cfg.ForwardKey != "" && !validForwardKey(r, cfg.ForwardKey) {
+		logger.Warn("llm proxy: forward key mismatch (config set, request key absent or wrong)")
 	}
 
 	body, err := io.ReadAll(r.Body)

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -103,13 +103,23 @@ func TestServiceLoadWhenDBEmpty(t *testing.T) {
 	}
 }
 
-func TestForwardKeyAuth(t *testing.T) {
+// TestForwardKeyRelaxed 验证 MYS-171 放宽后的 key 策略：
+// 配置了 ForwardKey 时，无 key / 错误 key 均不再 401（放行到上游）。
+func TestForwardKeyRelaxed(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
 	svc := NewService(db)
+
+	// mock 上游，记录收到的请求并返回 200
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
 	cfg, _ := svc.SaveConfig(SaveRequest{
-		LLMApiBase: "http://127.0.0.1:1/v1", LLMApiKey: "k", LLMModel: "m",
-		VLMApiBase: "http://127.0.0.1:1/v1", VLMApiKey: "k", VLMModel: "m",
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "m",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "m",
 	})
 	// 强制设一个已知转发 key
 	cfg.ForwardKey = "test-forward-key"
@@ -118,21 +128,178 @@ func TestForwardKeyAuth(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]interface{}{"model": "x", "messages": []interface{}{}})
 
-	// 无 key → 401
+	cases := []struct {
+		name string
+		auth string // "" 表示不带 Authorization 头
+		want int
+	}{
+		{"no key", "", http.StatusOK},
+		{"wrong key", "Bearer wrong-key", http.StatusOK},
+		{"matching key", "Bearer test-forward-key", http.StatusOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+			if tc.auth != "" {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			rec := httptest.NewRecorder()
+			handleChatCompletions(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d, body = %s", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestForwardKeyUnset 验证未配置 ForwardKey 时同样放行（不要求鉴权）。
+func TestForwardKeyUnset(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "m",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "m",
+	})
+	cfg.ForwardKey = ""
+	setActive(cfg)
+
+	body, _ := json.Marshal(map[string]interface{}{"model": "x", "messages": []interface{}{}})
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
 	rec := httptest.NewRecorder()
 	handleChatCompletions(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("no key: status = %d, want 401", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (no forward key configured)", rec.Code)
+	}
+}
+
+// TestForwardModelPrecedence 验证 MYS-171 model 规则：
+// 请求带非空 model → 上游收到该 model；请求无 model → 上游收到默认 llm.ModelName。
+func TestForwardModelPrecedence(t *testing.T) {
+	var gotModels []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if m, _ := req["model"].(string); m != "" {
+			gotModels = append(gotModels, m)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-default",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+
+	send := func(model interface{}) {
+		m := map[string]interface{}{
+			"messages": []map[string]interface{}{
+				{"role": "user", "content": "hi"},
+			},
+		}
+		if model != nil {
+			m["model"] = model
+		}
+		body, _ := json.Marshal(m)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer fk")
+		rec := httptest.NewRecorder()
+		handleChatCompletions(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
 	}
 
-	// 错误 key → 401
-	req = httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
-	req.Header.Set("Authorization", "Bearer wrong-key")
-	rec = httptest.NewRecorder()
+	// 请求带 model=X → 上游收到 X
+	send("request-model-a")
+	if len(gotModels) != 1 || gotModels[0] != "request-model-a" {
+		t.Fatalf("with model: got = %v, want [request-model-a]", gotModels)
+	}
+
+	// 请求无 model → 默认 llm.ModelName
+	send(nil)
+	if len(gotModels) != 2 || gotModels[1] != "llm-default" {
+		t.Fatalf("without model: got = %v, want [request-model-a llm-default]", gotModels)
+	}
+
+	// 请求 model 为空串 → 默认 llm.ModelName
+	send("")
+	if len(gotModels) != 3 || gotModels[2] != "llm-default" {
+		t.Fatalf("empty model: got = %v, want [request-model-a llm-default llm-default]", gotModels)
+	}
+}
+
+// TestForwardModelKeptForImage 验证带图请求：model 保留请求值，图片仍走 VLM 描述化后整体路由 LLM。
+func TestForwardModelKeptForImage(t *testing.T) {
+	var gotLLMModel string
+	vlmCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if strings.HasPrefix(r.URL.Path, "/vlm") {
+			vlmCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"一只猫在沙发上"}}]}`))
+			return
+		}
+		gotLLMModel, _ = req["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+	globalImageCache = newImageCache(10 << 20)
+
+	imgData := []byte("fake-png-bytes-456")
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	body, _ := json.Marshal(map[string]interface{}{
+		"model": "my-custom-model",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{
+				{"type": "text", "text": "what is this"},
+				{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+			}},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer fk")
+	rec := httptest.NewRecorder()
 	handleChatCompletions(rec, req)
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("wrong key: status = %d, want 401", rec.Code)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	if vlmCalls != 1 {
+		t.Errorf("VLM should be called once, calls = %d", vlmCalls)
+	}
+	if gotLLMModel != "my-custom-model" {
+		t.Errorf("image request should keep request model, got = %q", gotLLMModel)
 	}
 }
 
@@ -185,8 +352,8 @@ func TestImageDescribeRouting(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("text: status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	if gotLLMModel != "llm-target" {
-		t.Errorf("text routed model = %q, want llm-target", gotLLMModel)
+	if gotLLMModel != "devproxy" {
+		t.Errorf("text: request model should be kept (MYS-171), got %q, want devproxy", gotLLMModel)
 	}
 	if vlmCalls != 0 {
 		t.Errorf("text should not call VLM, calls = %d", vlmCalls)
@@ -211,9 +378,9 @@ func TestImageDescribeRouting(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("image: status = %d, body = %s", rec.Code, rec.Body.String())
 	}
-	// 整体走 LLM
-	if gotLLMModel != "llm-target" {
-		t.Errorf("image request should route to LLM, got model = %q", gotLLMModel)
+	// 整体走 LLM：请求 model 被保留（devproxy）
+	if gotLLMModel != "devproxy" {
+		t.Errorf("image request should keep request model, got = %q", gotLLMModel)
 	}
 	// VLM 被调用一次生成描述
 	if vlmCalls != 1 {

--- a/source/pbmssm/mvc/llmproxy/test.go
+++ b/source/pbmssm/mvc/llmproxy/test.go
@@ -107,7 +107,7 @@ func testLLMInference(ctx context.Context, cfg Config) TestResult {
 	return TestResult{Name: name, OK: true, Message: "LLM 推理成功: " + truncate(string(body), 200)}
 }
 
-// forwardLLM 核心转发：图片描述化（可选）+ 替换 model + 调 LLM 上游，返回响应体与状态码。
+// forwardLLM 核心转发：图片描述化（可选）+ model 请求优先/默认兜底 + 调 LLM 上游，返回响应体与状态码。
 // 供 handleChatCompletions 与测试接口共用。
 func forwardLLM(ctx context.Context, req map[string]interface{}, llm, vlm ProviderConfig) ([]byte, int, error) {
 	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
@@ -117,8 +117,11 @@ func forwardLLM(ctx context.Context, req map[string]interface{}, llm, vlm Provid
 	if err := describeImagesInRequest(req, vlm); err != nil {
 		return nil, 0, fmt.Errorf("image describe failed: %w", err)
 	}
-	// 替换 model 为 LLM 模型名
-	req["model"] = llm.ModelName
+	// MYS-171：model 名称支持——请求带非空 model 则保留（不替换），
+	// 否则用默认配置的 LLM 模型名兜底。
+	if model, _ := req["model"].(string); model == "" {
+		req["model"] = llm.ModelName
+	}
 	body, _ := json.Marshal(req)
 
 	upstreamURL := strings.TrimRight(llm.ApiBase, "/") + "/chat/completions"

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -3,10 +3,10 @@
 // 转发逻辑参考 llm-proxy（https://github.com/zzttzzmyswy/llm-proxy）：
 // 客户端（如 PicoClaw）以任意模型名请求本模块内置的 OpenAI 兼容端点，
 // 代理检测请求中是否含 image_url 分流到 VLM / LLM 配置的上游，
-// 并将 model 替换为对应配置的模型名后转发到上游 api_base。
+// 请求带非空 model 则保留，否则替换为对应配置的模型名后转发到上游 api_base。
 //
-// 入站请求需携带转发 key（Authorization: Bearer <forward_key>），
-// 校验通过后才用 bmssm 内部存储的上游 key 向供应商转发。
+// 入站 key 校验（MYS-171 放宽）：仅配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
+// 未配置 / 未携带 / 不匹配均放行，不强制拦截。转发时用 bmssm 内部存储的上游 key。
 package llmproxy
 
 import "time"


### PR DESCRIPTION
## Summary

修改 bmssm llm-proxy 转发逻辑，删除对转发 key 与 model 名称的限制：

- **key 校验放宽（方案 A）**：不再强制鉴权——ForwardKey 未配置、请求未携带、或 key 不匹配均放行；仅当配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权。兼容现有 picoclaw 链路（携带匹配 key 请求行为不变）。
- **model 支持**：`forwardLLM` 请求体带非空 `model` 则保留（不替换），否则用默认配置 `llm.ModelName` 兜底。
- **图片描述化链路不变**：含图请求仍走 VLM 描述化后整体路由 LLM，model 规则同样适用。

## 改动文件

- `source/pbmssm/mvc/llmproxy/server.go` — 放宽 forward key 校验
- `source/pbmssm/mvc/llmproxy/test.go` — `forwardLLM` model 请求优先/默认兜底
- `source/pbmssm/mvc/llmproxy/types.go` — 包注释同步
- `source/pbmssm/mvc/llmproxy/server_test.go` — 更新/新增单测

## Test plan

- [x] `go test ./mvc/llmproxy/...` 全部通过（15 个用例）
- [x] 覆盖：无 key 放行、key 不匹配放行、未配置 key 放行、请求 model 保留、无 model 用默认、带图 model 保留

关联 issue：MYS-171

🤖 Generated with [Claude Code](https://claude.com/claude-code)