### PR TITLE
feat(bmssm): 内存使用率改用 MemAvailable 计算（MYS-172）

### DIFF
--- a/source/pbmssm/pkg/metrics/cpu_memory_test.go
+++ b/source/pbmssm/pkg/metrics/cpu_memory_test.go
@@ -55,6 +55,45 @@ func TestMemoryPartialMissing(t *testing.T) {
 	}
 }
 
+// TestMemoryUsagePercentAvailable 使用率基于 MemAvailable（buff/cache 不计入）：
+// Total 6277 MB、Available 5781 MB → (6277-5781)/6277 = 7.90%。
+func TestMemoryUsagePercentAvailable(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/meminfo": "MemTotal:       6427708 kB\n" +
+			"MemFree:        3672508 kB\n" +
+			"MemAvailable:   5920400 kB\n",
+	}}
+	c := NewCollector(fr, nil)
+	got := c.MemoryUsagePercent()
+	want := (6277.0 - 5781.0) / 6277.0 * 100.0 // ≈ 7.90
+	if got < want-0.1 || got > want+0.1 {
+		t.Errorf("MemoryUsagePercent = %v, want ~%v (available 口径)", got, want)
+	}
+}
+
+// TestMemoryUsagePercentFallbackFree MemAvailable 缺失时退化为 MemFree：
+// Total 2048 kB、Free 1024 kB → (2-1)/2 = 50%。
+func TestMemoryUsagePercentFallbackFree(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/meminfo": "MemTotal:       2048 kB\nMemFree:        1024 kB\n",
+	}}
+	c := NewCollector(fr, nil)
+	got := c.MemoryUsagePercent()
+	want := 50.0
+	if got < want-0.01 || got > want+0.01 {
+		t.Errorf("MemoryUsagePercent = %v, want %v (free 回退)", got, want)
+	}
+}
+
+// TestMemoryUsagePercentMissing 无 meminfo 时返 0，不 panic。
+func TestMemoryUsagePercentMissing(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{}}
+	c := NewCollector(fr, nil)
+	if got := c.MemoryUsagePercent(); got != 0 {
+		t.Errorf("MemoryUsagePercent = %v, want 0 when missing", got)
+	}
+}
+
 // ---------------------------------------------------------------
 // CPUInfo — cores/freq/type 来自 /proc/cpuinfo + scaling_cur_freq
 // 真值：8 核，2300000 kHz → 2300 MHz，model name bm1684x

