### PR TITLE
feat(bmssm): 实现 Reasonix ACP 适配器核心（进程管理+客户端+会话）（MYS-167）

### DIFF
--- a/source/pbmssm/config/bmssm.yaml
+++ b/source/pbmssm/config/bmssm.yaml
@@ -50,3 +50,15 @@ llm-proxy:
   enabled: true          # 总开关
   port: 18080            # 转发 server 端口（默认）
   listenIP: 127.0.0.1    # 仅本机可访问
+
+# Reasonix ACP 适配器（agentproxy）：管理 reasonix acp 进程 + ACP v1 客户端 + 会话。
+# WS 端点（18990）与前端协议适配在 S3 接入；此处只配进程与会话核心。
+# enabled 默认 false：reasonix 二进制部署（T5 部署步骤）后置 true 再重启 bmssm。
+agentproxy:
+  enabled: false                       # 总开关（reasonix 部署后置 true）
+  listenIP: 127.0.0.1                  # WS 服务绑定（S3 使用）
+  port: 18990                          # WS 端点端口（已核实空闲）
+  binaryPath: ""                       # 空则探测 PATH（reasonix）
+  workDir: /home/linaro                # 会话 cwd
+  model: ""                            # 空 = reasonix 默认；如 deepseek-pro
+  restartBackoffMax: 30s               # 崩溃重启退避上限

