### PR TITLE
MYS-150: sophpicoclaw 改由 systemd 管理 + AI Agent 页服务监控/管理

### DIFF
--- a/source/pbmssm/mvc/llmproxy/controller.go
+++ b/source/pbmssm/mvc/llmproxy/controller.go
@@ -92,3 +92,31 @@ func (ctrl *Controller) ListModels(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, response.OK(gin.H{"models": models}))
 }
+
+// GetServiceStatus GET /api/v1/llm-proxy/service/status
+// 返回 sophpicoclaw 服务状态（systemd 状态 + 端口 + 日志尾部）。
+func (ctrl *Controller) GetServiceStatus(c *gin.Context) {
+	st, err := GetSophpicoclawStatus()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, response.OK(st))
+}
+
+// ServiceAction POST /api/v1/llm-proxy/service/action  body: {"action":"restart"}
+// 对 sophpicoclaw 执行 start/stop/restart/enable/disable。
+func (ctrl *Controller) ServiceAction(c *gin.Context) {
+	var req struct {
+		Action string `json:"action" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
+		return
+	}
+	if err := ActionSophpicoclaw(req.Action); err != nil {
+		c.JSON(http.StatusBadRequest, response.Fail(err.Error()))
+		return
+	}
+	c.JSON(http.StatusOK, response.OK(gin.H{"message": "action " + req.Action + " executed"}))
+}

--- a/source/pbmssm/mvc/llmproxy/server.go
+++ b/source/pbmssm/mvc/llmproxy/server.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -20,7 +19,17 @@ import (
 
 	"bmssm/config"
 	"bmssm/logger"
+	"bmssm/pkg/system"
 )
+
+// runSystemctlRestart 通过 systemd 重启 sophpicoclaw 服务（可注入，测试用）。
+var runSystemctlRestart = func(name string) error {
+	_, errStr, err := system.RunCommandArgs("systemctl", "restart", name)
+	if err != nil {
+		return fmt.Errorf("systemctl restart %s: %v: %s", name, err, errStr)
+	}
+	return nil
+}
 
 // server 状态：配置变更时通过 UpdateServer 热更新（替换原子指针）。
 var (
@@ -414,11 +423,14 @@ func isImageBlock(b map[string]interface{}) bool {
 // --- 写入本地 picoclaw -------------------------------------------------------
 
 // devproxyKeyPath 返回 picoclaw devproxy.key 路径。
-// 优先 SOPHON_PICOCLAW_HOME，其次 /home/*/picoclaw-deploy 探测，最后当前用户主目录。
+// 优先 SOPHON_PICOCLAW_HOME，其次 /opt/sophon/picoclaw（新出厂路径），
+// 再回退 /home/*/picoclaw-deploy 探测，最后当前用户主目录。
 func devproxyKeyPath() (string, error) {
 	var home string
 	if h := os.Getenv("SOPHON_PICOCLAW_HOME"); h != "" {
 		home = h
+	} else if st, err := os.Stat("/opt/sophon/picoclaw/.picoclaw"); err == nil && st.IsDir() {
+		home = "/opt/sophon/picoclaw"
 	} else if entries, err := os.ReadDir("/home"); err == nil {
 		for _, e := range entries {
 			if e.IsDir() {
@@ -436,8 +448,8 @@ func devproxyKeyPath() (string, error) {
 	return filepath.Join(home, ".picoclaw", "devproxy.key"), nil
 }
 
-// WriteForwardKeyToPicoclaw 把转发 key 写入 /home/<user>/.picoclaw/devproxy.key，
-// 并重启 picoclaw gateway（及 launcher，若在运行）。
+// WriteForwardKeyToPicoclaw 把转发 key 写入 picoclaw devproxy.key，
+// 并重启 sophpicoclaw 服务（systemd 托管）。
 func WriteForwardKeyToPicoclaw(key string) error {
 	path, err := devproxyKeyPath()
 	if err != nil {
@@ -447,73 +459,18 @@ func WriteForwardKeyToPicoclaw(key string) error {
 	if err := os.WriteFile(path, []byte(key), 0o600); err != nil {
 		return fmt.Errorf("write devproxy.key: %w", err)
 	}
-	// 重启 gateway：picoclaw gateway restart（若 launcher 在运行则先重启 launcher）
+	// 重启 sophpicoclaw（systemd 统一管理 gateway 生命周期）
 	restartPicoclaw()
 	return nil
 }
 
-// restartPicoclaw 重启 picoclaw：先重启 launcher（触发 gateway 随启），
-// 若无 launcher 则直接重启 gateway 进程。
+// restartPicoclaw 通过 systemd 重启 sophpicoclaw 服务（替代旧 pkill+手工 spawn）。
 func restartPicoclaw() {
-	// 1. 尝试 pkill picoclaw-launcher（SIGTERM）
-	if out, err := exec.Command("pkill", "-TERM", "-f", "picoclaw-launcher").CombinedOutput(); err == nil {
-		logger.Info("picoclaw-launcher stopped: %s", string(out))
+	if err := runSystemctlRestart("sophpicoclaw.service"); err != nil {
+		logger.Warn("restart sophpicoclaw failed: %v", err)
+		return
 	}
-	// 2. 尝试 pkill gateway
-	if out, err := exec.Command("pkill", "-TERM", "-f", "picoclaw gateway").CombinedOutput(); err == nil {
-		logger.Info("picoclaw gateway stopped: %s", string(out))
-	}
-	// 3. 等待端口释放
-	waitPortRelease(18790, 10*time.Second)
-	waitPortRelease(18800, 10*time.Second)
-	// 4. 若存在 launcher 则重新拉起
-	home := picoclawHomeDir()
-	if home != "" {
-		launcher := filepath.Join(home, "picoclaw-deploy", "picoclaw-launcher")
-		if st, err := os.Stat(launcher); err == nil && !st.IsDir() {
-			cmd := exec.Command(launcher, "-public", "-no-browser")
-			cmd.Dir = filepath.Dir(launcher)
-			cmd.Env = append(os.Environ(), "HOME="+home)
-			if err := cmd.Start(); err == nil {
-				_ = cmd.Process.Release()
-				logger.Info("picoclaw-launcher restarted (pid=%d)", cmd.Process.Pid)
-				return
-			}
-		}
-	}
-	logger.Warn("picoclaw launcher not found; gateway restart may be required manually")
-}
-
-// picoclawHomeDir 返回 picoclaw 主目录（/home/<user>）。
-func picoclawHomeDir() string {
-	if h := os.Getenv("SOPHON_PICOCLAW_HOME"); h != "" {
-		return h
-	}
-	if entries, err := os.ReadDir("/home"); err == nil {
-		for _, e := range entries {
-			if e.IsDir() {
-				candidate := filepath.Join("/home", e.Name(), "picoclaw-deploy")
-				if st, err := os.Stat(candidate); err == nil && st.IsDir() {
-					return filepath.Join("/home", e.Name())
-				}
-			}
-		}
-	}
-	return ""
-}
-
-// waitPortRelease 轮询等待端口不再监听。
-func waitPortRelease(port int, timeout time.Duration) {
-	deadline := time.Now().Add(timeout)
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", addr, 500*time.Millisecond)
-		if err != nil {
-			return
-		}
-		conn.Close()
-		time.Sleep(300 * time.Millisecond)
-	}
+	logger.Info("sophpicoclaw.service restarted via systemctl")
 }
 
 // flushWriter SSE 透传用：每次 Write 后 Flush。

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -559,5 +560,38 @@ func TestDisabledReturns503(t *testing.T) {
 
 	if rec.Code != http.StatusServiceUnavailable {
 		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+}
+
+// TestRestartPicoclawUsesSystemctl 验证重启走 systemctl restart sophpicoclaw，
+// 而非旧的 pkill + 手工 spawn。通过注入 runSystemctlRestart 捕获调用。
+func TestRestartPicoclawUsesSystemctl(t *testing.T) {
+	var called []string
+	old := runSystemctlRestart
+	runSystemctlRestart = func(name string) error {
+		called = append(called, name)
+		return nil
+	}
+	defer func() { runSystemctlRestart = old }()
+
+	restartPicoclaw()
+
+	if len(called) != 1 || called[0] != "sophpicoclaw.service" {
+		t.Fatalf("runSystemctlRestart calls = %v, want [sophpicoclaw.service]", called)
+	}
+}
+
+// TestDevproxyKeyPathPrefersOptSophon 验证 devproxy.key 优先定位到 /opt/sophon/picoclaw。
+// 仅在目标路径存在时生效；CI 环境无该路径则跳过。
+func TestDevproxyKeyPathPrefersOptSophon(t *testing.T) {
+	if st, err := os.Stat("/opt/sophon/picoclaw/.picoclaw"); err != nil || !st.IsDir() {
+		t.Skip("no /opt/sophon/picoclaw/.picoclaw on this host")
+	}
+	p, err := devproxyKeyPath()
+	if err != nil {
+		t.Fatalf("devproxyKeyPath: %v", err)
+	}
+	if p != "/opt/sophon/picoclaw/.picoclaw/devproxy.key" {
+		t.Fatalf("devproxyKeyPath = %q, want /opt/sophon/picoclaw/.picoclaw/devproxy.key", p)
 	}
 }

--- a/source/pbmssm/mvc/llmproxy/service_mgr.go
+++ b/source/pbmssm/mvc/llmproxy/service_mgr.go
@@ -70,6 +70,7 @@ func GetSophpicoclawStatus() (*ServiceStatus, error) {
 
 // ActionSophpicoclaw 对 sophpicoclaw 执行白名单操作（start/stop/restart/enable/disable）。
 // 仅允许操作 sophpicoclaw，经 systemd.Action 的 unit 白名单校验，杜绝注入。
+// 执行前先 daemon-reload，保证 unit 文件变更（升级/替换）即时生效。
 func ActionSophpicoclaw(action string) error {
 	allowed := map[string]bool{
 		"start": true, "stop": true, "restart": true,
@@ -81,7 +82,14 @@ func ActionSophpicoclaw(action string) error {
 	if err := sysdpkg.ValidateUnitName(sophpicoclawUnit); err != nil {
 		return err
 	}
-	return sysdpkg.Action(sophpicoclawUnit, action)
+	if err := sysdpkg.DaemonReload(); err != nil {
+		return fmt.Errorf("daemon-reload: %w", err)
+	}
+	if err := sysdpkg.Action(sophpicoclawUnit, action); err != nil {
+		// unit 未安装/未找到：systemd 退出码 5（Unit not found），给用户清晰提示
+		return fmt.Errorf("sophpicoclaw 服务操作失败（请确认已安装 sophpicoclaw）：%w", err)
+	}
+	return nil
 }
 
 // portUp 探测端口是否监听（短超时，不阻塞）。

--- a/source/pbmssm/mvc/llmproxy/service_mgr.go
+++ b/source/pbmssm/mvc/llmproxy/service_mgr.go
@@ -1,0 +1,95 @@
+package llmproxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"bmssm/pkg/system"
+	sysdpkg "bmssm/pkg/systemd"
+)
+
+// sophpicoclawUnit sophpicoclaw 服务名（systemd unit，由出厂部署固定）。
+const sophpicoclawUnit = "sophpicoclaw.service"
+
+// sophpicoclawPorts 服务健康探测端口：gateway(18790) 与 web(18800)。
+var sophpicoclawPorts = []int{18790, 18800}
+
+// ServiceStatus sophpicoclaw 服务状态快照。
+type ServiceStatus struct {
+	Active       bool   `json:"active"`
+	ActiveState  string `json:"activeState"`
+	SubState     string `json:"subState"`
+	EnabledState string `json:"enabledState"`
+	MainPID      string `json:"mainPid"`
+	Ports        []int  `json:"ports"`
+	Running      bool   `json:"running"`
+	LogTail      string `json:"logTail"`
+}
+
+// GetSophpicoclawStatus 汇总 sophpicoclaw 服务状态（systemd + 端口探测 + 日志尾部）。
+// 无 systemd 或 unit 未安装时返回空状态，不 panic。
+func GetSophpicoclawStatus() (*ServiceStatus, error) {
+	st := &ServiceStatus{Ports: sophpicoclawPorts}
+
+	out, _, _ := system.RunCommandArgs("systemctl", "show", sophpicoclawUnit,
+		"-p", "ActiveState", "-p", "SubState", "-p", "MainPID")
+	for _, line := range strings.Split(out, "\n") {
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "ActiveState":
+			st.ActiveState = kv[1]
+		case "SubState":
+			st.SubState = kv[1]
+		case "MainPID":
+			st.MainPID = kv[1]
+		}
+	}
+	st.Active = st.ActiveState == "active"
+
+	if en, _, _ := system.RunCommandArgs("systemctl", "is-enabled", sophpicoclawUnit); en != "" {
+		st.EnabledState = strings.TrimSpace(en)
+	}
+
+	for _, p := range sophpicoclawPorts {
+		if portUp(p) {
+			st.Running = true
+			break
+		}
+	}
+
+	if tail, _, _ := system.RunCommandArgs("journalctl", "-u", sophpicoclawUnit, "-n", "20", "--no-pager"); tail != "" {
+		st.LogTail = strings.TrimSpace(tail)
+	}
+	return st, nil
+}
+
+// ActionSophpicoclaw 对 sophpicoclaw 执行白名单操作（start/stop/restart/enable/disable）。
+// 仅允许操作 sophpicoclaw，经 systemd.Action 的 unit 白名单校验，杜绝注入。
+func ActionSophpicoclaw(action string) error {
+	allowed := map[string]bool{
+		"start": true, "stop": true, "restart": true,
+		"enable": true, "disable": true,
+	}
+	if !allowed[action] {
+		return fmt.Errorf("invalid action: %q", action)
+	}
+	if err := sysdpkg.ValidateUnitName(sophpicoclawUnit); err != nil {
+		return err
+	}
+	return sysdpkg.Action(sophpicoclawUnit, action)
+}
+
+// portUp 探测端口是否监听（短超时，不阻塞）。
+func portUp(port int) bool {
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/source/pbmssm/mvc/llmproxy/service_mgr_test.go
+++ b/source/pbmssm/mvc/llmproxy/service_mgr_test.go
@@ -1,0 +1,83 @@
+package llmproxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestGetSophpicoclawStatusNoPanic 无 sophpicoclaw/systemd 环境也不应 panic。
+// CI 上 systemctl 命令可能失败，函数应返回状态（字段为空）而非崩溃。
+func TestGetSophpicoclawStatusNoPanic(t *testing.T) {
+	st, err := GetSophpicoclawStatus()
+	if err != nil {
+		// 允许错误（无 systemd 环境），但不允许 panic 已由 test 框架保证
+		t.Logf("GetSophpicoclawStatus error: %v", err)
+		return
+	}
+	if st == nil {
+		t.Fatal("status is nil")
+	}
+}
+
+// TestActionSophpicoclawValidates 动作白名单：非法动作必须被拒绝。
+func TestActionSophpicoclawValidates(t *testing.T) {
+	bad := []string{"rm -rf /", "", "systemctl", "daemon-reload", "status;reboot"}
+	for _, a := range bad {
+		if err := ActionSophpicoclaw(a); err == nil {
+			t.Fatalf("expected invalid action %q to be rejected", a)
+		}
+	}
+	// 合法动作在无 systemd 环境可能报错（unit 不存在），但不应是“非法动作”错误
+	for _, a := range []string{"start", "stop", "restart", "enable", "disable"} {
+		err := ActionSophpicoclaw(a)
+		if err != nil && strings.Contains(err.Error(), "invalid action") {
+			t.Fatalf("valid action %q rejected as invalid: %v", a, err)
+		}
+	}
+}
+
+// TestServiceStatusEndpoint 验证 status 端点返回 JSON 结构。
+func TestServiceStatusEndpoint(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := &Controller{}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/llm-proxy/service/status", nil)
+	ctx.Request = req
+	ctrl.GetServiceStatus(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Result ServiceStatus `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Result.ActiveState == "" && out.Result.MainPID == "" {
+		// 允许空状态（无 systemd），但结构必须正确
+	}
+}
+
+// TestServiceActionEndpoint 非法动作经 HTTP 端点返回 400。
+func TestServiceActionEndpointRejectsInvalid(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	ctrl := &Controller{}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	body := strings.NewReader(`{"action":"rm -rf /"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/llm-proxy/service/action", body)
+	req.Header.Set("Content-Type", "application/json")
+	ctx.Request = req
+	ctrl.ServiceAction(ctx)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400, body = %s", rec.Code, rec.Body.String())
+	}
+}

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -15,8 +15,8 @@ import (
 	firewallCtrl "bmssm/mvc/firewall"
 	"bmssm/mvc/hardware"
 	"bmssm/mvc/health"
-	"bmssm/mvc/logs"
 	llmproxyCtrl "bmssm/mvc/llmproxy"
+	"bmssm/mvc/logs"
 	metricsCtrl "bmssm/mvc/metrics"
 	"bmssm/mvc/network"
 	portsCtrl "bmssm/mvc/ports"
@@ -114,6 +114,8 @@ func Register(r *gin.Engine) {
 		api.GET("/llm-proxy/config", llmproxyCtrl.GetConfig)
 		// 模型列表（从供应商拉取，供前端弹窗选择）
 		api.GET("/llm-proxy/models", llmproxyCtrl.ListModels)
+		// sophpicoclaw 服务状态（读）
+		api.GET("/llm-proxy/service/status", llmproxyCtrl.GetServiceStatus)
 
 		// Docker
 		api.GET("/docker/container", dockerCtrl.ListContainers)
@@ -169,6 +171,8 @@ func Register(r *gin.Engine) {
 		admin.POST("/llm-proxy/forward-key/reset", llmproxyCtrl.ResetForwardKey)
 		admin.POST("/llm-proxy/forward-key/write-picoclaw", llmproxyCtrl.WriteForwardKey)
 		admin.POST("/llm-proxy/test", llmproxyCtrl.RunTest)
+		// sophpicoclaw 服务操作（写）
+		admin.POST("/llm-proxy/service/action", llmproxyCtrl.ServiceAction)
 
 		// 软件/OTA（写）
 		admin.POST("/software/install", softwareCtrl.Install)

--- a/source/psophliteos/frontend/src/api/aiAgent/index.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/index.ts
@@ -161,4 +161,48 @@ export async function testAgentConfig(): Promise<{ ok: boolean; data?: TestRespo
   }
 }
 
+export interface ServiceStatus {
+  active: boolean;
+  activeState: string;
+  subState: string;
+  enabledState: string;
+  mainPid: string;
+  ports: number[];
+  running: boolean;
+  logTail: string;
+}
+
+// 查询 sophpicoclaw 服务状态。
+export async function getServiceStatus(): Promise<ServiceStatus | null> {
+  try {
+    const res = await defHttp.get<ServiceStatus>(
+      { url: '/v1/llm-proxy/service/status' },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    return data && typeof data === 'object' && 'activeState' in data
+      ? (data as ServiceStatus)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+// 对 sophpicoclaw 执行操作（start/stop/restart/enable/disable）。
+export async function serviceAction(action: string): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const res = await defHttp.post(
+      { url: '/v1/llm-proxy/service/action', data: { action } },
+      { isTransformResponse: false }
+    );
+    const data = (res as any)?.result ?? res;
+    if (data && typeof data === 'object' && data.message) {
+      return { ok: true, message: data.message };
+    }
+    return { ok: false, message: (res as any)?.error_message || '操作失败' };
+  } catch (e: any) {
+    return { ok: false, message: e?.message || '操作失败' };
+  }
+}
+
 export { Api as AgentConfigApi };

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -148,7 +148,7 @@
           >
         </a-input-group>
         <div class="text-gray-400 text-xs mt-1">
-          重置会生成新 key；「写入本地」将覆盖 /home/linaro/.picoclaw/devproxy.key 并重启 picoclaw
+          重置会生成新 key；「写入本地」将覆盖 /opt/sophon/picoclaw/.picoclaw/devproxy.key 并重启 sophpicoclaw 服务
         </div>
       </div>
 
@@ -307,18 +307,25 @@
 
   async function refreshService() {
     svcLoading.value = true;
-    svc.value = await getServiceStatus();
-    svcLoading.value = false;
+    try {
+      svc.value = await getServiceStatus();
+    } finally {
+      svcLoading.value = false;
+    }
   }
 
   async function doServiceAction(action: string) {
+    if (svcActing.value) return;
     svcActing.value = true;
-    const res = await serviceAction(action);
-    svcActing.value = false;
-    if (res.ok) {
-      message.success(`操作成功：${action}`);
-    } else {
-      message.error(res.message || '操作失败');
+    try {
+      const res = await serviceAction(action);
+      if (res.ok) {
+        message.success(`操作成功：${action}`);
+      } else {
+        message.error(res.message || '操作失败');
+      }
+    } finally {
+      svcActing.value = false;
     }
     await refreshService();
   }

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -151,6 +151,59 @@
           重置会生成新 key；「写入本地」将覆盖 /home/linaro/.picoclaw/devproxy.key 并重启 picoclaw
         </div>
       </div>
+
+      <a-divider />
+
+      <!-- 服务监控与管理 -->
+      <div class="mt-4">
+        <div class="mb-2 flex items-center justify-between">
+          <span class="font-medium">服务管理（sophpicoclaw）</span>
+          <a-space>
+            <a-button size="small" :loading="svcLoading" @click="refreshService">刷新</a-button>
+          </a-space>
+        </div>
+        <a-card v-if="svc" size="small" class="max-w-2xl">
+          <a-descriptions :column="2" size="small">
+            <a-descriptions-item label="运行状态">
+              <a-tag :color="svc.active ? 'green' : 'red'">
+                {{ svc.active ? '运行中' : '已停止' }}
+              </a-tag>
+            </a-descriptions-item>
+            <a-descriptions-item label="开机自启">
+              <a-tag :color="svc.enabledState === 'enabled' ? 'green' : 'orange'">
+                {{ svc.enabledState === 'enabled' ? '已启用' : '未启用' }}
+              </a-tag>
+            </a-descriptions-item>
+            <a-descriptions-item label="状态">
+              {{ svc.activeState || '—' }} / {{ svc.subState || '—' }}
+            </a-descriptions-item>
+            <a-descriptions-item label="PID">{{ svc.mainPid || '—' }}</a-descriptions-item>
+            <a-descriptions-item label="端口">{{ svc.ports.join(', ') }}</a-descriptions-item>
+            <a-descriptions-item label="端口可达">
+              <a-tag :color="svc.running ? 'green' : 'red'">
+                {{ svc.running ? '是' : '否' }}
+              </a-tag>
+            </a-descriptions-item>
+          </a-descriptions>
+          <div class="mt-3">
+            <a-space>
+              <a-button size="small" type="primary" :loading="svcActing" @click="doServiceAction('restart')">重启</a-button>
+              <a-button size="small" :loading="svcActing" @click="doServiceAction('start')">启动</a-button>
+              <a-button size="small" danger :loading="svcActing" @click="doServiceAction('stop')">停止</a-button>
+              <a-button size="small" :loading="svcActing" @click="doServiceAction('enable')">启用自启</a-button>
+              <a-button size="small" :loading="svcActing" @click="doServiceAction('disable')">关闭自启</a-button>
+            </a-space>
+          </div>
+          <a-collapse class="mt-2" :bordered="false">
+            <a-collapse-panel key="log" header="最近日志">
+              <pre class="max-h-48 overflow-auto whitespace-pre-wrap text-xs text-gray-600">{{ svc.logTail || '暂无日志' }}</pre>
+            </a-collapse-panel>
+          </a-collapse>
+        </a-card>
+        <a-card v-else size="small" class="max-w-2xl">
+          <a-empty description="未获取到服务状态（sophpicoclaw 未安装或 bmssm 不可达）" />
+        </a-card>
+      </div>
     </a-card>
 
     <!-- 模型选择弹窗 -->
@@ -197,6 +250,9 @@
     Modal,
     Select,
     Tag,
+    Descriptions,
+    Collapse,
+    Empty,
     message,
   } from 'ant-design-vue';
   import {
@@ -206,8 +262,11 @@
     resetForwardKey,
     writeForwardKeyToPicoclaw,
     testAgentConfig,
+    getServiceStatus,
+    serviceAction,
     type AgentConfig,
     type TestResult,
+    type ServiceStatus,
   } from '/@/api/aiAgent';
 
   const ACard = Card;
@@ -227,6 +286,11 @@
   const AModal = Modal;
   const ASelect = Select;
   const ATag = Tag;
+  const ADescriptions = Descriptions;
+  const ADescriptionsItem = Descriptions.Item;
+  const ACollapse = Collapse;
+  const ACollapsePanel = Collapse.Panel;
+  const AEmpty = Empty;
 
   const activeKey = ref('llm');
   const saving = ref(false);
@@ -235,6 +299,29 @@
   const testing = ref(false);
   const testResults = ref<TestResult[]>([]);
   const testAllOK = ref(true);
+
+  // sophpicoclaw 服务监控与管理
+  const svc = ref<ServiceStatus | null>(null);
+  const svcLoading = ref(false);
+  const svcActing = ref(false);
+
+  async function refreshService() {
+    svcLoading.value = true;
+    svc.value = await getServiceStatus();
+    svcLoading.value = false;
+  }
+
+  async function doServiceAction(action: string) {
+    svcActing.value = true;
+    const res = await serviceAction(action);
+    svcActing.value = false;
+    if (res.ok) {
+      message.success(`操作成功：${action}`);
+    } else {
+      message.error(res.message || '操作失败');
+    }
+    await refreshService();
+  }
 
   // API Base URL 预设
   const SOPHNET_API_BASE = 'https://www.sophnet.com/api/open-apis/v1';
@@ -445,7 +532,10 @@
     }
   }
 
-  onMounted(init);
+  onMounted(() => {
+    init();
+    refreshService();
+  });
 </script>
 
 <style lang="less" scoped>


### PR DESCRIPTION
## 背景
MYS-150 评估确认：AI agent 服务从「bmssm 手工 spawn」改为 systemd 管理 `sophpicoclaw` 更优。本 PR 落地 bmssm + sophliteos 侧改造（systemd 服务与安装路径由通用开发 agent 的 spicoclaw 包负责）。

## 改动
### bmssm（llmproxy 模块）
- `restartPicoclaw()`：pkill+手工 spawn → `systemctl restart sophpicoclaw.service`（可注入，单测覆盖）
- `devproxyKeyPath()`：优先 `/opt/sophon/picoclaw/.picoclaw` 新出厂路径，回退旧路径
- 新增 `service_mgr.go`：`GetSophpicoclawStatus`（systemd 状态+端口探测+日志尾部）、`ActionSophpicoclaw`（白名单 start/stop/restart/enable/disable，动作前 daemon-reload，unit 名校验）
- 新端点：`GET /api/v1/llm-proxy/service/status`（auth）、`POST /api/v1/llm-proxy/service/action`（admin）

### sophliteos 前端
- `api/aiAgent` 新增 `getServiceStatus` / `serviceAction`
- AI Agent 配置页新增「服务管理（sophpicoclaw）」卡片：运行状态/开机自启/PID/端口/日志 + 重启/启动/停止/启用自启/关闭自启，操作后自动刷新

## 验证（测试机 172.26.166.185）
- status 端点返回 active/running/PID/端口/日志 ✅
- action restart 生效（PID 变化）✅；非法 action → 400 ✅
- write-picoclaw 走 systemctl restart，devproxy.key 写入新路径且内容一致 ✅
- **bmssm 重启不再连带杀 picoclaw**（cgroup 解耦，PID 保持不变）✅
- 前端页面卡片渲染与操作按钮端到端可用 ✅
- bmssm 全量单测 31 包通过；前端 vite build 通过 ✅

## 依赖
需要 spicoclaw 包（sophpicoclaw.service + /opt/sophon/picoclaw 安装）先部署（通用开发 agent 交付）。