--- a/source/pbmssm/pkg/metrics/ion_memory_test.go
+++ b/source/pbmssm/pkg/metrics/ion_memory_test.go
@@ -225,15 +225,16 @@ func TestMemoryLayoutBM1684X(t *testing.T) {
 	if lay.ChipType != "bm1684x" {
 		t.Fatalf("ChipType = %q, want bm1684x", lay.ChipType)
 	}
-	// 系统：6277 MB total，used = 6277-3586(free) = 2691，使用率 ~42.88%
+	// 系统：6277 MB total，used = 6277-5781(available) = 496，使用率 ~7.90%
+	// （buff/cache 可回收不计入，available 口径）
 	if !approxEqual(lay.System.TotalMB, 6277, 1) {
 		t.Errorf("System.TotalMB = %v, want ~6277", lay.System.TotalMB)
 	}
-	if !approxEqual(lay.System.UsedMB, 2691, 1) {
-		t.Errorf("System.UsedMB = %v, want ~2691", lay.System.UsedMB)
+	if !approxEqual(lay.System.UsedMB, 496, 1) {
+		t.Errorf("System.UsedMB = %v, want ~496", lay.System.UsedMB)
 	}
-	if !approxEqual(lay.System.UsagePct, 42.88, 0.1) {
-		t.Errorf("System.UsagePct = %v, want ~42.88", lay.System.UsagePct)
+	if !approxEqual(lay.System.UsagePct, 7.90, 0.1) {
+		t.Errorf("System.UsagePct = %v, want ~7.90", lay.System.UsagePct)
 	}
 	// TPU：2531262464 B = 2414 MB 整；used 0
 	if !approxEqual(lay.TPU.TotalMB, 2414, 0.01) || !approxEqual(lay.TPU.UsagePct, 0, 0.01) {

--- a/source/pbmssm/pkg/metrics/memory.go
+++ b/source/pbmssm/pkg/metrics/memory.go
@@ -29,14 +29,20 @@ func (c *Collector) Memory() Memory {
 	return m
 }
 
-// MemoryUsagePercent 计算内存使用百分比 (0-100)，对齐 pget_info。
-// 使用率 = (total - free) / total * 100
+// MemoryUsagePercent 计算内存使用百分比 (0-100)。
+// 使用率 = (total - available) / total * 100，基于 MemAvailable：
+// buff/cache 部分可随时回收，不计入真实占用（否则常驻 90%+，无告警价值）。
+// 与告警 memUsage 口径一致；MemAvailable 缺失时退化为 MemFree。
 func (c *Collector) MemoryUsagePercent() float64 {
 	m := c.Memory()
 	if m.Total <= 0 {
 		return 0
 	}
-	return (m.Total - m.Free) / m.Total * 100.0
+	avail := m.Available
+	if avail <= 0 {
+		avail = m.Free
+	}
+	return (m.Total - avail) / m.Total * 100.0
 }
 
 // memLineMB 从形如 "MemTotal:       6427708 kB" 的行提取 kB 并转 MB。

--- a/source/pbmssm/pkg/metrics/memory_layout.go
+++ b/source/pbmssm/pkg/metrics/memory_layout.go
@@ -7,14 +7,15 @@ func (c *Collector) MemoryLayout() MemoryLayout {
 	chip := c.ChipType()
 	sys := c.Memory()
 
-	// 系统"已用"= total - free（free 缺失时回退 available），对齐前端旧逻辑。
-	sysFree := sys.Free
-	if sysFree <= 0 {
-		sysFree = sys.Available
+	// 系统"已用"= total - available（buff/cache 可回收不计入真实占用）；
+	// available 缺失时回退 free。
+	sysAvail := sys.Available
+	if sysAvail <= 0 {
+		sysAvail = sys.Free
 	}
 	layout := MemoryLayout{
 		ChipType: chip,
-		System:   memRegionMBFloat(sys.Total, sys.Total-sysFree),
+		System:   memRegionMBFloat(sys.Total, sys.Total-sysAvail),
 	}
 	tpuT, tpuU := c.TpuMemory(chip)
 	layout.TPU = memRegionMB(tpuT, tpuU)

--- a/source/pbmssm/pkg/metrics/prometheus.go
+++ b/source/pbmssm/pkg/metrics/prometheus.go
@@ -27,14 +27,15 @@ func labelsForDevice(d DeviceLabels) []string {
 type MetricsRegistry struct {
 	NumDevices prometheus.Gauge
 
-	SystemMemoryTotal *prometheus.GaugeVec
-	SystemMemoryUsed  *prometheus.GaugeVec
-	SystemMemoryFree  *prometheus.GaugeVec
-	VppMemoryTotal    *prometheus.GaugeVec
-	VppMemoryUsed     *prometheus.GaugeVec
-	VpuMemoryTotal    *prometheus.GaugeVec
-	VpuMemoryUsed     *prometheus.GaugeVec
-	TpuMemoryTotal    *prometheus.GaugeVec
+	SystemMemoryTotal     *prometheus.GaugeVec
+	SystemMemoryUsed      *prometheus.GaugeVec
+	SystemMemoryFree      *prometheus.GaugeVec
+	SystemMemoryAvailable *prometheus.GaugeVec
+	VppMemoryTotal        *prometheus.GaugeVec
+	VppMemoryUsed         *prometheus.GaugeVec
+	VpuMemoryTotal        *prometheus.GaugeVec
+	VpuMemoryUsed         *prometheus.GaugeVec
+	TpuMemoryTotal        *prometheus.GaugeVec
 	TpuMemoryUsed     *prometheus.GaugeVec
 	DeviceMemoryTotal *prometheus.GaugeVec
 	DeviceMemoryUsed  *prometheus.GaugeVec
@@ -66,14 +67,15 @@ func NewMetricsRegistry() *MetricsRegistry {
 			Help: "Number of TPU devices",
 		}),
 
-		SystemMemoryTotal: newGaugeVec("system_memory_total_bytes", "Total system memory in bytes"),
-		SystemMemoryUsed:  newGaugeVec("system_memory_used_bytes", "Used system memory in bytes"),
-		SystemMemoryFree:  newGaugeVec("system_memory_free_bytes", "Free system memory in bytes"),
-		VppMemoryTotal:    newGaugeVec("vpp_memory_total_bytes", "Total VPP memory in bytes"),
-		VppMemoryUsed:     newGaugeVec("vpp_memory_used_bytes", "Used VPP memory in bytes"),
-		VpuMemoryTotal:    newGaugeVec("vpu_memory_total_bytes", "Total VPU memory in bytes"),
-		VpuMemoryUsed:     newGaugeVec("vpu_memory_used_bytes", "Used VPU memory in bytes"),
-		TpuMemoryTotal:    newGaugeVec("tpu_memory_total_bytes", "Total TPU memory in bytes"),
+		SystemMemoryTotal:     newGaugeVec("system_memory_total_bytes", "Total system memory in bytes"),
+		SystemMemoryUsed:      newGaugeVec("system_memory_used_bytes", "Used system memory in bytes (total - available, buff/cache excluded)"),
+		SystemMemoryFree:      newGaugeVec("system_memory_free_bytes", "Free system memory in bytes"),
+		SystemMemoryAvailable: newGaugeVec("system_memory_available_bytes", "Available system memory in bytes"),
+		VppMemoryTotal:        newGaugeVec("vpp_memory_total_bytes", "Total VPP memory in bytes"),
+		VppMemoryUsed:         newGaugeVec("vpp_memory_used_bytes", "Used VPP memory in bytes"),
+		VpuMemoryTotal:        newGaugeVec("vpu_memory_total_bytes", "Total VPU memory in bytes"),
+		VpuMemoryUsed:         newGaugeVec("vpu_memory_used_bytes", "Used VPU memory in bytes"),
+		TpuMemoryTotal:        newGaugeVec("tpu_memory_total_bytes", "Total TPU memory in bytes"),
 		TpuMemoryUsed:     newGaugeVec("tpu_memory_used_bytes", "Used TPU memory in bytes"),
 		DeviceMemoryTotal: newGaugeVec("device_memory_total_bytes", "Total device memory in bytes"),
 		DeviceMemoryUsed:  newGaugeVec("device_memory_used_bytes", "Used device memory in bytes"),
@@ -102,7 +104,7 @@ func NewMetricsRegistry() *MetricsRegistry {
 
 	// Register all labeled gauges
 	for _, g := range []prometheus.Collector{
-		r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree,
+		r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree, r.SystemMemoryAvailable,
 		r.VppMemoryTotal, r.VppMemoryUsed,
 		r.VpuMemoryTotal, r.VpuMemoryUsed,
 		r.TpuMemoryTotal, r.TpuMemoryUsed,
@@ -140,6 +142,7 @@ func (r *MetricsRegistry) Update(hw *HardwareMetrics, dev DeviceLabels) {
 	setInt(r.SystemMemoryTotal, hw.SystemMemoryTotal)
 	setInt(r.SystemMemoryUsed, hw.SystemMemoryUsed)
 	setInt(r.SystemMemoryFree, hw.SystemMemoryFree)
+	setInt(r.SystemMemoryAvailable, hw.SystemMemoryAvailable)
 
 	// 设备内存
 	setInt(r.VppMemoryTotal, hw.VppMemoryTotal)
@@ -186,7 +189,7 @@ func (r *MetricsRegistry) SetDeviceCount(n int64) {
 func (r *MetricsRegistry) Reset() {
 	r.NumDevices.Set(0)
 	for _, g := range []*prometheus.GaugeVec{
-		r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree,
+		r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree, r.SystemMemoryAvailable,
 		r.VppMemoryTotal, r.VppMemoryUsed,
 		r.VpuMemoryTotal, r.VpuMemoryUsed,
 		r.TpuMemoryTotal, r.TpuMemoryUsed,
@@ -205,9 +208,10 @@ func (r *MetricsRegistry) Reset() {
 // 各字段含义对齐 Rust exporter 的 HardwareMetrics。
 type HardwareMetrics struct {
 	// 系统内存（bytes）
-	SystemMemoryTotal int64
-	SystemMemoryUsed  int64
-	SystemMemoryFree  int64
+	SystemMemoryTotal     int64
+	SystemMemoryUsed      int64
+	SystemMemoryFree      int64
+	SystemMemoryAvailable int64
 
 	// 设备内存（bytes）
 	VppMemoryTotal    int64
@@ -285,7 +289,14 @@ func (c *Collector) CollectAll() *HardwareMetrics {
 
 	mem := c.Memory()
 	hw.SystemMemoryTotal = int64(mem.Total * 1024 * 1024)
-	hw.SystemMemoryUsed = int64((mem.Total - mem.Free) * 1024 * 1024)
+	// 已用 = total - available（buff/cache 可回收不计入，与使用率口径一致）；
+	// available 缺失时退化为 free。
+	memUsed := mem.Total - mem.Available
+	if mem.Available <= 0 {
+		memUsed = mem.Total - mem.Free
+	}
+	hw.SystemMemoryUsed = int64(memUsed * 1024 * 1024)
+	hw.SystemMemoryAvailable = int64(mem.Available * 1024 * 1024)
 	hw.SystemMemoryFree = int64(mem.Free * 1024 * 1024)
 
 	cpu := c.CPUInfo()

--- a/source/pbmssm/pkg/metrics/prometheus_test.go
+++ b/source/pbmssm/pkg/metrics/prometheus_test.go
@@ -12,7 +12,7 @@ func TestNewMetricsRegistry(t *testing.T) {
 	t.Cleanup(func() {
 		prometheus.Unregister(r.NumDevices)
 		for _, g := range []prometheus.Collector{
-			r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree,
+			r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree, r.SystemMemoryAvailable,
 			r.VppMemoryTotal, r.VppMemoryUsed,
 			r.VpuMemoryTotal, r.VpuMemoryUsed,
 			r.TpuMemoryTotal, r.TpuMemoryUsed,
@@ -45,7 +45,7 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 	t.Cleanup(func() {
 		prometheus.Unregister(r.NumDevices)
 		for _, g := range []prometheus.Collector{
-			r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree,
+			r.SystemMemoryTotal, r.SystemMemoryUsed, r.SystemMemoryFree, r.SystemMemoryAvailable,
 			r.VppMemoryTotal, r.VppMemoryUsed,
 			r.VpuMemoryTotal, r.VpuMemoryUsed,
 			r.TpuMemoryTotal, r.TpuMemoryUsed,
@@ -64,9 +64,10 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 		ChipType: "BM1684", BoardType: "0x10",
 	}
 	hw := &HardwareMetrics{
-		SystemMemoryTotal: 8 * 1024 * 1024 * 1024,
-		SystemMemoryUsed:  4 * 1024 * 1024 * 1024,
-		SystemMemoryFree:  4 * 1024 * 1024 * 1024,
+		SystemMemoryTotal:     8 * 1024 * 1024 * 1024,
+		SystemMemoryUsed:      4 * 1024 * 1024 * 1024,
+		SystemMemoryFree:      4 * 1024 * 1024 * 1024,
+		SystemMemoryAvailable: 4 * 1024 * 1024 * 1024,
 		CPUUsage:          42,
 		TPUUsage:          75,
 		TPUAvgUsage:       70,


### PR DESCRIPTION
## Summary

bmssm 获取内存使用率由 `free` 字段改为基于 `available` 字段计算。buff/cache 部分内存可随时回收，原 `free` 口径下使用率常驻 90%+，无监控/告警价值。

## Changes

- `source/pbmssm/pkg/metrics/memory.go`：`MemoryUsagePercent()` 由 `(total-free)/total` 改为 `(total-available)/total`；`MemAvailable` 缺失时回退 `MemFree`
- `source/pbmssm/pkg/metrics/memory_layout.go`：系统"已用"内存由 `free` 优先改为 `available` 优先（`total-available`）
- `source/pbmssm/pkg/metrics/prometheus.go`：`SystemMemoryUsed` 改用 available 口径；新增 `system_memory_available_bytes` Prometheus gauge 并接入注册/更新/重置
- 测试：新增 `MemoryUsagePercent` 单测（available 口径 / free 回退 / 缺失归零），更新 `MemoryLayout` 期望值

## Test

- `go test ./...` 全量通过（bmssm 全部包 ok）
- 真实 `/proc/meminfo` 验证：旧口径 97.1%，新口径 36.1%（示例主机）

🤖 Generated with [Claude Code](https://claude.com/claude-code)