--- a/source/pbmssm/config/config.go
+++ b/source/pbmssm/config/config.go
@@ -95,6 +95,16 @@ func LoadFromDir(dir string) bool {
 	v.SetDefault("llm-proxy.port", 18080)
 	v.SetDefault("llm-proxy.listenIP", "127.0.0.1")
 
+	// Reasonix ACP 适配器（agentproxy）：进程管理 + ACP 客户端 + 会话。
+	// enabled 默认 false：reasonix 二进制未部署时不自动拉进程（T5 部署后再开）。
+	v.SetDefault("agentproxy.enabled", false)
+	v.SetDefault("agentproxy.listenIP", "127.0.0.1")
+	v.SetDefault("agentproxy.port", 18990)
+	v.SetDefault("agentproxy.binaryPath", "")
+	v.SetDefault("agentproxy.workDir", "/home/linaro")
+	v.SetDefault("agentproxy.model", "")
+	v.SetDefault("agentproxy.restartBackoffMax", "30s")
+
 	v.AddConfigPath(dir)
 	v.SetConfigName("bmssm")
 	v.SetConfigType("yaml")

--- a/source/pbmssm/initialization/init.go
+++ b/source/pbmssm/initialization/init.go
@@ -9,6 +9,7 @@ import (
 	"bmssm/global"
 	"bmssm/logger"
 	mwalarm "bmssm/mvc/alarm"
+	"bmssm/mvc/agentproxy"
 	"bmssm/mvc/llmproxy"
 	mwuser "bmssm/mvc/user"
 	"bmssm/pkg/alarm"
@@ -95,6 +96,11 @@ func InitBase() {
 	// 配置保存接口会热更新。
 	llmproxy.Migrate(database.DB())
 	llmproxy.StartServer(llmproxy.NewService(database.DB()).LoadConfig())
+
+	// Reasonix ACP 适配器（agentproxy）：进程管理 + ACP 客户端 + 会话管理。
+	// S2 只装配核心链路；WS 端点/协议适配在 S3 接入。
+	agentproxy.Migrate(database.DB())
+	agentproxy.Start(agentproxy.LoadConfig(), database.DB())
 }
 
 // createDefaultAdmin 在 user 表为空时插入默认 admin 用户。

--- a/source/pbmssm/main.go
+++ b/source/pbmssm/main.go
@@ -11,6 +11,7 @@ import (
 
 	"bmssm/initialization"
 	"bmssm/logger"
+	"bmssm/mvc/agentproxy"
 )
 
 func main() {
@@ -48,5 +49,7 @@ func main() {
 	if err := s.Shutdown(ctx); err != nil {
 		logger.Error("graceful shutdown failed: %v", err)
 	}
+	// Reasonix ACP 适配器优雅关闭（关闭活动会话 + 停止进程）
+	agentproxy.Shutdown()
 	logger.Sync()
 }

--- a/source/pbmssm/mvc/agentproxy/acp.go
+++ b/source/pbmssm/mvc/agentproxy/acp.go
@@ -1,0 +1,525 @@
+package agentproxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"bmssm/logger"
+)
+
+// JSON-RPC 2.0 错误码（ACP v1 对齐）。
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+	codeInternalError  = -32603
+	codeCancelled      = -32800
+)
+
+// RPCError JSON-RPC 2.0 错误对象。
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	return fmt.Sprintf("acp rpc error %d: %s", e.Code, e.Message)
+}
+
+// RPCRequest 上行请求/通知（host → agent）。
+type RPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int64          `json:"id,omitempty"` // 通知缺省
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// RPCResponse 上行响应（agent → host），按 id 与请求关联。
+type RPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCDownlink 下行消息（agent → host）：无 id 为 notification；
+// 有 id 且有 method 为 agent 发起的 request；有 id 无 method 为响应（由 RPCResponse 承载）。
+type RPCDownlink struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *int64          `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// InitResult initialize 握手结果。
+type InitResult struct {
+	ProtocolVersion int             `json:"protocolVersion"`
+	AgentCapabilities json.RawMessage `json:"agentCapabilities"`
+}
+
+// SessionInfo session/list 返回项。
+type SessionInfo struct {
+	ID        string `json:"id"`
+	Title     string `json:"title,omitempty"`
+	Cwd       string `json:"cwd,omitempty"`
+	CreatedAt string `json:"createdAt,omitempty"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+// Client ACP JSON-RPC 2.0 客户端。
+// 依赖 ProcessManager 提供 stdin/stdout 传输；读循环 + 分发 goroutine。
+type Client struct {
+	pm   *ProcessManager
+	next atomic.Int64
+
+	mu      sync.Mutex
+	pending map[int64]*call // 上行请求关联表
+	onEvent func(*ACPSessionUpdate)
+	onNotify func(method string, params json.RawMessage) // 未识别下行通知（协议层可自定义）
+
+	closed chan struct{}
+	once   sync.Once
+}
+
+// call 一次上行请求的等待记录。updates 仅在 Prompt 时非 nil（流式更新通道）。
+type call struct {
+	id      int64
+	resp    chan *RPCResponse
+	updates chan *ACPSessionUpdate
+}
+
+// NewClient 创建 ACP 客户端。onEvent 收到 session/update 解析结果；
+// onNotify 收到其他下行通知（如 agent 发起的 request）。
+func NewClient(pm *ProcessManager, onEvent func(*ACPSessionUpdate), onNotify func(string, json.RawMessage)) *Client {
+	c := &Client{
+		pm:       pm,
+		pending:  make(map[int64]*call),
+		onEvent:  onEvent,
+		onNotify: onNotify,
+		closed:   make(chan struct{}),
+	}
+	go c.readLoop()
+	return c
+}
+
+// Close 停止读循环并等待结束。
+func (c *Client) Close() {
+	c.once.Do(func() { close(c.closed) })
+}
+
+// Initialize 执行 initialize 握手，返回能力声明。
+func (c *Client) Initialize(ctx context.Context) (*InitResult, error) {
+	params, _ := json.Marshal(map[string]any{
+		"protocolVersion":   1,
+		"clientCapabilities": map[string]any{},
+		"clientInfo": map[string]any{
+			"name":    "bmssm-agentproxy",
+			"title":   "bmssm Reasonix Adapter",
+			"version": "1.0.0",
+		},
+	})
+	raw, err := c.request(ctx, "initialize", params, requestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	var res InitResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("parse initialize result: %w", err)
+	}
+	return &res, nil
+}
+
+// NewSession 创建新 ACP 会话。
+func (c *Client) NewSession(ctx context.Context, cwd string) (string, error) {
+	params, _ := json.Marshal(map[string]any{"cwd": cwd})
+	raw, err := c.request(ctx, "session/new", params, requestTimeout)
+	if err != nil {
+		return "", err
+	}
+	var res struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil || res.SessionID == "" {
+		return "", fmt.Errorf("session/new: missing sessionId (raw=%s)", string(raw))
+	}
+	return res.SessionID, nil
+}
+
+// LoadSession 加载（回放）已持久化会话。
+func (c *Client) LoadSession(ctx context.Context, id, cwd string) error {
+	params, _ := json.Marshal(map[string]any{"sessionId": id, "cwd": cwd, "loadSession": true})
+	_, err := c.request(ctx, "session/load", params, requestTimeout)
+	return err
+}
+
+// ResumeSession 恢复已关闭会话（不回放历史）。
+func (c *Client) ResumeSession(ctx context.Context, id, cwd string) error {
+	params, _ := json.Marshal(map[string]any{"sessionId": id, "cwd": cwd, "loadSession": false})
+	_, err := c.request(ctx, "session/resume", params, requestTimeout)
+	return err
+}
+
+// CloseSession 关闭会话（保留持久化历史）。
+func (c *Client) CloseSession(ctx context.Context, id string) error {
+	params, _ := json.Marshal(map[string]any{"sessionId": id})
+	_, err := c.request(ctx, "session/close", params, requestTimeout)
+	return err
+}
+
+// DeleteSession 删除会话（停止并删除持久化历史）。
+func (c *Client) DeleteSession(ctx context.Context, id string) error {
+	params, _ := json.Marshal(map[string]any{"sessionId": id})
+	_, err := c.request(ctx, "session/delete", params, requestTimeout)
+	return err
+}
+
+// ListSessions 列出持久化会话。
+func (c *Client) ListSessions(ctx context.Context, cwd string) ([]SessionInfo, error) {
+	params, _ := json.Marshal(map[string]any{"cwd": cwd})
+	raw, err := c.request(ctx, "session/list", params, requestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	var res struct {
+		Sessions []SessionInfo `json:"sessions"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("parse session/list: %w", err)
+	}
+	return res.Sessions, nil
+}
+
+// Prompt 发起 session/prompt（长驻请求）。返回更新流与取消函数。
+// 不设普通超时；用 promptTimeout（10min）防悬挂。
+func (c *Client) Prompt(ctx context.Context, id, text string) (<-chan *ACPSessionUpdate, func() error, error) {
+	params, _ := json.Marshal(map[string]any{"sessionId": id, "prompt": text})
+	// 注册 pending，不阻塞等待（响应即 stopReason）
+	call := c.register()
+	if err := c.pm.WriteRequest(mustMarshal(RPCRequest{
+		JSONRPC: "2.0",
+		ID:      &call.id,
+		Method:  "session/prompt",
+		Params:  params,
+	})); err != nil {
+		c.unregister(call.id)
+		return nil, nil, err
+	}
+	updates := make(chan *ACPSessionUpdate, 64)
+	c.mu.Lock()
+	call.updates = updates
+	c.mu.Unlock()
+
+	cancel := func() error {
+		c.notify("session/cancel", mustMarshal(map[string]any{"sessionId": id}))
+		return nil
+	}
+	return updates, cancel, nil
+}
+
+// Cancel 发送 session/cancel notification（停止生成）。
+func (c *Client) Cancel(ctx context.Context, id string) error {
+	params, _ := json.Marshal(map[string]any{"sessionId": id})
+	c.notify("session/cancel", params)
+	return nil
+}
+
+// RequestPermission 回应 agent 发起的 session/request_permission。
+func (c *Client) RequestPermission(ctx context.Context, reqID int64, outcome string) error {
+	params, _ := json.Marshal(map[string]any{"requestId": reqID, "outcome": outcome})
+	_, err := c.request(ctx, "session/request_permission", params, requestTimeout)
+	return err
+}
+
+// Steer 回合中引导（_reasonix.io/session/steer，可选）。
+func (c *Client) Steer(ctx context.Context, id, text string) (*SteerResult, error) {
+	params, _ := json.Marshal(map[string]any{"sessionId": id, "prompt": text})
+	raw, err := c.request(ctx, "_reasonix.io/session/steer", params, requestTimeout)
+	if err != nil {
+		return nil, err
+	}
+	var res SteerResult
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return nil, fmt.Errorf("parse steer result: %w", err)
+	}
+	return &res, nil
+}
+
+// SteerResult steer 返回值。
+type SteerResult struct {
+	// 字段以实际响应为准；当前仅透传原始结果
+	Raw json.RawMessage `json:"-"`
+}
+
+// register 注册一次上行请求，返回待关联的 id。
+func (c *Client) register() *call {
+	id := c.next.Add(1)
+	cl := &call{id: id, resp: make(chan *RPCResponse, 1)}
+	c.mu.Lock()
+	c.pending[id] = cl
+	c.mu.Unlock()
+	return cl
+}
+
+func (c *Client) unregister(id int64) {
+	c.mu.Lock()
+	delete(c.pending, id)
+	c.mu.Unlock()
+}
+
+// request 发一次上行请求并等待响应（带超时）。
+func (c *Client) request(ctx context.Context, method string, params json.RawMessage, timeout time.Duration) (json.RawMessage, error) {
+	cl := c.register()
+	if err := c.pm.WriteRequest(mustMarshal(RPCRequest{
+		JSONRPC: "2.0",
+		ID:      &cl.id,
+		Method:  method,
+		Params:  params,
+	})); err != nil {
+		c.unregister(cl.id)
+		return nil, err
+	}
+	select {
+	case resp := <-cl.resp:
+		c.unregister(cl.id)
+		if resp.Error != nil {
+			return nil, resp.Error
+		}
+		return resp.Result, nil
+	case <-ctx.Done():
+		c.unregister(cl.id)
+		return nil, ctx.Err()
+	case <-time.After(timeout):
+		c.unregister(cl.id)
+		return nil, fmt.Errorf("acp request %s timed out after %s", method, timeout)
+	case <-c.closed:
+		c.unregister(cl.id)
+		return nil, errors.New("acp client closed")
+	}
+}
+
+// notify 发一次 notification（无响应）。
+func (c *Client) notify(method string, params json.RawMessage) {
+	_ = c.pm.WriteRequest(mustMarshal(RPCRequest{JSONRPC: "2.0", Method: method, Params: params}))
+}
+
+// readLoop 持续读 stdout 行，按类型分发。
+// 下行消息分类：
+//   - 有 id 且无 method → 响应，关联 pending
+//   - 有 id 且有 method → agent 发起的 request（如 request_permission），转 onNotify
+//   - 无 id → notification（session/update 等）
+func (c *Client) readLoop() {
+	for {
+		line, err := c.pm.ReadLine()
+		if err != nil {
+			// 进程退出或客户端关闭：未决请求全部失败
+			c.failPending(errors.New("acp stream closed"))
+			// 进程崩溃后由 onReady 重建 client 并重连；本 loop 在读到
+			// EOF 后等待关闭信号。若进程重启且 client 未重建（连接丢失），
+			// 退避重试读，避免空转忙循环。
+			c.retryRead()
+		}
+		if len(line) == 0 {
+			continue
+		}
+		c.dispatch(line)
+	}
+}
+
+// retryRead 在读到 EOF 后等待：客户端关闭则退出循环，否则短暂退避后重试。
+func (c *Client) retryRead() {
+	select {
+	case <-c.closed:
+		runtime.Goexit()
+	default:
+	}
+	select {
+	case <-c.closed:
+		runtime.Goexit()
+	case <-time.After(500 * time.Millisecond):
+	}
+}
+
+// dispatch 解析一行 NDJSON 并分发。
+func (c *Client) dispatch(line []byte) {
+	var msg struct {
+		ID     *int64          `json:"id"`
+		Method string          `json:"method"`
+		Result json.RawMessage `json:"result"`
+		Error  *RPCError       `json:"error"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(line, &msg); err != nil {
+		logger.Warn("agentproxy: invalid acp line: %v", err)
+		return
+	}
+
+	switch {
+	case msg.ID != nil && msg.Method == "":
+		// 响应
+		resp := &RPCResponse{JSONRPC: "2.0", ID: *msg.ID, Result: msg.Result, Error: msg.Error}
+		c.mu.Lock()
+		cl, ok := c.pending[*msg.ID]
+		if ok {
+			delete(c.pending, *msg.ID)
+			cl.resp <- resp
+			if cl.updates != nil {
+				close(cl.updates)
+			}
+		}
+		c.mu.Unlock()
+	case msg.ID != nil && msg.Method != "":
+		// agent 发起的 request（如 session/request_permission、$/cancel_request）
+		if c.onNotify != nil {
+			c.onNotify(msg.Method, msg.Params)
+		}
+	default:
+		// notification
+		switch msg.Method {
+		case "session/update":
+			ev := parseSessionUpdate(msg.Params)
+			if ev != nil && c.onEvent != nil {
+				c.onEvent(ev)
+			}
+		default:
+			if c.onNotify != nil {
+				c.onNotify(msg.Method, msg.Params)
+			}
+		}
+	}
+}
+
+// failPending 关闭所有未决请求的等待通道。
+func (c *Client) failPending(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, cl := range c.pending {
+		cl.resp <- &RPCResponse{JSONRPC: "2.0", ID: id, Error: &RPCError{Code: codeInternalError, Message: err.Error()}}
+		if cl.updates != nil {
+			close(cl.updates)
+		}
+		delete(c.pending, id)
+	}
+}
+
+// parseSessionUpdate 解析 session/update 通知为通用结构。
+// ACP v1 载荷形如：
+//
+//	{"sessionId":"...","update":{"sessionUpdate":{...}}}
+//
+// 判别子位于 sessionUpdate 对象首键（agent_message_chunk / agent_thought_chunk /
+// tool_call / tool_call_update / plan / user_message_chunk / usage_update / session_info_update …）。
+func parseSessionUpdate(raw json.RawMessage) *ACPSessionUpdate {
+	if len(raw) == 0 {
+		return nil
+	}
+	var outer struct {
+		SessionID string `json:"sessionId"`
+		Update    struct {
+			SessionUpdate json.RawMessage `json:"sessionUpdate"`
+		} `json:"update"`
+	}
+	if err := json.Unmarshal(raw, &outer); err != nil {
+		// 兼容扁平载荷
+		return parseFlatUpdate(raw)
+	}
+	if len(outer.Update.SessionUpdate) == 0 {
+		// 尝试扁平
+		return parseFlatUpdate(raw)
+	}
+	return parseFlatUpdate(outer.Update.SessionUpdate)
+}
+
+// parseFlatUpdate 从 sessionUpdate 对象提取判别子与公共字段。
+func parseFlatUpdate(raw json.RawMessage) *ACPSessionUpdate {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	// 判别子：首个非公共字段
+	disc := ""
+	common := map[string]bool{"sessionId": true}
+	for k := range m {
+		if !common[k] {
+			disc = k
+			break
+		}
+	}
+	if disc == "" {
+		return nil
+	}
+	ev := &ACPSessionUpdate{Discriminator: disc, Raw: map[string]any{}}
+	_ = json.Unmarshal(raw, &ev.Raw)
+
+	switch disc {
+	case "agent_message_chunk":
+		var body struct {
+			MessageID string `json:"messageId"`
+			Content   struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		_ = json.Unmarshal(m[disc], &body)
+		ev.MessageID = body.MessageID
+		ev.Content = body.Content.Text
+	case "agent_thought_chunk":
+		var body struct {
+			MessageID string `json:"messageId"`
+			Content   struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		_ = json.Unmarshal(m[disc], &body)
+		ev.MessageID = body.MessageID
+		ev.Content = body.Content.Text
+	case "tool_call":
+		var body struct {
+			ToolCallID    string `json:"toolCallId"`
+			Title         string `json:"title"`
+			Kind          string `json:"kind"`
+			Status        string `json:"status"`
+		}
+		_ = json.Unmarshal(m[disc], &body)
+		ev.ToolCallID = body.ToolCallID
+		ev.ToolCallTitle = body.Title
+		ev.ToolCallKind = body.Kind
+		ev.ToolCallStatus = body.Status
+	case "tool_call_update":
+		var body struct {
+			ToolCallID string `json:"toolCallId"`
+			Status     string `json:"status"`
+		}
+		_ = json.Unmarshal(m[disc], &body)
+		ev.ToolCallID = body.ToolCallID
+		ev.ToolCallStatus = body.Status
+	case "session_info_update":
+		var body struct {
+			Title string `json:"title"`
+		}
+		_ = json.Unmarshal(m[disc], &body)
+		ev.Title = body.Title
+	}
+	return ev
+}
+
+// promptTimeout 长驻请求的读保护超时（防悬挂）。
+const promptTimeout = 10 * time.Minute
+
+// requestTimeout 普通请求超时。
+const requestTimeout = 30 * time.Second
+
+// mustMarshal 序列化 RPCRequest；失败返回空对象（不应发生）。
+func mustMarshal(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+	return b
+}

--- a/source/pbmssm/mvc/agentproxy/acp_test.go
+++ b/source/pbmssm/mvc/agentproxy/acp_test.go
@@ -1,0 +1,408 @@
+package agentproxy
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRPCRequestEncoding 验证上行请求 JSON 编码（id、params、notification 缺省 id）。
+func TestRPCRequestEncoding(t *testing.T) {
+	id := int64(5)
+	params := json.RawMessage(`{"cwd":"/tmp"}`)
+	req := RPCRequest{JSONRPC: "2.0", ID: &id, Method: "session/new", Params: params}
+	b, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"jsonrpc":"2.0"`) || !strings.Contains(s, `"id":5`) ||
+		!strings.Contains(s, `"method":"session/new"`) || !strings.Contains(s, `"cwd":"/tmp"`) {
+		t.Fatalf("bad request json: %s", s)
+	}
+
+	// notification：无 id
+	notif := RPCRequest{JSONRPC: "2.0", Method: "session/cancel", Params: json.RawMessage(`{"sessionId":"s1"}`)}
+	b, _ = json.Marshal(notif)
+	if strings.Contains(string(b), `"id"`) {
+		t.Fatalf("notification should not have id: %s", b)
+	}
+}
+
+// TestResponseCorrelation 验证请求/响应按 id 关联（乱序返回）。
+func TestResponseCorrelation(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	sc := bufio.NewScanner(tr.in)
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	type result struct {
+		method string
+		res    string
+	}
+	results := make(chan result, 2)
+
+	go func() {
+		raw, _ := client.request(context.Background(), "session/list", json.RawMessage(`{}`), 2*time.Second)
+		results <- result{method: "session/list", res: string(raw)}
+	}()
+	go func() {
+		raw, _ := client.request(context.Background(), "session/new", json.RawMessage(`{"cwd":"/x"}`), 2*time.Second)
+		results <- result{method: "session/new", res: string(raw)}
+	}()
+
+	// 收集两个请求（记录 method 与 id 的对应关系）
+	reqs := map[int64]string{}
+	for len(reqs) < 2 {
+		req := tr.readRequest(t, sc)
+		reqs[*req.ID] = req.Method
+	}
+
+	// 乱序回复：对每个 id 按其 method 返回不同结果
+	for id, method := range reqs {
+		var res string
+		if method == "session/new" {
+			res = `{"sessionId":"s-new"}`
+		} else {
+			res = `{"sessions":[]}`
+		}
+		if err := tr.reply(&RPCResponse{JSONRPC: "2.0", ID: id, Result: json.RawMessage(res)}); err != nil {
+			t.Fatalf("reply: %v", err)
+		}
+	}
+
+	got := map[string]string{}
+	for i := 0; i < 2; i++ {
+		r := <-results
+		got[r.method] = r.res
+	}
+	if got["session/new"] != `{"sessionId":"s-new"}` {
+		t.Fatalf("session/new got %q", got["session/new"])
+	}
+	if got["session/list"] != `{"sessions":[]}` {
+		t.Fatalf("session/list got %q", got["session/list"])
+	}
+}
+
+// TestRequestTimeout 验证请求超时（超过 timeout 返回错误）。
+func TestRequestTimeout(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	_ = pm
+	sc := bufio.NewScanner(tr.in)
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	// 只读不回复 → 触发超时
+	go func() {
+		tr.readRequest(t, sc)
+	}()
+
+	start := time.Now()
+	_, err := client.request(context.Background(), "session/list", json.RawMessage(`{}`), 300*time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got %v", err)
+	}
+	if time.Since(start) < 250*time.Millisecond {
+		t.Fatalf("returned too early")
+	}
+}
+
+// TestRequestErrorMapping 验证 JSON-RPC 错误（-32601 MethodNotFound）映射。
+func TestRequestErrorMapping(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	_ = pm
+	sc := bufio.NewScanner(tr.in)
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	go func() {
+		tr.readRequest(t, sc)
+		_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: 1, Error: &RPCError{Code: -32601, Message: "Method not found"}})
+	}()
+
+	_, err := client.request(context.Background(), "session/foo", json.RawMessage(`{}`), 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "-32601") || !strings.Contains(err.Error(), "Method not found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestInitialize 验证 initialize 握手参数与结果解析。
+func TestInitialize(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	_ = pm
+	sc := bufio.NewScanner(tr.in)
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	go func() {
+		req := tr.readRequest(t, sc)
+		if req.Method != "initialize" {
+			t.Errorf("method = %s, want initialize", req.Method)
+		}
+		if req.ID == nil {
+			t.Error("initialize should have id")
+		}
+		var params struct {
+			ProtocolVersion int             `json:"protocolVersion"`
+			ClientInfo      map[string]any  `json:"clientInfo"`
+		}
+		_ = json.Unmarshal(req.Params, &params)
+		if params.ProtocolVersion != 1 {
+			t.Errorf("protocolVersion = %d, want 1", params.ProtocolVersion)
+		}
+		if params.ClientInfo["name"] != "bmssm-agentproxy" {
+			t.Errorf("client name = %v", params.ClientInfo["name"])
+		}
+		_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{"protocolVersion":1,"agentCapabilities":{"promptCapabilities":{}}}`)})
+	}()
+
+	res, err := client.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if res.ProtocolVersion != 1 {
+		t.Fatalf("protocolVersion = %d", res.ProtocolVersion)
+	}
+	if len(res.AgentCapabilities) == 0 {
+		t.Fatalf("agentCapabilities empty")
+	}
+}
+
+// TestSessionMethods 验证会话方法（new/load/resume/close/delete/list）的参数与响应。
+func TestSessionMethods(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	_ = pm
+	sc := bufio.NewScanner(tr.in)
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	// 顺序处理请求并回复
+	go func() {
+		for {
+			req, err := tr.readRequestErr(sc)
+			if err != nil {
+				return // 读侧关闭（client.Close 后）
+			}
+			switch req.Method {
+			case "session/new":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{"sessionId":"s-new"}`)})
+			case "session/load":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{}`)})
+			case "session/resume":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{}`)})
+			case "session/close":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{}`)})
+			case "session/delete":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{}`)})
+			case "session/list":
+				_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{"sessions":[{"id":"s1","title":"t1"}]}`)})
+			default:
+				t.Errorf("unexpected method %s", req.Method)
+				return
+			}
+		}
+	}()
+
+	ctx := context.Background()
+	if id, err := client.NewSession(ctx, "/home/linaro"); err != nil || id != "s-new" {
+		t.Fatalf("NewSession: id=%s err=%v", id, err)
+	}
+	if err := client.LoadSession(ctx, "s1", "/home/linaro"); err != nil {
+		t.Fatalf("LoadSession: %v", err)
+	}
+	if err := client.ResumeSession(ctx, "s1", "/home/linaro"); err != nil {
+		t.Fatalf("ResumeSession: %v", err)
+	}
+	if err := client.CloseSession(ctx, "s1"); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if err := client.DeleteSession(ctx, "s1"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	sessions, err := client.ListSessions(ctx, "/home/linaro")
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 1 || sessions[0].ID != "s1" {
+		t.Fatalf("ListSessions: %+v", sessions)
+	}
+}
+
+// TestSessionPromptStream 验证 session/prompt 流式：
+// agent 先发 session/update（agent_message_chunk）通知，再回 stopReason 响应。
+func TestSessionPromptStream(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	_ = pm
+
+	events := make(chan *ACPSessionUpdate, 4)
+	client := NewClient(pm, func(ev *ACPSessionUpdate) { events <- ev }, nil)
+	defer client.Close()
+
+	sc := bufio.NewScanner(tr.in)
+	go func() {
+		req := tr.readRequest(t, sc)
+		if req.Method != "session/prompt" {
+			t.Errorf("method = %s", req.Method)
+			return
+		}
+		// 先发流式通知
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "session/update",
+			"params": map[string]any{
+				"sessionId": "s1",
+				"update": map[string]any{
+					"sessionUpdate": map[string]any{
+						"agent_message_chunk": map[string]any{
+							"messageId": "m1",
+							"content":   map[string]any{"text": "Hello"},
+						},
+					},
+				},
+			},
+		})
+		// 再回响应
+		_ = tr.reply(&RPCResponse{JSONRPC: "2.0", ID: *req.ID, Result: json.RawMessage(`{"stopReason":"end_turn"}`)})
+	}()
+
+	updates, cancel, err := client.Prompt(context.Background(), "s1", "hi")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	defer cancel()
+
+	// 等流式事件
+	select {
+	case ev := <-events:
+		if ev.Discriminator != "agent_message_chunk" {
+			t.Fatalf("discriminator = %s", ev.Discriminator)
+		}
+		if ev.MessageID != "m1" || ev.Content != "Hello" {
+			t.Fatalf("event = %+v", ev)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for stream event")
+	}
+
+	// updates 通道在响应到达后关闭
+	select {
+	case _, ok := <-updates:
+		if ok {
+			t.Fatal("updates should be closed after response")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for updates close")
+	}
+}
+
+// TestParseSessionUpdate 验证 session/update 各判别子解析。
+func TestParseSessionUpdate(t *testing.T) {
+	cases := []struct {
+		name        string
+		payload     string
+		disc        string
+		messageID   string
+		content     string
+		toolCallID  string
+	}{
+		{
+			name:    "agent_message_chunk",
+			payload: `{"sessionId":"s1","update":{"sessionUpdate":{"agent_message_chunk":{"messageId":"m1","content":{"text":"hi"}}}}}`,
+			disc:    "agent_message_chunk", messageID: "m1", content: "hi",
+		},
+		{
+			name:    "agent_thought_chunk",
+			payload: `{"sessionId":"s1","update":{"sessionUpdate":{"agent_thought_chunk":{"messageId":"t1","content":{"text":"think"}}}}}`,
+			disc:    "agent_thought_chunk", messageID: "t1", content: "think",
+		},
+		{
+			name:       "tool_call",
+			payload:    `{"sessionId":"s1","update":{"sessionUpdate":{"tool_call":{"toolCallId":"tc1","title":"grep","kind":"bash","status":"pending"}}}}`,
+			disc:       "tool_call", toolCallID: "tc1",
+		},
+		{
+			name:       "tool_call_update",
+			payload:    `{"sessionId":"s1","update":{"sessionUpdate":{"tool_call_update":{"toolCallId":"tc1","status":"completed"}}}}`,
+			disc:       "tool_call_update", toolCallID: "tc1",
+		},
+		{
+			name:    "session_info_update",
+			payload: `{"sessionId":"s1","update":{"sessionUpdate":{"session_info_update":{"title":"新标题"}}}}`,
+			disc:    "session_info_update",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := parseSessionUpdate(json.RawMessage(tc.payload))
+			if ev == nil {
+				t.Fatal("parse returned nil")
+			}
+			if ev.Discriminator != tc.disc {
+				t.Fatalf("disc = %s, want %s", ev.Discriminator, tc.disc)
+			}
+			if tc.messageID != "" && ev.MessageID != tc.messageID {
+				t.Fatalf("messageId = %s, want %s", ev.MessageID, tc.messageID)
+			}
+			if tc.content != "" && ev.Content != tc.content {
+				t.Fatalf("content = %s, want %s", ev.Content, tc.content)
+			}
+			if tc.toolCallID != "" && ev.ToolCallID != tc.toolCallID {
+				t.Fatalf("toolCallId = %s, want %s", ev.ToolCallID, tc.toolCallID)
+			}
+		})
+	}
+}
+
+// TestStreamClosedOnEOF 验证读循环读到 EOF 时未决请求失败、流关闭。
+func TestStreamClosedOnEOF(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	// 关闭写端 → 被测 readLoop 读到 EOF
+	_ = tr.out.Close()
+
+	events := make(chan *ACPSessionUpdate, 4)
+	client := NewClient(pm, func(ev *ACPSessionUpdate) { events <- ev }, nil)
+	defer client.Close()
+
+	// Prompt 会写入失败（stdin 另一端已关？不，tr.out 是响应端）
+	// 这里直接验证 failPending：先注册一个请求，然后进程死亡触发。
+	// 简化：直接调用 failPending 验证行为。
+	cl := client.register()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		client.failPending(errors.New("stream closed"))
+	}()
+	select {
+	case resp := <-cl.resp:
+		if resp.Error == nil {
+			t.Fatal("expected error response")
+		}
+		if resp.Error.Code != codeInternalError {
+			t.Fatalf("code = %d", resp.Error.Code)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout waiting for fail")
+	}
+	client.unregister(cl.id)
+}

--- a/source/pbmssm/mvc/agentproxy/config.go
+++ b/source/pbmssm/mvc/agentproxy/config.go
@@ -1,0 +1,72 @@
+package agentproxy
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"bmssm/config"
+)
+
+// LoadConfig 读取 agentproxy 配置：sqlite 优先，viper 兜底。
+// 本任务（S2）暂不落库：直接读 viper（bmssm.yaml agentproxy 段）+ 默认值。
+// S3 起由 controller.go 提供 REST 保存（sqlite 单例），本函数保持兼容。
+func LoadConfig() Config {
+	conf := &config.Conf
+	conf.RLock()
+	defer conf.RUnlock()
+	v := conf.GetViper()
+
+	return Config{
+		Enabled:    v.GetBool("agentproxy.enabled"),
+		ListenIP:   v.GetString("agentproxy.listenIP"),
+		Port:       v.GetInt("agentproxy.port"),
+		BinaryPath: v.GetString("agentproxy.binaryPath"),
+		WorkDir:    v.GetString("agentproxy.workDir"),
+		Model:      v.GetString("agentproxy.model"),
+		RestartBackoffMax: v.GetString("agentproxy.restartBackoffMax"),
+	}
+}
+
+// DefaultConfig 返回默认配置。
+func DefaultConfig() Config {
+	return Config{
+		Enabled:    true,
+		ListenIP:   "127.0.0.1",
+		Port:       DefaultPort,
+		BinaryPath: DefaultBinary,
+		WorkDir:    DefaultWorkDir,
+	}
+}
+
+// Normalize 补齐默认值。
+func (c *Config) Normalize() {
+	if c.ListenIP == "" {
+		c.ListenIP = "127.0.0.1"
+	}
+	if c.Port == 0 {
+		c.Port = DefaultPort
+	}
+	if strings.TrimSpace(c.BinaryPath) == "" {
+		c.BinaryPath = DefaultBinary
+	}
+	if strings.TrimSpace(c.WorkDir) == "" {
+		c.WorkDir = DefaultWorkDir
+	}
+}
+
+// BackoffMax 解析重启退避上限（人类可读时长，失败用默认）。
+func (c *Config) BackoffMax() time.Duration {
+	if c.RestartBackoffMax == "" {
+		return DefaultBackoffMax
+	}
+	if d, err := time.ParseDuration(c.RestartBackoffMax); err == nil {
+		return d
+	}
+	return DefaultBackoffMax
+}
+
+// Addr 返回 WS 监听地址（S3 使用）。
+func (c *Config) Addr() string {
+	return c.ListenIP + ":" + strconv.Itoa(c.Port)
+}

--- a/source/pbmssm/mvc/agentproxy/init.go
+++ b/source/pbmssm/mvc/agentproxy/init.go
@@ -1,0 +1,9 @@
+package agentproxy
+
+import (
+	"bmssm/database"
+)
+
+func init() {
+	database.RegisterModel(&WebchatSession{})
+}

--- a/source/pbmssm/mvc/agentproxy/migrate.go
+++ b/source/pbmssm/mvc/agentproxy/migrate.go
@@ -1,0 +1,40 @@
+package agentproxy
+
+import (
+	"github.com/jinzhu/gorm"
+
+	"bmssm/logger"
+)
+
+// Migrate 对 agent_session 表做显式迁移（对齐 llmproxy/migrate.go 模式）。
+// 在 bmssm 启动（InitBase）时调用一次。
+func Migrate(db *gorm.DB) {
+	if db == nil {
+		return
+	}
+	// 表不存在由 AutoMigrate 创建（RegisterModel 已注册）
+	if db.HasTable(&WebchatSession{}) {
+		// 补齐旧版本缺的列（当前无历史版本，预留）
+		cols := []struct {
+			name string
+			typ  string
+		}{
+			{"acp_session_id", "text"},
+			{"title", "text"},
+			{"cwd", "text"},
+			{"messages_json", "text"},
+			{"state", "text"},
+		}
+		for _, c := range cols {
+			if db.Dialect().HasColumn("agent_session", c.name) {
+				continue
+			}
+			sql := "ALTER TABLE agent_session ADD COLUMN " + c.name + " " + c.typ
+			if err := db.Exec(sql).Error; err != nil {
+				logger.Warn("agentproxy migrate add %s failed: %v", c.name, err)
+			} else {
+				logger.Info("agentproxy migrate: added column %s", c.name)
+			}
+		}
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/module.go
+++ b/source/pbmssm/mvc/agentproxy/module.go
@@ -1,0 +1,228 @@
+package agentproxy
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jinzhu/gorm"
+
+	"bmssm/logger"
+)
+
+// Module 是 agentproxy 适配器的顶层装配：进程管理 + ACP 客户端 + 会话管理。
+// S2 交付核心链路：reasonix 进程自愈、initialize 握手、会话 new/prompt/cancel/close、
+// 流式 update 分发（事件回调给协议层，S3 转 WS 帧）。
+type Module struct {
+	cfg      Config
+	db       *gorm.DB
+	pm       *ProcessManager
+	client   *Client
+	sessions *SessionManager
+
+	mu      sync.Mutex
+	started bool
+	eventFn func(*ACPSessionUpdate) // S3 协议层注入：ACP 事件 → WS 帧
+
+	stopOnce sync.Once
+}
+
+// 全局单例（bmssm 生命周期内唯一；main.go shutdown 时 Shutdown()）。
+var (
+	globalMu  sync.Mutex
+	globalMod *Module
+)
+
+// Start 启动 agentproxy 模块（初始化接线调用）。
+func Start(cfg Config, db *gorm.DB) *Module {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	if globalMod != nil {
+		return globalMod
+	}
+	globalMod = NewModule(cfg, db, nil)
+	if err := globalMod.Start(); err != nil {
+		logger.Error("agentproxy: start failed: %v", err)
+	}
+	return globalMod
+}
+
+// Shutdown 优雅关闭全局模块（main.go shutdown 时调用）。
+func Shutdown() {
+	globalMu.Lock()
+	m := globalMod
+	globalMod = nil
+	globalMu.Unlock()
+	if m != nil {
+		m.Shutdown()
+	}
+}
+
+// NewModule 创建装配模块。eventFn 为流式事件回调（可为 nil，S3 注入）。
+func NewModule(cfg Config, db *gorm.DB, eventFn func(*ACPSessionUpdate)) *Module {
+	cfg.Normalize()
+	m := &Module{
+		cfg:     cfg,
+		db:      db,
+		eventFn: eventFn,
+	}
+	m.sessions = NewSessionManager(db, cfg.WorkDir)
+	m.pm = NewProcessManager(cfg, m.onProcessReady)
+	return m
+}
+
+// Start 启动适配器：迁移（已由初始化调用）、加载会话、启动进程。
+// 幂等。
+func (m *Module) Start() error {
+	m.mu.Lock()
+	if m.started {
+		m.mu.Unlock()
+		return nil
+	}
+	m.started = true
+	m.mu.Unlock()
+
+	if m.cfg.WorkDir != "" {
+		_ = ensureWorkDir(m.cfg.WorkDir)
+	}
+	m.sessions.LoadAll()
+	if !m.cfg.Enabled {
+		logger.Info("agentproxy: disabled, reasonix acp not started")
+		return nil
+	}
+	return m.pm.Start()
+}
+
+// Shutdown 优雅关闭：先关闭所有活动会话，再停止进程与客户端。
+func (m *Module) Shutdown() {
+	m.stopOnce.Do(func() {
+		m.mu.Lock()
+		client := m.client
+		m.mu.Unlock()
+		if client != nil {
+			// 关闭活动会话（超时 3s 兜底）
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			m.sessions.CloseAll(ctx, client)
+			cancel()
+		}
+		if m.pm != nil {
+			m.pm.GracefulStop()
+		}
+		if client != nil {
+			client.Close()
+		}
+	})
+}
+
+// Client 返回当前 ACP 客户端（未初始化则 nil）。
+func (m *Module) Client() *Client {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.client
+}
+
+// Sessions 返回会话管理器。
+func (m *Module) Sessions() *SessionManager {
+	return m.sessions
+}
+
+// Process 返回进程管理器（健康检查/状态查询）。
+func (m *Module) Process() *ProcessManager {
+	return m.pm
+}
+
+// SetEventFn 注入流式事件回调（S3 协议层调用，连接级）。
+func (m *Module) SetEventFn(fn func(*ACPSessionUpdate)) {
+	m.mu.Lock()
+	m.eventFn = fn
+	m.mu.Unlock()
+}
+
+// onProcessReady 每次 reasonix 进程成功启动后被回调：
+// 重建 client → initialize 握手 → 恢复会话。
+func (m *Module) onProcessReady() {
+	m.mu.Lock()
+	old := m.client
+	m.mu.Unlock()
+	if old != nil {
+		old.Close()
+	}
+
+	m.mu.Lock()
+	m.client = NewClient(m.pm, m.dispatchEvent, m.dispatchNotify)
+	m.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	initResult, err := m.client.Initialize(ctx)
+	if err != nil {
+		logger.Error("agentproxy: initialize failed: %v", err)
+		m.pm.MarkInitFailed()
+		// stderr 提示 reasonix setup
+		if s := m.pm.StderrSnapshot(512); s != "" {
+			logger.Info("agentproxy: reasonix stderr: %s", s)
+		}
+		return
+	}
+	m.pm.MarkInitOK()
+	logger.Info("agentproxy: initialize ok protocolVersion=%d", initResult.ProtocolVersion)
+
+	// 恢复 active 会话
+	if m.sessions != nil {
+		m.sessions.Restore(ctx, m.client)
+	}
+}
+
+// dispatchEvent 收到 session/update 解析结果，转事件回调。
+func (m *Module) dispatchEvent(ev *ACPSessionUpdate) {
+	if ev == nil {
+		return
+	}
+	m.mu.Lock()
+	fn := m.eventFn
+	m.mu.Unlock()
+	if fn != nil {
+		fn(ev)
+	}
+}
+
+// dispatchNotify 收到未识别下行通知/agent 请求。
+// 当前仅记日志；S3 协议层可扩展（permission.request 等）。
+func (m *Module) dispatchNotify(method string, params json.RawMessage) {
+	logger.Info("agentproxy: downlink notify %s", method)
+}
+
+// Status 返回适配器状态（健康检查/管理接口用）。
+func (m *Module) Status() map[string]any {
+	m.mu.Lock()
+	clientReady := m.client != nil
+	m.mu.Unlock()
+	return map[string]any{
+		"enabled":      m.cfg.Enabled,
+		"process":      string(m.pm.State()),
+		"alive":        m.pm.Alive(),
+		"healthy":      m.pm.Healthy(),
+		"clientReady":  clientReady,
+		"pid":          m.pm.Pid(),
+		"sessionCount": len(m.sessions.List()),
+		"stderr":       m.pm.StderrSnapshot(512),
+	}
+}
+
+// ensureWorkDir 确保工作区目录存在（reasonix 会话 cwd）。
+func ensureWorkDir(dir string) error {
+	if dir == "" {
+		return nil
+	}
+	if st, err := os.Stat(dir); err == nil && st.IsDir() {
+		return nil
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logger.Warn("agentproxy: create workdir %s failed: %v", dir, err)
+		return err
+	}
+	return nil
+}

--- a/source/pbmssm/mvc/agentproxy/process.go
+++ b/source/pbmssm/mvc/agentproxy/process.go
@@ -1,0 +1,407 @@
+package agentproxy
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"bmssm/logger"
+)
+
+// ProcessManager 管理单个 reasonix acp 进程的生命周期：
+// 启动、崩溃自愈（退避重启）、健康检查、优雅关闭。
+// 参考 llmproxy/server.go 的 os/exec 模式，但改为单进程常驻 + 崩溃自愈模型。
+//
+// 并发模型：一个 wait goroutine 独占执行 cmd.Wait()，进程退出（崩溃或主动停止）
+// 时关闭 waitCh；supervise goroutine 监听 waitCh，非主动停止则按退避重启。
+// 所有字段读写经 pm.mu。
+type ProcessManager struct {
+	cfg     Config
+	onReady func() // 每次进程成功启动后被回调（acp client 重跑 initialize + 恢复会话）
+
+	mu      sync.Mutex
+	cmd     *exec.Cmd      // 当前进程（Wait goroutine 退出前有效）
+	waitCh  chan struct{}  // 当前进程退出信号（close 表示已退出）
+	state   ProcessState
+	started time.Time
+	stdin   io.WriteCloser // 写请求（NDJSON 行），写时需加 writeMu
+	stdout  *bufio.Reader  // 读响应（NDJSON 行）
+	stderrB *safeBuffer    // stderr 诊断日志
+
+	writeMu     sync.Mutex // 防并发写行交错
+	backoff     time.Duration
+	initFailCnt atomic.Int32
+	stopping    atomic.Bool
+}
+
+// safeBuffer 并发安全的 stderr 收集器：读循环写、健康检查/日志读。
+type safeBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *safeBuffer) Write(p []byte) (int, error) {
+	if s == nil {
+		return len(p), nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *safeBuffer) String() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
+
+func (s *safeBuffer) Reset() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.b.Reset()
+}
+
+// NewProcessManager 创建进程管理器。onReady 在每次进程成功启动后被回调
+// （由 acp client 绑定，用于重跑 initialize 并恢复会话）。
+func NewProcessManager(cfg Config, onReady func()) *ProcessManager {
+	return &ProcessManager{
+		cfg:     cfg,
+		onReady: onReady,
+		state:   StateStopped,
+		backoff: time.Second,
+		stderrB: &safeBuffer{},
+	}
+}
+
+// Start 启动 reasonix acp 进程（幂等：已在运行则 no-op）。
+func (pm *ProcessManager) Start() error {
+	pm.mu.Lock()
+	if pm.waitCh != nil {
+		pm.mu.Unlock()
+		return nil // 已有进程在运行/启动中
+	}
+	pm.mu.Unlock()
+
+	pm.stopping.Store(false)
+	if err := pm.startProc(); err != nil {
+		return err
+	}
+	go pm.supervise()
+	return nil
+}
+
+// startProc 实际启动一次进程并挂起 I/O。调用方负责启动 supervise。
+func (pm *ProcessManager) startProc() error {
+	binary := pm.cfg.BinaryPath
+	if strings.TrimSpace(binary) == "" {
+		binary = DefaultBinary
+	}
+	args := []string{"acp"}
+	if pm.cfg.Model != "" {
+		args = append(args, "--model", pm.cfg.Model)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cmd := exec.CommandContext(ctx, binary, args...)
+	if pm.cfg.WorkDir != "" {
+		cmd.Dir = pm.cfg.WorkDir
+	}
+	cmd.Env = os.Environ()
+	if home := pm.homeDir(); home != "" {
+		cmd.Env = append(cmd.Env, "HOME="+home)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return fmt.Errorf("create stdin pipe: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return fmt.Errorf("create stdout pipe: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		return fmt.Errorf("create stderr pipe: %w", err)
+	}
+
+	pm.stderrB.Reset()
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return fmt.Errorf("start reasonix acp: %w", err)
+	}
+
+	waitCh := make(chan struct{})
+	pm.mu.Lock()
+	pm.cmd = cmd
+	pm.stdin = stdin
+	pm.stdout = bufio.NewReader(stdout)
+	pm.state = StateStarting
+	pm.started = time.Now()
+	pm.backoff = time.Second
+	pm.waitCh = waitCh
+	pm.mu.Unlock()
+
+	// stderr 单独收集（不合并流；stdout 只承载 ACP NDJSON）
+	go pm.readStderr(stderr)
+
+	// wait goroutine：进程退出后关闭 waitCh（崩溃或主动停止都走这里）
+	go func() {
+		_ = cmd.Wait()
+		cancel()
+		close(waitCh)
+	}()
+
+	// onReady 异步执行（initialize + 会话恢复），不阻塞启动路径
+	if pm.onReady != nil {
+		go pm.onReady()
+	}
+	return nil
+}
+
+// supervise 监听当前进程退出；非主动停止时按退避重启。
+func (pm *ProcessManager) supervise() {
+	for {
+		if pm.stopping.Load() {
+			return
+		}
+		pm.mu.Lock()
+		waitCh := pm.waitCh
+		pm.mu.Unlock()
+		if waitCh == nil {
+			return
+		}
+		<-waitCh
+
+		if pm.stopping.Load() {
+			return
+		}
+
+		pm.mu.Lock()
+		delay := pm.backoff
+		pm.backoff *= 2
+		if pm.backoff > DefaultBackoffMax {
+			pm.backoff = DefaultBackoffMax
+		}
+		pm.mu.Unlock()
+		logger.Warn("agentproxy: reasonix acp exited, restarting in %s", delay)
+		time.Sleep(delay)
+
+		if pm.stopping.Load() {
+			return
+		}
+		if err := pm.startProc(); err != nil {
+			logger.Error("agentproxy: restart failed: %v", err)
+			return
+		}
+	}
+}
+
+// readStderr 持续读取 stderr 到安全缓冲，周期性 flush 到诊断日志。
+// 进程退出（pipe EOF）时做最终 flush 后返回。
+func (pm *ProcessManager) readStderr(r io.Reader) {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	lastFlush := time.Now()
+	flush := func() {
+		if s := strings.TrimSpace(pm.stderrB.String()); s != "" {
+			logger.Info("agentproxy: reasonix stderr: %s", s)
+		}
+		pm.stderrB.Reset()
+		lastFlush = time.Now()
+	}
+	for sc.Scan() {
+		pm.stderrB.Write([]byte(sc.Text() + "\n"))
+		if pm.stderrB.String() != "" && time.Since(lastFlush) >= 5*time.Second {
+			flush()
+		}
+	}
+	flush()
+}
+
+// restart 主动重启进程（配置变更 binaryPath/workDir 时调用）。
+// 不改变 stopping 语义（保持运行）。
+func (pm *ProcessManager) restart() {
+	pm.stopProc(false)
+	if err := pm.startProc(); err != nil {
+		logger.Error("agentproxy: restart failed: %v", err)
+		pm.mu.Lock()
+		pm.state = StateStopped
+		pm.mu.Unlock()
+		return
+	}
+	go pm.supervise()
+}
+
+// Alive 返回当前是否有存活进程。
+func (pm *ProcessManager) Alive() bool {
+	pm.mu.Lock()
+	waitCh := pm.waitCh
+	pm.mu.Unlock()
+	if waitCh == nil {
+		return false
+	}
+	select {
+	case <-waitCh:
+		return false
+	default:
+		return true
+	}
+}
+
+// State 返回当前生命周期状态。
+func (pm *ProcessManager) State() ProcessState {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.state
+}
+
+// Pid 返回当前进程 pid（无则 0）。
+func (pm *ProcessManager) Pid() int {
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	if pm.cmd == nil || pm.cmd.Process == nil {
+		return 0
+	}
+	return pm.cmd.Process.Pid
+}
+
+// Healthy 健康检查：进程存活 + stdin 可写 + 最近 initialize 成功。
+func (pm *ProcessManager) Healthy() bool {
+	if !pm.Alive() {
+		return false
+	}
+	if pm.initFailCnt.Load() > 0 {
+		return false
+	}
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+	return pm.stdin != nil
+}
+
+// MarkInitFailed 记录一次 initialize 失败；连续超过阈值进入 degraded 状态。
+func (pm *ProcessManager) MarkInitFailed() {
+	cnt := pm.initFailCnt.Add(1)
+	pm.mu.Lock()
+	if int(cnt) >= initFailThreshold {
+		pm.state = StateDegraded
+	}
+	pm.mu.Unlock()
+}
+
+// MarkInitOK 记录 initialize 成功（清零失败计数、恢复 running）。
+func (pm *ProcessManager) MarkInitOK() {
+	pm.initFailCnt.Store(0)
+	pm.mu.Lock()
+	pm.state = StateRunning
+	pm.mu.Unlock()
+}
+
+// StderrSnapshot 返回最近 stderr 内容（诊断用，截断尾部）。
+func (pm *ProcessManager) StderrSnapshot(max int) string {
+	s := pm.stderrB.String()
+	if max > 0 && len(s) > max {
+		return s[len(s)-max:]
+	}
+	return s
+}
+
+// WriteRequest 向进程 stdin 写一行 NDJSON（加锁防并发写行交错）。
+func (pm *ProcessManager) WriteRequest(line []byte) error {
+	pm.mu.Lock()
+	stdin := pm.stdin
+	pm.mu.Unlock()
+	if stdin == nil {
+		return fmt.Errorf("reasonix acp process not started")
+	}
+	pm.writeMu.Lock()
+	defer pm.writeMu.Unlock()
+	_, err := stdin.Write(append(line, '\n'))
+	return err
+}
+
+// ReadLine 从进程 stdout 读一行 NDJSON。进程退出返回 io.EOF。
+func (pm *ProcessManager) ReadLine() ([]byte, error) {
+	pm.mu.Lock()
+	stdout := pm.stdout
+	pm.mu.Unlock()
+	if stdout == nil {
+		return nil, io.EOF
+	}
+	line, err := stdout.ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(line, "\r\n"), nil
+}
+
+// GracefulStop 优雅关闭：SIGTERM，等待 5s，超时 Kill。会话清理由调用方负责。
+func (pm *ProcessManager) GracefulStop() {
+	pm.stopping.Store(true)
+	pm.stopProc(true)
+}
+
+// stopProc 停止当前进程并等待退出（不改变 stopping 状态，由调用方决定）。
+// graceful=true 时 SIGTERM 后等待 5s 再 Kill；false 直接 Kill。
+func (pm *ProcessManager) stopProc(graceful bool) {
+	pm.mu.Lock()
+	cmd := pm.cmd
+	waitCh := pm.waitCh
+	pm.cmd = nil
+	pm.waitCh = nil
+	pm.stdin = nil
+	pm.stdout = nil
+	if pm.state != StateStopped {
+		pm.state = StateStopped
+	}
+	pm.mu.Unlock()
+
+	if cmd == nil || cmd.Process == nil {
+		return // 无进程
+	}
+
+	if graceful {
+		// 设计文档 §3.3：SIGTERM 优雅关闭；mock/真实 reasonix 都应能处理
+		_ = cmd.Process.Signal(syscall.SIGTERM)
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+			_ = cmd.Process.Kill()
+			<-waitCh
+		}
+	} else {
+		_ = cmd.Process.Kill()
+		<-waitCh
+	}
+}
+
+// homeDir 探测 reasonix 运行主目录。
+func (pm *ProcessManager) homeDir() string {
+	if h := os.Getenv("SOPHON_REASONIX_HOME"); h != "" {
+		return h
+	}
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return h
+	}
+	return "/home/linaro"
+}
+
+// initFailThreshold 连续 initialize 失败阈值：超过进入 degraded 状态。
+const initFailThreshold = 3

--- a/source/pbmssm/mvc/agentproxy/process_test.go
+++ b/source/pbmssm/mvc/agentproxy/process_test.go
@@ -1,0 +1,246 @@
+package agentproxy
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestProcessStartInitialize 用真实 mock 脚本验证：
+// 启动进程 → onReady 回调 → client initialize 握手成功 → 进程存活。
+func TestProcessStartInitialize(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	dir := t.TempDir()
+
+	var pm *ProcessManager
+	ready := make(chan struct{}, 4)
+	pm = NewProcessManager(Config{BinaryPath: path, WorkDir: dir}, func() {
+		select {
+		case ready <- struct{}{}:
+		default:
+		}
+	})
+	// 直接启动，onReady 触发后重建 client 并 initialize
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+
+	// onReady 触发（进程已起，stdin/stdout 就绪）
+	select {
+	case <-ready:
+	case <-time.After(3 * time.Second):
+		t.Fatal("onReady not fired")
+	}
+
+	// 用真实 client 走 initialize 握手
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	res, err := client.Initialize(ctx)
+	if err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if res.ProtocolVersion != 1 {
+		t.Fatalf("protocolVersion = %d", res.ProtocolVersion)
+	}
+	if !pm.Alive() {
+		t.Fatal("process should be alive")
+	}
+}
+
+// TestProcessCrashRestart 验证进程崩溃后自动重启：
+// 用 timeout 包装脚本让 mock 进程 1s 后退出（模拟崩溃），
+// supervise 检测退出 → 退避重启 → 新进程再次就绪。
+func TestProcessCrashRestart(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	dir := t.TempDir()
+
+	// 包装脚本：timeout 1s 后杀掉 mock（模拟进程崩溃）
+	crashPath := dir + "/crash-wrapper.sh"
+	content := "#!/bin/sh\ntimeout 1 sh \"$REASONIX_MOCK_PATH\"\n"
+	if err := writeFile(crashPath, content); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("REASONIX_MOCK_PATH", path)
+
+	started := make(chan struct{}, 8)
+	pm := NewProcessManager(Config{BinaryPath: crashPath, WorkDir: dir}, func() {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+
+	// 等第一次就绪
+	waitFor(t, 3*time.Second, "first ready", func() bool { return len(started) > 0 })
+	// mock 在 1s 后崩溃；supervise 重启后再次就绪
+	waitFor(t, 8*time.Second, "restart ready", func() bool { return len(started) >= 2 })
+	if !pm.Alive() {
+		t.Fatal("process not alive after crash restart")
+	}
+}
+
+// TestProcessKillRestart 直接 kill 进程模拟崩溃，验证 supervise 自动重启。
+func TestProcessKillRestart(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	dir := t.TempDir()
+
+	started := make(chan struct{}, 8)
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: dir}, func() {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+	})
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+
+	// 等第一次就绪
+	waitFor(t, 3*time.Second, "first ready", func() bool {
+		return len(started) > 0
+	})
+	// 记第一个 pid
+	firstPid := pm.Pid()
+	if firstPid == 0 {
+		t.Fatal("no pid after start")
+	}
+
+	// kill 进程（SIGKILL，不触发 graceful 路径）
+	if err := killProcess(firstPid); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+
+	// 等待自动重启：新 pid 出现且 != 旧 pid
+	waitFor(t, 5*time.Second, "restart", func() bool {
+		pid := pm.Pid()
+		return pid != 0 && pid != firstPid
+	})
+	if !pm.Alive() {
+		t.Fatal("process not alive after restart")
+	}
+}
+
+// TestProcessGracefulStop 验证优雅关闭：stopProc 后进程退出、状态 stopped。
+func TestProcessGracefulStop(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	waitFor(t, 3*time.Second, "alive", pm.Alive)
+
+	pm.GracefulStop()
+	if pm.Alive() {
+		t.Fatal("should be stopped after GracefulStop")
+	}
+	if pm.State() != StateStopped {
+		t.Fatalf("state = %s", pm.State())
+	}
+}
+
+// TestProcessDegradedState 验证连续 initialize 失败进入 degraded 状态。
+func TestProcessDegradedState(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+
+	pm.MarkInitFailed()
+	pm.MarkInitFailed()
+	if pm.State() == StateDegraded {
+		t.Fatal("should not be degraded after 2 fails")
+	}
+	pm.MarkInitFailed()
+	if pm.State() != StateDegraded {
+		t.Fatalf("state = %s, want degraded", pm.State())
+	}
+	pm.MarkInitOK()
+	if pm.State() != StateRunning {
+		t.Fatalf("state = %s, want running", pm.State())
+	}
+}
+
+// TestModuleEndToEnd 用真实 mock 进程 + 完整 Module 验证链路：
+// start → initialize（模块自动）→ session/new → prompt 流式。
+// 需要 mock 支持 session/new 与 session/prompt。
+func TestModuleEndToEnd(t *testing.T) {
+	path := mockReasonixPath(t, promptHandler())
+	dir := t.TempDir()
+
+	events := make(chan *ACPSessionUpdate, 16)
+	m := NewModule(Config{
+		Enabled:    true,
+		BinaryPath: path,
+		WorkDir:    dir,
+	}, nil, func(ev *ACPSessionUpdate) {
+		events <- ev
+	})
+	if err := m.Start(); err != nil {
+		t.Fatalf("module start: %v", err)
+	}
+	defer m.Shutdown()
+
+	// 等 client 就绪（initialize 完成）
+	waitFor(t, 5*time.Second, "client ready", func() bool {
+		return m.Client() != nil
+	})
+	waitFor(t, 5*time.Second, "process running", func() bool {
+		return m.Process().State() == StateRunning
+	})
+
+	ctx := context.Background()
+	client := m.Client()
+	// 创建会话
+	sess, err := m.Sessions().New(ctx, client, "测试会话")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if sess.ACPSessionID == "" {
+		t.Fatal("no acp session id")
+	}
+
+	// prompt 流式
+	updates, cancel, err := client.Prompt(ctx, sess.ACPSessionID, "你好")
+	if err != nil {
+		t.Fatalf("Prompt: %v", err)
+	}
+	defer cancel()
+
+	select {
+	case ev := <-events:
+		if ev.Discriminator != "agent_message_chunk" {
+			t.Fatalf("disc = %s", ev.Discriminator)
+		}
+		if ev.Content == "" {
+			t.Fatal("empty content")
+		}
+		t.Logf("stream event: %+v", ev)
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for stream event")
+	}
+	// 等 updates 关闭（响应到达）
+	select {
+	case _, ok := <-updates:
+		if ok {
+			t.Fatal("updates should be closed")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timeout waiting for prompt response")
+	}
+
+	// 会话状态与持久化
+	if got, ok := m.Sessions().Get(sess.ID); !ok || got == nil {
+		t.Fatal("session not found after prompt")
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/session.go
+++ b/source/pbmssm/mvc/agentproxy/session.go
@@ -1,0 +1,328 @@
+package agentproxy
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/jinzhu/gorm"
+
+	"bmssm/logger"
+)
+
+// SessionManager 管理 ACP 会话 ⇄ webchat 会话模型映射与持久化。
+// 前端会话（localStorage id）在服务端有独立记录（agent_session 表）：
+//   - ID = webchat 会话 uuid（前端 localStorage 同一 id）
+//   - ACPSessionID = reasonix 侧 sessionId（session/new 返回值）
+//
+// 多会话语义对齐设计文档 §5：所有会话统一使用配置的工作区根 cwd。
+type SessionManager struct {
+	db  *gorm.DB
+	cwd string
+
+	mu       sync.Mutex
+	sessions map[string]*WebchatSession // key = webchat id
+
+	activeByACP map[string]string // acpSessionId → webchat id（会话恢复用）
+}
+
+// NewSessionManager 创建会话管理器。db 可为 nil（内存态）；cwd 为统一工作区根。
+func NewSessionManager(db *gorm.DB, cwd string) *SessionManager {
+	return &SessionManager{
+		db:          db,
+		cwd:         cwd,
+		sessions:    make(map[string]*WebchatSession),
+		activeByACP: make(map[string]string),
+	}
+}
+
+// LoadAll 启动时从 DB 加载全量会话（内存缓存重建）。
+func (sm *SessionManager) LoadAll() {
+	if sm == nil || sm.db == nil {
+		return
+	}
+	var rows []WebchatSession
+	if err := sm.db.Find(&rows).Error; err != nil {
+		logger.Warn("agentproxy: load sessions failed: %v", err)
+		return
+	}
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	for i := range rows {
+		rows[i].Messages = decodeMessages(rows[i].MessagesJSON)
+		sm.sessions[rows[i].ID] = &rows[i]
+		if rows[i].ACPSessionID != "" {
+			sm.activeByACP[rows[i].ACPSessionID] = rows[i].ID
+		}
+	}
+}
+
+// List 返回全部会话（按更新时间倒序，供前端会话列表）。
+func (sm *SessionManager) List() []WebchatSession {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	out := make([]WebchatSession, 0, len(sm.sessions))
+	for _, s := range sm.sessions {
+		out = append(out, *s)
+	}
+	// 稳定排序：updated_at 倒序
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j].UpdatedAt.After(out[j-1].UpdatedAt); j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}
+
+// Get 按 webchat id 取会话。
+func (sm *SessionManager) Get(id string) (*WebchatSession, bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	s, ok := sm.sessions[id]
+	if !ok {
+		return nil, false
+	}
+	cp := *s
+	return &cp, true
+}
+
+// New 创建新会话：先向 reasonix 申请 ACP sessionId，再落本地记录。
+func (sm *SessionManager) New(ctx context.Context, client *Client, title string) (*WebchatSession, error) {
+	acpID, err := client.NewSession(ctx, sm.cwd)
+	if err != nil {
+		return nil, fmt.Errorf("acp session/new: %w", err)
+	}
+	now := time.Now()
+	s := &WebchatSession{
+		ID:           newSessionID(),
+		ACPSessionID: acpID,
+		Title:        title,
+		Cwd:          sm.cwd,
+		Messages:     []ChatMessage{},
+		State:        SessionActive,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	sm.mu.Lock()
+	sm.sessions[s.ID] = s
+	sm.activeByACP[acpID] = s.ID
+	sm.mu.Unlock()
+	sm.persist(s)
+	return s, nil
+}
+
+// Load 加载已持久化的 ACP 会话（回放历史），返回映射后的 webchat 记录。
+// 用于「重进页面恢复会话」：先 resume（会话可 prompt），可选 load 回放。
+func (sm *SessionManager) Load(ctx context.Context, client *Client, acpID, title string) (*WebchatSession, error) {
+	// 已在本地映射？直接复用
+	if s, ok := sm.GetByACP(acpID); ok {
+		if s.State == SessionClosed {
+			if err := client.ResumeSession(ctx, acpID, sm.cwd); err != nil {
+				return nil, err
+			}
+			s.State = SessionActive
+			sm.persist(s)
+		}
+		return s, nil
+	}
+	if err := client.LoadSession(ctx, acpID, sm.cwd); err != nil {
+		return nil, fmt.Errorf("acp session/load: %w", err)
+	}
+	now := time.Now()
+	s := &WebchatSession{
+		ID:           newSessionID(),
+		ACPSessionID: acpID,
+		Title:        title,
+		Cwd:          sm.cwd,
+		Messages:     []ChatMessage{},
+		State:        SessionActive,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+	sm.mu.Lock()
+	sm.sessions[s.ID] = s
+	sm.activeByACP[acpID] = s.ID
+	sm.mu.Unlock()
+	sm.persist(s)
+	return s, nil
+}
+
+// Switch 切换会话：目标 ACP 会话已 close 则 resume；返回映射记录。
+// 会话上下文在 reasonix 侧持久化，前端切换后直接 prompt。
+func (sm *SessionManager) Switch(ctx context.Context, client *Client, webchatID string) (*WebchatSession, error) {
+	sm.mu.Lock()
+	s, ok := sm.sessions[webchatID]
+	sm.mu.Unlock()
+	if !ok {
+		return nil, fmt.Errorf("session %s not found", webchatID)
+	}
+	if s.State == SessionClosed {
+		if err := client.ResumeSession(ctx, s.ACPSessionID, sm.cwd); err != nil {
+			return nil, fmt.Errorf("acp session/resume: %w", err)
+		}
+		s.State = SessionActive
+		sm.persist(s)
+	}
+	return s, nil
+}
+
+// Close 关闭会话（ACP session/close，保留历史）。
+func (sm *SessionManager) Close(ctx context.Context, client *Client, webchatID string) error {
+	sm.mu.Lock()
+	s, ok := sm.sessions[webchatID]
+	sm.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if err := client.CloseSession(ctx, s.ACPSessionID); err != nil {
+		logger.Warn("agentproxy: acp session/close failed: %v", err)
+	}
+	s.State = SessionClosed
+	sm.persist(s)
+	return nil
+}
+
+// Delete 删除会话（ACP session/delete + 本地记录删除）。
+func (sm *SessionManager) Delete(ctx context.Context, client *Client, webchatID string) error {
+	sm.mu.Lock()
+	s, ok := sm.sessions[webchatID]
+	if ok {
+		delete(sm.sessions, webchatID)
+		delete(sm.activeByACP, s.ACPSessionID)
+	}
+	sm.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	if err := client.DeleteSession(ctx, s.ACPSessionID); err != nil {
+		logger.Warn("agentproxy: acp session/delete failed: %v", err)
+	}
+	if sm.db != nil {
+		if err := sm.db.Where("id = ?", webchatID).Delete(&WebchatSession{}).Error; err != nil {
+			logger.Warn("agentproxy: delete session row failed: %v", err)
+		}
+	}
+	return nil
+}
+
+// CloseAll 关闭全部 active 会话（优雅关闭时调用）。逐个尝试，失败不阻断。
+func (sm *SessionManager) CloseAll(ctx context.Context, client *Client) {
+	sm.mu.Lock()
+	active := make([]*WebchatSession, 0)
+	for _, s := range sm.sessions {
+		if s.State == SessionActive {
+			active = append(active, s)
+		}
+	}
+	sm.mu.Unlock()
+	for _, s := range active {
+		if err := client.CloseSession(ctx, s.ACPSessionID); err != nil {
+			logger.Warn("agentproxy: close session %s failed: %v", s.ACPSessionID, err)
+		}
+		s.State = SessionClosed
+		sm.persist(s)
+	}
+}
+
+// Restore 进程重启后恢复：对 DB 中 active 状态的会话逐个 resume（不回放）。
+// 由 onReady（initialize 成功后）调用。
+func (sm *SessionManager) Restore(ctx context.Context, client *Client) {
+	sm.mu.Lock()
+	active := make([]*WebchatSession, 0)
+	for _, s := range sm.sessions {
+		if s.State == SessionActive {
+			active = append(active, s)
+		}
+	}
+	sm.mu.Unlock()
+	for _, s := range active {
+		if err := client.ResumeSession(ctx, s.ACPSessionID, sm.cwd); err != nil {
+			logger.Warn("agentproxy: restore session %s failed: %v", s.ACPSessionID, err)
+		}
+	}
+}
+
+// GetByACP 按 ACP sessionId 查本地记录。
+func (sm *SessionManager) GetByACP(acpID string) (*WebchatSession, bool) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	wid, ok := sm.activeByACP[acpID]
+	if !ok {
+		return nil, false
+	}
+	s, ok := sm.sessions[wid]
+	if !ok {
+		return nil, false
+	}
+	cp := *s
+	return &cp, true
+}
+
+// AppendMessage 追加一条消息历史快照并持久化。
+func (sm *SessionManager) AppendMessage(webchatID string, msg ChatMessage) {
+	sm.mu.Lock()
+	s, ok := sm.sessions[webchatID]
+	if !ok {
+		sm.mu.Unlock()
+		return
+	}
+	s.Messages = append(s.Messages, msg)
+	s.UpdatedAt = time.Now()
+	sm.mu.Unlock()
+	sm.persist(s)
+}
+
+// persist 落库（失败仅告警，不阻断内存态）。
+func (sm *SessionManager) persist(s *WebchatSession) {
+	if sm.db == nil {
+		return
+	}
+	s.MessagesJSON = encodeMessages(s.Messages)
+	if err := sm.db.Save(s).Error; err != nil {
+		logger.Warn("agentproxy: persist session %s failed: %v", s.ID, err)
+	}
+}
+
+func encodeMessages(msgs []ChatMessage) string {
+	b, err := json.Marshal(msgs)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func decodeMessages(s string) []ChatMessage {
+	if s == "" {
+		return []ChatMessage{}
+	}
+	var msgs []ChatMessage
+	if err := json.Unmarshal([]byte(s), &msgs); err != nil {
+		return []ChatMessage{}
+	}
+	return msgs
+}
+
+// newSessionID 生成 webchat 会话 uuid（crypto/rand，标准库，不引入外部依赖）。
+func newSessionID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return fmt.Sprintf("%d", time.Now().UnixNano())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	dst := make([]byte, 36)
+	hex.Encode(dst[0:8], b[0:4])
+	dst[8] = '-'
+	hex.Encode(dst[9:13], b[4:6])
+	dst[13] = '-'
+	hex.Encode(dst[14:18], b[6:8])
+	dst[18] = '-'
+	hex.Encode(dst[19:23], b[8:10])
+	dst[23] = '-'
+	hex.Encode(dst[24:36], b[10:16])
+	return string(dst)
+}

--- a/source/pbmssm/mvc/agentproxy/session_test.go
+++ b/source/pbmssm/mvc/agentproxy/session_test.go
@@ -1,0 +1,227 @@
+package agentproxy
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
+)
+
+// newTestDB 创建内存 sqlite（测试专用）。
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&WebchatSession{}).Error; err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+// newTestClient 用 mock 进程创建可用 client。
+func newTestClient(t *testing.T, pm *ProcessManager) *Client {
+	t.Helper()
+	client := NewClient(pm, nil, nil)
+	t.Cleanup(client.Close)
+	return client
+}
+
+// TestSessionNewMapping 验证 New：创建 ACP 会话并映射 webchat 记录。
+func TestSessionNewMapping(t *testing.T) {
+	db := newTestDB(t)
+	path := mockReasonixPath(t, promptHandler())
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+	client := newTestClient(t, pm)
+
+	sm := NewSessionManager(db, "/home/linaro")
+	ctx := context.Background()
+	s, err := sm.New(ctx, client, "会话1")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if s.ID == "" {
+		t.Fatal("no webchat id")
+	}
+	if s.ACPSessionID == "" {
+		t.Fatal("no acp session id")
+	}
+	if s.State != SessionActive {
+		t.Fatalf("state = %s", s.State)
+	}
+
+	// 映射可查
+	if got, ok := sm.GetByACP(s.ACPSessionID); !ok || got.ID != s.ID {
+		t.Fatalf("GetByACP failed: %+v ok=%v", got, ok)
+	}
+	// 列表包含
+	if len(sm.List()) != 1 {
+		t.Fatalf("list len = %d", len(sm.List()))
+	}
+}
+
+// TestSessionPersistReload 验证持久化：写库后重新 LoadAll 可恢复。
+func TestSessionPersistReload(t *testing.T) {
+	db := newTestDB(t)
+	sm := NewSessionManager(db, "/home/linaro")
+
+	// 直接插入记录（模拟已有会话）
+	s := &WebchatSession{
+		ID:           "web-1",
+		ACPSessionID: "acp-1",
+		Title:        "已存会话",
+		Cwd:          "/home/linaro",
+		Messages:     []ChatMessage{{Role: "user", Content: "你好"}},
+		State:        SessionActive,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	sm.mu.Lock()
+	sm.sessions[s.ID] = s
+	sm.activeByACP[s.ACPSessionID] = s.ID
+	sm.mu.Unlock()
+	sm.persist(s)
+
+	// 重建 manager（模拟重启），LoadAll 恢复
+	sm2 := NewSessionManager(db, "/home/linaro")
+	sm2.LoadAll()
+	if len(sm2.List()) != 1 {
+		t.Fatalf("after reload list len = %d", len(sm2.List()))
+	}
+	got, ok := sm2.Get("web-1")
+	if !ok {
+		t.Fatal("session not found after reload")
+	}
+	if got.ACPSessionID != "acp-1" {
+		t.Fatalf("acp id = %s", got.ACPSessionID)
+	}
+	if got.State != SessionActive {
+		t.Fatalf("state = %s", got.State)
+	}
+	if len(got.Messages) != 1 || got.Messages[0].Content != "你好" {
+		t.Fatalf("messages = %+v", got.Messages)
+	}
+}
+
+// TestSessionDelete 验证删除：ACP delete + 本地记录移除。
+func TestSessionDelete(t *testing.T) {
+	db := newTestDB(t)
+	path := mockReasonixPath(t, promptHandler())
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+	client := newTestClient(t, pm)
+
+	sm := NewSessionManager(db, "/home/linaro")
+	ctx := context.Background()
+	s, _ := sm.New(ctx, client, "待删")
+	if err := sm.Delete(ctx, client, s.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := sm.Get(s.ID); ok {
+		t.Fatal("session still present after delete")
+	}
+	// 数据库行也删了
+	var count int
+	db.Model(&WebchatSession{}).Where("id = ?", s.ID).Count(&count)
+	if count != 0 {
+		t.Fatalf("db row count = %d", count)
+	}
+}
+
+// TestSessionSwitchResume 验证 Switch：closed 会话 resume 后 active。
+func TestSessionSwitchResume(t *testing.T) {
+	db := newTestDB(t)
+	path := mockReasonixPath(t, promptHandler())
+	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+	if err := pm.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	defer pm.GracefulStop()
+	client := newTestClient(t, pm)
+
+	sm := NewSessionManager(db, "/home/linaro")
+	ctx := context.Background()
+	s, _ := sm.New(ctx, client, "会话A")
+
+	// close 后 active→closed
+	if err := sm.Close(ctx, client, s.ID); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got, _ := sm.Get(s.ID); got.State != SessionClosed {
+		t.Fatalf("state after close = %s", got.State)
+	}
+
+	// switch 恢复
+	if _, err := sm.Switch(ctx, client, s.ID); err != nil {
+		t.Fatalf("Switch: %v", err)
+	}
+	if got, _ := sm.Get(s.ID); got.State != SessionActive {
+		t.Fatalf("state after switch = %s", got.State)
+	}
+}
+
+// TestSessionAppendMessage 验证消息历史追加与持久化。
+func TestSessionAppendMessage(t *testing.T) {
+	db := newTestDB(t)
+	sm := NewSessionManager(db, "/home/linaro")
+	s := &WebchatSession{
+		ID:           "web-msg",
+		ACPSessionID: "acp-msg",
+		State:        SessionActive,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+	sm.mu.Lock()
+	sm.sessions[s.ID] = s
+	sm.mu.Unlock()
+
+	sm.AppendMessage(s.ID, ChatMessage{Role: "user", Content: "问题"})
+	sm.AppendMessage(s.ID, ChatMessage{Role: "assistant", Content: "回答"})
+
+	got, _ := sm.Get(s.ID)
+	if len(got.Messages) != 2 {
+		t.Fatalf("messages len = %d", len(got.Messages))
+	}
+	// 持久化校验：重读 DB
+	var row WebchatSession
+	if err := db.Where("id = ?", s.ID).First(&row).Error; err != nil {
+		t.Fatalf("db read: %v", err)
+	}
+	var msgs []ChatMessage
+	_ = json.Unmarshal([]byte(row.MessagesJSON), &msgs)
+	if len(msgs) != 2 {
+		t.Fatalf("db messages len = %d", len(msgs))
+	}
+}
+
+// TestNewSessionID 验证 uuid 生成格式。
+func TestNewSessionID(t *testing.T) {
+	id := newSessionID()
+	if len(id) != 36 {
+		t.Fatalf("uuid len = %d: %s", len(id), id)
+	}
+	if id[14] != '4' {
+		t.Fatalf("not version 4: %s", id)
+	}
+	// 唯一性
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		got := newSessionID()
+		if seen[got] {
+			t.Fatalf("duplicate uuid %s", got)
+		}
+		seen[got] = true
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/testutil_test.go
+++ b/source/pbmssm/mvc/agentproxy/testutil_test.go
@@ -1,0 +1,226 @@
+package agentproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// mockReasonix 是一个独立的 reasonix acp 模拟器（真实子进程，NDJSON 循环）。
+// 用法：
+//
+//	path := mockReasonixPath(t, script)   // 生成 sh 脚本路径
+//	pm := NewProcessManager(Config{BinaryPath: path, WorkDir: t.TempDir()}, nil)
+//	pm.Start()
+//
+// mock script 是一个 shell 脚本，逐行读 stdin，按请求 method 响应。
+// 内建 mock 通过 REASONIX_MOCK_CRASH_AFTER 环境变量控制启动后 N 行输出后崩溃。
+func mockReasonixPath(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := dir + "/reasonix-acp-mock.sh"
+	// handle_line 必须先于主循环定义（sh 函数需在使用前定义）。
+	script := `#!/bin/sh
+# mock reasonix acp：NDJSON 循环
+trap 'exit 0' TERM INT   # 让 SIGTERM/SIGINT 能退出（sh read 循环默认不退出）
+` + buildMockHandler(body) + `
+count=0
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  count=$((count+1))
+  # 模拟崩溃：输出 N 行后退出（诊断用，经 stderr）
+  if [ -n "$REASONIX_MOCK_CRASH_AFTER" ] && [ "$count" -ge "$REASONIX_MOCK_CRASH_AFTER" ]; then
+    echo "mock crash at $count" >&2
+    exit 3
+  fi
+  handle_line "$line"
+done
+`
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write mock script: %v", err)
+	}
+	return path
+}
+
+// buildMockHandler 构造每行请求的分发逻辑（shell 函数 handle_line）。
+func buildMockHandler(body string) string {
+	return `handle_line() {
+  line="$1"
+  method=$(printf '%s' "$line" | sed -n 's/.*"method":"\([^"]*\)".*/\1/p')
+  id=$(printf '%s' "$line" | sed -n 's/.*"id":\([0-9][0-9]*\).*/\1/p')
+  case "$method" in
+    initialize)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"protocolVersion":1,"agentCapabilities":{}}}'
+      ;;
+` + body + `
+    *)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"error":{"code":-32601,"message":"Method not found"}}'
+      ;;
+  esac
+}
+`
+}
+
+// runMockReasonix 启动真实 reasonix mock 子进程并返回句柄。
+// 用于完整链路集成测试（client + process + session）。
+func runMockReasonix(t *testing.T, handler string) (*exec.Cmd, io.WriteCloser, *bufio.Scanner, string) {
+	t.Helper()
+	path := mockReasonixPath(t, handler)
+	cmd := exec.Command("sh", path)
+	stdin, _ := cmd.StdinPipe()
+	stdout, _ := cmd.StdoutPipe()
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start mock: %v", err)
+	}
+	t.Cleanup(func() { _ = cmd.Process.Kill() })
+	return cmd, stdin, bufio.NewScanner(stdout), path
+}
+
+// waitFor 轮询等待条件成立（超时返回错误）。
+func waitFor(t *testing.T, timeout time.Duration, desc string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", desc)
+}
+
+// promptHandler 构造支持 session/new、session/prompt、session/cancel 的 mock 分发体。
+// prompt 响应前先发一条 session/update（agent_message_chunk）通知，再回 stopReason。
+func promptHandler() string {
+	return `
+    session/new)
+      sid="mock-acp-session-'"$id"'"
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"sessionId":"'"$sid"'"}}'
+      ;;
+    session/prompt)
+      echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock","update":{"sessionUpdate":{"agent_message_chunk":{"messageId":"m1","content":{"text":"你好，Reasonix！"}}}}}}'
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"stopReason":"end_turn"}}'
+      ;;
+    session/cancel)
+      echo '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"mock","update":{"sessionUpdate":{"agent_message_chunk":{"messageId":"m2","content":{"text":"已取消"}}}}}}'
+      ;;
+    session/resume)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{}}'
+      ;;
+    session/load)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{}}'
+      ;;
+    session/close)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{}}'
+      ;;
+    session/delete)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{}}'
+      ;;
+`
+}
+
+// writeLine 向 stdin 写一行 NDJSON（测试辅助）。
+func writeLine(w io.WriteCloser, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(w, "%s\n", b)
+	return err
+}
+
+// readRPCLine 从 scanner 读一行并解析为 RPCResponse（测试辅助）。
+func readRPCLine(t *testing.T, sc *bufio.Scanner) (*RPCResponse, error) {
+	t.Helper()
+	if !sc.Scan() {
+		return nil, io.EOF
+	}
+	var resp RPCResponse
+	if err := json.Unmarshal(sc.Bytes(), &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// stdIOTransport 提供基于真实管道对（mock 进程）的进程传输：
+// 用 sh 管道对实现读写，满足 ProcessManager 接口语义的测试替身。
+type stdIOTransport struct {
+	pm  *ProcessManager
+	in  *os.File  // 读方向（从传输读到行）
+	out *os.File  // 写方向（向传输写行）
+}
+
+// newStdIOTransport 创建双向管道对：一端给被测 ProcessManager，
+// 另一端给测试（模拟 reasonix 进程）。
+func newStdIOTransport(t *testing.T) (*stdIOTransport, *ProcessManager) {
+	t.Helper()
+	r1, w1, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe1: %v", err)
+	}
+	r2, w2, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe2: %v", err)
+	}
+	// 被测进程：stdin=w1（写请求），stdout=r2（读响应）
+	pm := &ProcessManager{
+		stdin:  w1,
+		stdout: bufio.NewReader(r2),
+		state:  StateRunning,
+		backoff: time.Second,
+		stderrB: &safeBuffer{},
+	}
+	// 测试侧：读 r1（请求），写 w2（响应）
+	return &stdIOTransport{pm: pm, in: r1, out: w2}, pm
+}
+
+// readRequest 从测试侧读一行（被测进程发出的请求）。
+func (tr *stdIOTransport) readRequest(t *testing.T, sc *bufio.Scanner) *RPCRequest {
+	t.Helper()
+	req, err := tr.readRequestErr(sc)
+	if err != nil {
+		t.Fatalf("no request line: %v", err)
+	}
+	return req
+}
+
+// readRequestErr 从测试侧读一行，EOF 返回错误（供 goroutine 优雅退出）。
+func (tr *stdIOTransport) readRequestErr(sc *bufio.Scanner) (*RPCRequest, error) {
+	if !sc.Scan() {
+		return nil, sc.Err()
+	}
+	var req RPCRequest
+	if err := json.Unmarshal(sc.Bytes(), &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+// reply 从测试侧回一行响应。
+func (tr *stdIOTransport) reply(v any) error {
+	b, _ := json.Marshal(v)
+	_, err := fmt.Fprintf(tr.out, "%s\n", b)
+	return err
+}
+
+// contains 判断子串。
+func contains(s, sub string) bool {
+	return strings.Contains(s, sub)
+}
+
+// writeFile 写文件（测试辅助）。
+func writeFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o755)
+}
+
+// killProcess 向指定 pid 发 SIGKILL（模拟崩溃）。
+func killProcess(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}

--- a/source/pbmssm/mvc/agentproxy/types.go
+++ b/source/pbmssm/mvc/agentproxy/types.go
@@ -1,0 +1,84 @@
+// Package agentproxy 实现 bmssm 的「Reasonix ACP 适配器」核心：
+// reasonix acp 进程管理 + ACP JSON-RPC 2.0 客户端 + 会话管理。
+//
+// 只通过 `reasonix acp` 进程的 ACP v1 协议（NDJSON over stdin/stdout）交互，
+// 不修改 Reasonix 源码。WS 端点与前端适配由后续任务（MYS-168/S3）实现。
+package agentproxy
+
+import "time"
+
+// 默认值。
+const (
+	DefaultPort      = 18990
+	DefaultWorkDir   = "/home/linaro"
+	DefaultBinary    = "reasonix"
+	DefaultBackoffMax = 30 * time.Second
+)
+
+// Config agentproxy 运行配置（sqlite 单例 + viper 兜底）。
+// 字段对齐 agentproxy-design.md §7.1。
+type Config struct {
+	Enabled           bool   `json:"enabled"`
+	ListenIP          string `json:"listenIP"`
+	Port              int    `json:"port"`
+	BinaryPath        string `json:"binaryPath"`
+	WorkDir           string `json:"workDir"`
+	Model             string `json:"model"`
+	RestartBackoffMax string `json:"restartBackoffMax,omitempty"` // 人类可读；解析失败用默认
+}
+
+// ProcessState reasonix 进程生命周期状态。
+type ProcessState string
+
+const (
+	StateStopped  ProcessState = "stopped"
+	StateStarting ProcessState = "starting"
+	StateRunning  ProcessState = "running"
+	StateDegraded ProcessState = "degraded" // 连续初始化失败，仍周期性重试
+)
+
+// SessionState webchat 会话模型状态。
+type SessionState string
+
+const (
+	SessionActive SessionState = "active" // ACP 会话可被 prompt
+	SessionClosed SessionState = "closed" // 已 close，可 resume 恢复
+)
+
+// WebchatSession webchatUI 会话模型（sqlite 持久化）。
+type WebchatSession struct {
+	ID            string       `json:"id"`   // uuid 主键（前端 localStorage 同一 id）
+	ACPSessionID  string       `json:"acpSessionId"`
+	Title         string       `json:"title"`
+	Cwd           string       `json:"cwd"`
+	Messages      []ChatMessage `json:"messages,omitempty" gorm:"-"` // 历史快照（JSON 存 MessagesJSON）
+	MessagesJSON  string       `json:"-"`                            // sqlite 存储用
+	State         SessionState `json:"state"`
+	CreatedAt     time.Time    `json:"createdAt"`
+	UpdatedAt     time.Time    `json:"updatedAt"`
+}
+
+// TableName 指定表名。
+func (WebchatSession) TableName() string { return "agent_session" }
+
+// ChatMessage 会话历史消息快照（渲染用；reasonix 侧 transcript 是权威上下文）。
+type ChatMessage struct {
+	Role    string `json:"role"`    // user / assistant / thought / tool_calls
+	Content string `json:"content"` // 文本或 JSON 摘要
+	ID      string `json:"id,omitempty"`
+}
+
+// ACPSessionUpdate ACP session/update 通知的通用载荷（判别子见 Discriminator）。
+type ACPSessionUpdate struct {
+	SessionID         string            `json:"sessionId,omitempty"`
+	Discriminator     string            `json:"discriminator,omitempty"`
+	MessageID         string            `json:"messageId,omitempty"`
+	Content           string            `json:"content,omitempty"`
+	ToolCallID        string            `json:"toolCallId,omitempty"`
+	ToolCallTitle     string            `json:"toolCallTitle,omitempty"`
+	ToolCallKind      string            `json:"toolCallKind,omitempty"`
+	ToolCallStatus    string            `json:"toolCallStatus,omitempty"`
+	StopReason        string            `json:"stopReason,omitempty"`
+	Title             string            `json:"title,omitempty"`
+	Raw               map[string]any    `json:"-"`
+}


### PR DESCRIPTION
## Summary

实现 bmssm 的 Reasonix ACP 适配器核心（MYS-167 S2T2）：新增 `mvc/agentproxy/` 包，通过 `reasonix acp` 进程的 ACP v1 协议（NDJSON JSON-RPC 2.0 over stdin/stdout）交互，不修改 Reasonix 源码。

- **process.go**：os/exec 启动 reasonix acp；stdin/stdout 逐行读写（NDJSON），stderr 单独收集为诊断日志；崩溃退避自动重启（1s→30s 上限）；连续 initialize 失败（3 次）进入 degraded 状态；SIGTERM 优雅关闭（超时 5s Kill）
- **acp.go**：JSON-RPC 2.0 编解码（request/response/notification）；id 关联 + 超时；initialize 握手（读能力声明）；会话方法封装（new/load/resume/close/delete/list/prompt/cancel）；session/update 流式通知分发（agent_message_chunk / agent_thought_chunk / tool_call / tool_call_update / plan）
- **session.go**：ACP 会话 ⇄ webchat 会话模型映射（uuid、acp_session_id、标题、消息历史）；sqlite 持久化（`agent_session` 表）；多会话创建/切换/删除；进程重启后恢复 active 会话
- **module.go / init.go / migrate.go / config.go**：顶层装配（进程+客户端+会话）、模型注册、表迁移、配置读取与启动接线（bmssm.yaml `agentproxy` 段）

## Test plan

- `go test ./mvc/agentproxy/` 全部通过：
  - JSON-RPC 编解码 / 请求关联（乱序）/ 超时 / 错误映射（-32601）
  - 真实 mock 进程：启动 + initialize 握手、崩溃自动重启、SIGKILL 后重启、SIGTERM 优雅关闭、degraded 状态
  - 会话：创建映射 / sqlite 持久化重载 / 删除 / 切换恢复 / 消息历史
  - 模块端到端：`session/new` → `session/prompt` → 流式收到 `agent_message_chunk`
- `go build ./...` 与全项目 `go test ./...` 全绿，无回归

## Notes

- WS 端点与协议适配（pico 消息 ⇄ ACP）在 S3（MYS-168）接入；REST 管理接口随 S3 一起
- `agentproxy.enabled` 默认 false：reasonix 二进制部署（T5）后置 true
- 测试机暂无 reasonix 二进制，集成测试用 mock 脚本模拟 ACP NDJSON 行为