### PR TITLE
feat(bmssm): Reasonix WS 端点与协议适配（MYS-168）

### DIFF
--- a/source/pbmssm/mvc/agentproxy/acp.go
+++ b/source/pbmssm/mvc/agentproxy/acp.go
@@ -90,10 +90,12 @@ type Client struct {
 }
 
 // call 一次上行请求的等待记录。updates 仅在 Prompt 时非 nil（流式更新通道）。
+// sessionID 仅 Prompt 时非空，用于把 session/update 通知匹配到对应 prompt 的流。
 type call struct {
-	id      int64
-	resp    chan *RPCResponse
-	updates chan *ACPSessionUpdate
+	id        int64
+	sessionID string
+	resp      chan *RPCResponse
+	updates   chan *ACPSessionUpdate
 }
 
 // NewClient 创建 ACP 客户端。onEvent 收到 session/update 解析结果；
@@ -214,6 +216,7 @@ func (c *Client) Prompt(ctx context.Context, id, text string) (<-chan *ACPSessio
 	}
 	updates := make(chan *ACPSessionUpdate, 64)
 	c.mu.Lock()
+	call.sessionID = id
 	call.updates = updates
 	c.mu.Unlock()
 
@@ -385,9 +388,26 @@ func (c *Client) dispatch(line []byte) {
 		switch msg.Method {
 		case "session/update":
 			ev := parseSessionUpdate(msg.Params)
-			if ev != nil && c.onEvent != nil {
+			if ev == nil {
+				return
+			}
+			// 模块级路由（S3 Hub 按 ACP sessionId 分发到 WS 连接）
+			if c.onEvent != nil {
 				c.onEvent(ev)
 			}
+			// Prompt 的流式通道：把该会话的更新推给对应在途 prompt（驱动 typing.stop）。
+			// 无匹配 prompt（如 load 回放）时跳过。
+			c.mu.Lock()
+			for _, cl := range c.pending {
+				if cl.updates != nil && cl.sessionID != "" && cl.sessionID == ev.SessionID {
+					select {
+					case cl.updates <- ev:
+					default:
+						// 流缓冲满：丢弃（慢消费者由连接层关闭，不阻塞读循环）
+					}
+				}
+			}
+			c.mu.Unlock()
 		default:
 			if c.onNotify != nil {
 				c.onNotify(msg.Method, msg.Params)
@@ -416,6 +436,7 @@ func (c *Client) failPending(err error) {
 //
 // 判别子位于 sessionUpdate 对象首键（agent_message_chunk / agent_thought_chunk /
 // tool_call / tool_call_update / plan / user_message_chunk / usage_update / session_info_update …）。
+// sessionId 取外层（标准 ACP 载荷）；sessionUpdate 内部带 sessionId 时以内部为准。
 func parseSessionUpdate(raw json.RawMessage) *ACPSessionUpdate {
 	if len(raw) == 0 {
 		return nil
@@ -434,7 +455,11 @@ func parseSessionUpdate(raw json.RawMessage) *ACPSessionUpdate {
 		// 尝试扁平
 		return parseFlatUpdate(raw)
 	}
-	return parseFlatUpdate(outer.Update.SessionUpdate)
+	ev := parseFlatUpdate(outer.Update.SessionUpdate)
+	if ev != nil && ev.SessionID == "" {
+		ev.SessionID = outer.SessionID
+	}
+	return ev
 }
 
 // parseFlatUpdate 从 sessionUpdate 对象提取判别子与公共字段。

--- a/source/pbmssm/mvc/agentproxy/acp_test.go
+++ b/source/pbmssm/mvc/agentproxy/acp_test.go
@@ -306,14 +306,29 @@ func TestSessionPromptStream(t *testing.T) {
 		t.Fatal("timeout waiting for stream event")
 	}
 
-	// updates 通道在响应到达后关闭
+	// updates 通道：既承载流式事件，又在响应到达后关闭（for range 消费到关闭）。
 	select {
-	case _, ok := <-updates:
-		if ok {
-			t.Fatal("updates should be closed after response")
+	case ev, ok := <-updates:
+		if !ok {
+			t.Fatal("updates closed before stream event")
+		}
+		if ev.Discriminator != "agent_message_chunk" || ev.MessageID != "m1" {
+			t.Fatalf("updates event = %+v", ev)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("timeout waiting for updates close")
+		t.Fatal("timeout waiting for updates event")
+	}
+	// 继续消费直到关闭（响应到达后 close）
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case _, ok := <-updates:
+			if !ok {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timeout waiting for updates close")
+		}
 	}
 }
 

--- a/source/pbmssm/mvc/agentproxy/module.go
+++ b/source/pbmssm/mvc/agentproxy/module.go
@@ -12,19 +12,20 @@ import (
 	"bmssm/logger"
 )
 
-// Module 是 agentproxy 适配器的顶层装配：进程管理 + ACP 客户端 + 会话管理。
-// S2 交付核心链路：reasonix 进程自愈、initialize 握手、会话 new/prompt/cancel/close、
-// 流式 update 分发（事件回调给协议层，S3 转 WS 帧）。
+// Module 是 agentproxy 适配器的顶层装配：进程管理 + ACP 客户端 + 会话管理 + WS 端点。
+// S3 起包含 WS 服务（ws.go Hub）：模块事件广播 → Hub 按连接路由 → 前端协议帧。
 type Module struct {
 	cfg      Config
 	db       *gorm.DB
 	pm       *ProcessManager
 	client   *Client
 	sessions *SessionManager
+	hub      *Hub // WS 端点（S3）
 
-	mu      sync.Mutex
-	started bool
-	eventFn func(*ACPSessionUpdate) // S3 协议层注入：ACP 事件 → WS 帧
+	mu        sync.Mutex
+	started   bool
+	nextID    int64
+	listeners map[int64]func(*ACPSessionUpdate) // 流式事件监听者（Hub 注册，广播分发）
 
 	stopOnce sync.Once
 }
@@ -60,20 +61,26 @@ func Shutdown() {
 	}
 }
 
-// NewModule 创建装配模块。eventFn 为流式事件回调（可为 nil，S3 注入）。
+// NewModule 创建装配模块。eventFn 为流式事件监听者（可为 nil；多个监听者可用
+// AddEventListener 注册，WS Hub 启动时自动注册）。
 func NewModule(cfg Config, db *gorm.DB, eventFn func(*ACPSessionUpdate)) *Module {
 	cfg.Normalize()
 	m := &Module{
-		cfg:     cfg,
-		db:      db,
-		eventFn: eventFn,
+		cfg:       cfg,
+		db:        db,
+		listeners: make(map[int64]func(*ACPSessionUpdate)),
+	}
+	if eventFn != nil {
+		m.listeners[m.nextID] = eventFn
+		m.nextID++
 	}
 	m.sessions = NewSessionManager(db, cfg.WorkDir)
 	m.pm = NewProcessManager(cfg, m.onProcessReady)
+	m.hub = newHub(m, forwardKey(db))
 	return m
 }
 
-// Start 启动适配器：迁移（已由初始化调用）、加载会话、启动进程。
+// Start 启动适配器：迁移（已由初始化调用）、加载会话、启动进程、拉起 WS 服务。
 // 幂等。
 func (m *Module) Start() error {
 	m.mu.Lock()
@@ -88,6 +95,15 @@ func (m *Module) Start() error {
 		_ = ensureWorkDir(m.cfg.WorkDir)
 	}
 	m.sessions.LoadAll()
+	// WS 服务随模块启动（与 enabled 无关：WebSocket 端点始终可连接，
+	// 但 reasonix 未就绪时发送会返回错误帧）。
+	if m.hub != nil {
+		go func() {
+			if err := m.hub.Start(); err != nil {
+				logger.Error("agentproxy: ws hub start failed: %v", err)
+			}
+		}()
+	}
 	if !m.cfg.Enabled {
 		logger.Info("agentproxy: disabled, reasonix acp not started")
 		return nil
@@ -95,9 +111,12 @@ func (m *Module) Start() error {
 	return m.pm.Start()
 }
 
-// Shutdown 优雅关闭：先关闭所有活动会话，再停止进程与客户端。
+// Shutdown 优雅关闭：关闭 WS 服务与连接、所有活动会话，再停止进程与客户端。
 func (m *Module) Shutdown() {
 	m.stopOnce.Do(func() {
+		if m.hub != nil {
+			m.hub.Stop()
+		}
 		m.mu.Lock()
 		client := m.client
 		m.mu.Unlock()
@@ -133,11 +152,49 @@ func (m *Module) Process() *ProcessManager {
 	return m.pm
 }
 
-// SetEventFn 注入流式事件回调（S3 协议层调用，连接级）。
+// AddEventListener 注册流式事件监听者，返回可注销的句柄。
+// S3 Hub 启动时调用；多个监听者广播分发。
+func (m *Module) AddEventListener(fn func(*ACPSessionUpdate)) (remove func()) {
+	if fn == nil {
+		return func() {}
+	}
+	m.mu.Lock()
+	id := m.nextID
+	m.nextID++
+	m.listeners[id] = fn
+	m.mu.Unlock()
+	return func() {
+		m.mu.Lock()
+		delete(m.listeners, id)
+		m.mu.Unlock()
+	}
+}
+
+// SetEventFn 设置/清除唯一流式事件监听者（兼容旧用法；清除传 nil）。
 func (m *Module) SetEventFn(fn func(*ACPSessionUpdate)) {
 	m.mu.Lock()
-	m.eventFn = fn
+	m.listeners = make(map[int64]func(*ACPSessionUpdate))
+	if fn != nil {
+		m.listeners[m.nextID] = fn
+		m.nextID++
+	}
 	m.mu.Unlock()
+}
+
+// dispatchEvent 收到 session/update 解析结果，广播给所有监听者。
+func (m *Module) dispatchEvent(ev *ACPSessionUpdate) {
+	if ev == nil {
+		return
+	}
+	m.mu.Lock()
+	fns := make([]func(*ACPSessionUpdate), 0, len(m.listeners))
+	for _, fn := range m.listeners {
+		fns = append(fns, fn)
+	}
+	m.mu.Unlock()
+	for _, fn := range fns {
+		fn(ev)
+	}
 }
 
 // onProcessReady 每次 reasonix 进程成功启动后被回调：
@@ -173,19 +230,6 @@ func (m *Module) onProcessReady() {
 	// 恢复 active 会话
 	if m.sessions != nil {
 		m.sessions.Restore(ctx, m.client)
-	}
-}
-
-// dispatchEvent 收到 session/update 解析结果，转事件回调。
-func (m *Module) dispatchEvent(ev *ACPSessionUpdate) {
-	if ev == nil {
-		return
-	}
-	m.mu.Lock()
-	fn := m.eventFn
-	m.mu.Unlock()
-	if fn != nil {
-		fn(ev)
 	}
 }
 
@@ -225,4 +269,20 @@ func ensureWorkDir(dir string) error {
 		return err
 	}
 	return nil
+}
+
+// forwardKey 读取转发 key（WS 子协议 token.<key> 认证凭据）。
+// 复用 llm_proxy_config.forward_key（与 pico 模式完全一致，前端 PicoWS 零改动）。
+// 读失败返回空串（认证放行——对齐 MYS-171 放宽策略）。
+func forwardKey(db *gorm.DB) string {
+	if db == nil {
+		return ""
+	}
+	var cfg struct {
+		ForwardKey string `gorm:"column:forward_key"`
+	}
+	if err := db.Table("llm_proxy_config").Where("id = 1").Scan(&cfg).Error; err != nil {
+		return ""
+	}
+	return cfg.ForwardKey
 }

--- a/source/pbmssm/mvc/agentproxy/protocol.go
+++ b/source/pbmssm/mvc/agentproxy/protocol.go
@@ -1,0 +1,273 @@
+package agentproxy
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// WSFrame 一条发给 webchatUI 的 WS 帧（对齐 pico 协议，前端 web-client/js/chat.js 消费）。
+//
+// 帧结构（与 pico 一致）：
+//
+//	{ "type": "message.create", "session_id": "<webchat-id>",
+//	  "payload": { "message_id": "...", "content": "...", "kind": "text", "model_name": "..." } }
+//
+// type 取值：message.create / message.update / typing.start / typing.stop / session.create / error。
+type WSFrame struct {
+	Type      string         `json:"type"`
+	SessionID string         `json:"session_id,omitempty"`
+	Payload   map[string]any `json:"payload,omitempty"`
+}
+
+// ToolCallState tool_call / tool_call_update 的聚合状态（折叠块累积用）。
+type ToolCallState struct {
+	ID     string `json:"toolCallId"`
+	Title  string `json:"title,omitempty"`
+	Kind   string `json:"kind,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+// StreamState 连接级流式累积状态：一个 WS 连接一个实例。
+// 同一 messageId 的内容按 ACP chunk 增量累积，发送全量（前端 accumulate 前缀替换语义）。
+type StreamState struct {
+	mu        sync.Mutex
+	created   map[string]bool            // messageId / toolCallId -> 已发 message.create
+	content   map[string]string          // messageId -> 当前完整内容
+	toolCalls map[string]*ToolCallState  // toolCallId -> 聚合
+	typingOn  bool                       // 当前回合是否仍显示「输入中…」
+}
+
+// NewStreamState 创建流状态。
+func NewStreamState() *StreamState {
+	return &StreamState{
+		created:   make(map[string]bool),
+		content:   make(map[string]string),
+		toolCalls: make(map[string]*ToolCallState),
+		typingOn:  true,
+	}
+}
+
+// MessageAdapter 协议适配层：把 ACP session/update 事件映射为 webchatUI 的 WS 帧。
+// 无 I/O（不直接写 WS），连接层负责把返回的帧写入连接。
+type MessageAdapter struct {
+	state *StreamState
+	model string // message.create 的 model_name（取配置 model，空则 Reasonix）
+
+	mu      sync.Mutex
+	nextSeq int // messageId 缺失时的顺序兜底
+}
+
+// NewMessageAdapter 创建协议适配器。
+func NewMessageAdapter(model string) *MessageAdapter {
+	return &MessageAdapter{state: NewStreamState(), model: model}
+}
+
+// ResetRound 开始新回合（message.send 后）：清空累积状态、重置 typing 指示。
+// 同一连接多轮对话时每轮独立。
+func (a *MessageAdapter) ResetRound() {
+	a.mu.Lock()
+	a.state = NewStreamState()
+	a.mu.Unlock()
+}
+
+// OnSessionCreate 新建会话绑定回包：通知前端把服务端 webchat id 绑到本地会话。
+func (a *MessageAdapter) OnSessionCreate(webchatID string) []WSFrame {
+	return []WSFrame{{Type: "session.create", SessionID: webchatID}}
+}
+
+// OnPromptStart 回合开始（message.send 后）：发 typing.start。
+func (a *MessageAdapter) OnPromptStart(webchatID string) []WSFrame {
+	return []WSFrame{{Type: "typing.start", SessionID: webchatID}}
+}
+
+// OnPromptEnd 回合结束（prompt 响应 stopReason 到达）：若仍显示「输入中」则发 typing.stop。
+func (a *MessageAdapter) OnPromptEnd(webchatID string) []WSFrame {
+	a.state.mu.Lock()
+	on := a.state.typingOn
+	a.state.typingOn = false
+	a.state.mu.Unlock()
+	if on {
+		return []WSFrame{{Type: "typing.stop", SessionID: webchatID}}
+	}
+	return nil
+}
+
+// OnError 构造错误帧（前端 handleError 展示）。
+func (a *MessageAdapter) OnError(webchatID, message, code string) []WSFrame {
+	payload := map[string]any{"message": message}
+	if code != "" {
+		payload["code"] = code
+	}
+	return []WSFrame{{Type: "error", SessionID: webchatID, Payload: payload}}
+}
+
+// OnACPEvent ACP session/update 事件 → WS 帧列表。
+// 映射规则（agentproxy-design.md §6.1）：
+//   - agent_message_chunk  → message.create / message.update（kind:text）
+//   - agent_thought_chunk  → message.create / message.update（kind:thought，折叠块）
+//   - tool_call            → message.create（kind:tool_calls，折叠块）
+//   - tool_call_update     → message.update（kind:tool_calls）
+//   - plan / user_message_chunk / usage_update / session_info_update → 忽略（前端无对应组件）
+func (a *MessageAdapter) OnACPEvent(ev *ACPSessionUpdate, webchatID string) []WSFrame {
+	if ev == nil {
+		return nil
+	}
+	switch ev.Discriminator {
+	case "agent_message_chunk":
+		return a.messageChunk(ev, webchatID, "text")
+	case "agent_thought_chunk":
+		return a.messageChunk(ev, webchatID, "thought")
+	case "tool_call":
+		return a.toolCall(ev, webchatID, false)
+	case "tool_call_update":
+		return a.toolCall(ev, webchatID, true)
+	default:
+		// plan / user_message_chunk / usage_update / session_info_update 等：
+		// 前端无对应组件，记日志忽略。
+		return nil
+	}
+}
+
+// messageChunk 处理文本/思考增量 chunk：累积内容，按 messageId 决定 create 或 update。
+// 首个内容 chunk 到达时停止「输入中」指示器。
+func (a *MessageAdapter) messageChunk(ev *ACPSessionUpdate, webchatID, kind string) []WSFrame {
+	id := ev.MessageID
+	a.mu.Lock()
+	if id == "" {
+		a.nextSeq++
+		id = fmt.Sprintf("%s-%d", kind, a.nextSeq)
+	}
+	a.mu.Unlock()
+
+	a.state.mu.Lock()
+	cur := a.state.content[id] + ev.Content
+	a.state.content[id] = cur
+	already := a.state.created[id]
+	a.state.created[id] = true
+	typing := a.state.typingOn
+	a.state.typingOn = false
+	a.state.mu.Unlock()
+
+	frames := make([]WSFrame, 0, 2)
+	if typing {
+		frames = append(frames, WSFrame{Type: "typing.stop", SessionID: webchatID})
+	}
+	if !already {
+		frames = append(frames, WSFrame{
+			Type:      "message.create",
+			SessionID: webchatID,
+			Payload: map[string]any{
+				"message_id": id,
+				"content":    cur,
+				"kind":       kind,
+				"model_name": a.modelName(),
+			},
+		})
+	} else {
+		frames = append(frames, WSFrame{
+			Type:      "message.update",
+			SessionID: webchatID,
+			Payload: map[string]any{
+				"message_id": id,
+				"content":    cur,
+				"kind":       kind,
+			},
+		})
+	}
+	return frames
+}
+
+// toolCall 处理工具调用事件：折叠块按 toolCallId 累积状态。
+// tool_call 首次到达 → message.create（kind:tool_calls）；状态更新 → message.update。
+func (a *MessageAdapter) toolCall(ev *ACPSessionUpdate, webchatID string, update bool) []WSFrame {
+	id := ev.ToolCallID
+	if id == "" {
+		return nil
+	}
+	tc := &ToolCallState{ID: id, Title: ev.ToolCallTitle, Kind: ev.ToolCallKind, Status: ev.ToolCallStatus}
+
+	a.state.mu.Lock()
+	if !update {
+		// 首次 tool_call：若已存在（重复通知），按 update 处理
+		_, exists := a.state.toolCalls[id]
+		if exists {
+			update = true
+		}
+	}
+	if prev, ok := a.state.toolCalls[id]; ok {
+		if tc.Title == "" {
+			tc.Title = prev.Title
+		}
+		if tc.Kind == "" {
+			tc.Kind = prev.Kind
+		}
+		if tc.Status == "" {
+			tc.Status = prev.Status
+		}
+	}
+	a.state.toolCalls[id] = tc
+	already := a.state.created[id]
+	a.state.created[id] = true
+	typing := a.state.typingOn
+	a.state.typingOn = false
+	a.state.mu.Unlock()
+
+	frames := make([]WSFrame, 0, 2)
+	if typing {
+		frames = append(frames, WSFrame{Type: "typing.stop", SessionID: webchatID})
+	}
+	content := toolCallSummary(tc)
+	if !update && !already {
+		frames = append(frames, WSFrame{
+			Type:      "message.create",
+			SessionID: webchatID,
+			Payload: map[string]any{
+				"message_id": id,
+				"content":    content,
+				"kind":       "tool_calls",
+				"model_name": a.modelName(),
+				"tool_calls": []*ToolCallState{tc},
+			},
+		})
+	} else {
+		frames = append(frames, WSFrame{
+			Type:      "message.update",
+			SessionID: webchatID,
+			Payload: map[string]any{
+				"message_id": id,
+				"content":    content,
+				"kind":       "tool_calls",
+			},
+		})
+	}
+	return frames
+}
+
+// modelName 返回 message.create 的 model_name。
+func (a *MessageAdapter) modelName() string {
+	if strings.TrimSpace(a.model) != "" {
+		return a.model
+	}
+	return "Reasonix"
+}
+
+// toolCallSummary 生成工具折叠块的文本摘要（前端 collapse body 直接渲染）。
+func toolCallSummary(tc *ToolCallState) string {
+	parts := make([]string, 0, 3)
+	if tc.Title != "" {
+		parts = append(parts, tc.Title)
+	} else if tc.ID != "" {
+		parts = append(parts, tc.ID)
+	}
+	if tc.Kind != "" {
+		parts = append(parts, tc.Kind)
+	}
+	if tc.Status != "" {
+		parts = append(parts, tc.Status)
+	}
+	if len(parts) == 0 {
+		return tc.ID
+	}
+	return strings.Join(parts, " · ")
+}

--- a/source/pbmssm/mvc/agentproxy/protocol_test.go
+++ b/source/pbmssm/mvc/agentproxy/protocol_test.go
@@ -1,0 +1,207 @@
+package agentproxy
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// collectFrames 把 OnACPEvent 输出拼成字符串（测试断言用）。
+func collectFrames(frames []WSFrame) []map[string]any {
+	out := make([]map[string]any, 0, len(frames))
+	for _, f := range frames {
+		m := map[string]any{"type": f.Type, "session_id": f.SessionID, "payload": f.Payload}
+		out = append(out, m)
+	}
+	return out
+}
+
+func payloadOf(t *testing.T, frames []WSFrame, wantType string) map[string]any {
+	t.Helper()
+	for _, f := range frames {
+		if f.Type == wantType {
+			return f.Payload
+		}
+	}
+	t.Fatalf("no %s frame in %v", wantType, frames)
+	return nil
+}
+
+func TestMessageChunkCreateThenUpdate(t *testing.T) {
+	a := NewMessageAdapter("test-model")
+
+	// 首个 chunk → message.create（带 typing.stop，因 typingOn 初始 true）
+	ev1 := &ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "m1", Content: "你好"}
+	f1 := a.OnACPEvent(ev1, "ws1")
+	if len(f1) != 2 {
+		t.Fatalf("first chunk frames = %d, want 2 (typing.stop + create)", len(f1))
+	}
+	if f1[0].Type != "typing.stop" {
+		t.Errorf("f1[0].type = %s, want typing.stop", f1[0].Type)
+	}
+	if f1[1].Type != "message.create" {
+		t.Fatalf("f1[1].type = %s, want message.create", f1[1].Type)
+	}
+	p := f1[1].Payload
+	if p["message_id"] != "m1" {
+		t.Errorf("message_id = %v, want m1", p["message_id"])
+	}
+	if p["content"] != "你好" {
+		t.Errorf("content = %v, want 你好", p["content"])
+	}
+	if p["kind"] != "text" {
+		t.Errorf("kind = %v, want text", p["kind"])
+	}
+	if p["model_name"] != "test-model" {
+		t.Errorf("model_name = %v, want test-model", p["model_name"])
+	}
+	if f1[1].SessionID != "ws1" {
+		t.Errorf("session_id = %s, want ws1", f1[1].SessionID)
+	}
+
+	// 后续 chunk → message.update（增量累积）
+	ev2 := &ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "m1", Content: "，Reasonix！"}
+	f2 := a.OnACPEvent(ev2, "ws1")
+	if len(f2) != 1 || f2[0].Type != "message.update" {
+		t.Fatalf("second chunk frames = %v, want single message.update", collectFrames(f2))
+	}
+	if f2[0].Payload["content"] != "你好，Reasonix！" {
+		t.Errorf("accumulated content = %v, want 你好，Reasonix！", f2[0].Payload["content"])
+	}
+}
+
+func TestThoughtChunkMapsToCollapse(t *testing.T) {
+	a := NewMessageAdapter("")
+
+	ev := &ACPSessionUpdate{Discriminator: "agent_thought_chunk", MessageID: "t1", Content: "思考中"}
+	f := a.OnACPEvent(ev, "ws1")
+	create := payloadOf(t, f, "message.create")
+	if create["kind"] != "thought" {
+		t.Errorf("kind = %v, want thought", create["kind"])
+	}
+	// model 为空时回退 Reasonix
+	if create["model_name"] != "Reasonix" {
+		t.Errorf("model_name = %v, want Reasonix", create["model_name"])
+	}
+
+	// thought 增量 → update
+	ev2 := &ACPSessionUpdate{Discriminator: "agent_thought_chunk", MessageID: "t1", Content: "继续"}
+	f2 := a.OnACPEvent(ev2, "ws1")
+	up := payloadOf(t, f2, "message.update")
+	if up["kind"] != "thought" {
+		t.Errorf("update kind = %v, want thought", up["kind"])
+	}
+	if up["content"] != "思考中继续" {
+		t.Errorf("update content = %v, want 思考中继续", up["content"])
+	}
+}
+
+func TestToolCallCreateAndUpdate(t *testing.T) {
+	a := NewMessageAdapter("test-model")
+
+	// tool_call → message.create kind:tool_calls + tool_calls 数组
+	ev1 := &ACPSessionUpdate{Discriminator: "tool_call", ToolCallID: "tc1", ToolCallTitle: "grep", ToolCallKind: "bash", ToolCallStatus: "pending"}
+	f1 := a.OnACPEvent(ev1, "ws1")
+	create := payloadOf(t, f1, "message.create")
+	if create["kind"] != "tool_calls" {
+		t.Errorf("kind = %v, want tool_calls", create["kind"])
+	}
+	if create["message_id"] != "tc1" {
+		t.Errorf("message_id = %v, want tc1", create["message_id"])
+	}
+	tcs, ok := create["tool_calls"].([]*ToolCallState)
+	if !ok || len(tcs) != 1 || tcs[0].ID != "tc1" {
+		t.Errorf("tool_calls = %v, want [{ID:tc1}]", create["tool_calls"])
+	}
+
+	// tool_call_update → message.update
+	ev2 := &ACPSessionUpdate{Discriminator: "tool_call_update", ToolCallID: "tc1", ToolCallStatus: "completed"}
+	f2 := a.OnACPEvent(ev2, "ws1")
+	up := payloadOf(t, f2, "message.update")
+	if up["kind"] != "tool_calls" {
+		t.Errorf("update kind = %v, want tool_calls", up["kind"])
+	}
+}
+
+func TestUnknownEventIgnored(t *testing.T) {
+	a := NewMessageAdapter("")
+	cases := []*ACPSessionUpdate{
+		{Discriminator: "plan"},
+		{Discriminator: "user_message_chunk", MessageID: "u1", Content: "用户"},
+		{Discriminator: "usage_update"},
+		{Discriminator: "session_info_update", Title: "新标题"},
+	}
+	for _, ev := range cases {
+		if frames := a.OnACPEvent(ev, "ws1"); len(frames) != 0 {
+			t.Errorf("discriminator %s produced frames %v, want none", ev.Discriminator, collectFrames(frames))
+		}
+	}
+}
+
+func TestOnPromptStartEnd(t *testing.T) {
+	a := NewMessageAdapter("")
+
+	f1 := a.OnPromptStart("ws1")
+	if len(f1) != 1 || f1[0].Type != "typing.start" {
+		t.Fatalf("prompt start = %v, want typing.start", collectFrames(f1))
+	}
+
+	// 无内容时 prompt end → typing.stop（因为 typingOn 仍 true）
+	f2 := a.OnPromptEnd("ws1")
+	if len(f2) != 1 || f2[0].Type != "typing.stop" {
+		t.Fatalf("prompt end = %v, want typing.stop", collectFrames(f2))
+	}
+
+	// 第二次 end → 无帧
+	if f3 := a.OnPromptEnd("ws1"); len(f3) != 0 {
+		t.Errorf("second prompt end = %v, want none", collectFrames(f3))
+	}
+}
+
+func TestOnError(t *testing.T) {
+	a := NewMessageAdapter("")
+	f := a.OnError("ws1", "出错了", "ERR1")
+	if len(f) != 1 || f[0].Type != "error" {
+		t.Fatalf("error frames = %v", collectFrames(f))
+	}
+	if f[0].Payload["message"] != "出错了" || f[0].Payload["code"] != "ERR1" {
+		t.Errorf("error payload = %v", f[0].Payload)
+	}
+}
+
+func TestMessageMissingIDGetsSequence(t *testing.T) {
+	a := NewMessageAdapter("")
+	ev := &ACPSessionUpdate{Discriminator: "agent_message_chunk", Content: "无 id"}
+	f := a.OnACPEvent(ev, "ws1")
+	create := payloadOf(t, f, "message.create")
+	id, ok := create["message_id"].(string)
+	if !ok || id == "" {
+		t.Errorf("message_id missing: %v", create["message_id"])
+	}
+}
+
+func TestFrameSerialization(t *testing.T) {
+	// 验证 WSFrame 序列化为前端可消费的 JSON（字段名对齐 pico 协议）
+	a := NewMessageAdapter("m1")
+	ev := &ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "m1", Content: "hi"}
+	frames := a.OnACPEvent(ev, "ws-abc")
+	if len(frames) == 0 {
+		t.Fatal("no frames")
+	}
+	b, err := json.Marshal(frames[len(frames)-1])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["type"] != "message.create" {
+		t.Errorf("json type = %v", m["type"])
+	}
+	if m["session_id"] != "ws-abc" {
+		t.Errorf("json session_id = %v", m["session_id"])
+	}
+	if _, ok := m["payload"]; !ok {
+		t.Errorf("json payload missing")
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -1,0 +1,565 @@
+package agentproxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"bmssm/logger"
+)
+
+// wsPath WebSocket 端点路径（对齐设计文档 §6.3）。
+const wsPath = "/agent/ws"
+
+// wsIdleTimeout 连接 30 分钟无任何消息即关闭。
+const wsIdleTimeout = 30 * time.Minute
+
+// wsPingInterval 心跳间隔。
+const wsPingInterval = 30 * time.Second
+
+// clientFrame 客户端（webchatUI）发来的 WS 帧。
+// 与 pico 协议对齐：message.send / session.switch / session.delete / session.cancel / session.new。
+type clientFrame struct {
+	Type      string         `json:"type"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	SessionID string         `json:"session_id,omitempty"` // 顶层（兼容 ws.js）
+}
+
+// clientMessage 从 message.send payload 提取的内容。
+type clientMessage struct {
+	Content string `json:"content,omitempty"`
+}
+
+// conn 一条 WS 连接：绑定一个 webchat 会话模型，独立流式累积。
+//
+// 锁约定（避免死锁）：
+//   - Hub.mu 保护 conns/byACP 索引；Hub.HandleEvent 持 hub.mu 调 c.enqueue（c.mu）。
+//   - 锁顺序：hub.mu 先于 c.mu。close() 不持 c.mu 同时拿 hub.mu（先关 done，再清理）。
+//   - c.mu 保护 session/adapter/promptCancel。handleFrame 持 c.mu 处理各 handle*，
+//     内部不再重复加锁。
+type conn struct {
+	ws       *websocket.Conn
+	writeMu  sync.Mutex // gorilla 不允许并发写
+	send     chan []WSFrame
+	done     chan struct{}
+	closeOnce sync.Once
+	addr     string
+
+	hub    *Hub
+	module *Module
+
+	mu           sync.Mutex
+	session      *WebchatSession
+	adapter      *MessageAdapter
+	promptCancel func() error // 进行中的 prompt 取消函数
+	roundToken   int64        // 当前回合标记（递增，防旧回合覆盖新回合状态）
+}
+
+// Hub 管理全部 WS 连接，并把模块级 ACP 事件路由到对应连接。
+//
+// 事件路由：Module.dispatchEvent（ACP session/update 解析结果）→ Hub.HandleEvent(ev)。
+// 事件带 ACP sessionId；Hub 维护 acpSessionID → conn 索引，精确投递。
+type Hub struct {
+	module *Module
+	key    string // 转发 key（子协议 token.<key> 认证；空 = 放行）
+
+	mu       sync.Mutex
+	conns    map[*conn]bool
+	byACP    map[string]*conn // acpSessionID -> conn
+	started  bool
+	srv      *http.Server // WS http.Server（listen 持有，Stop 关闭）
+	unlisten func()       // 模块事件监听注销句柄（Start 注册，Stop 调用）
+}
+
+// newHub 创建 Hub。key 为转发 key（对齐 llm_proxy_config.forward_key）。
+func newHub(module *Module, key string) *Hub {
+	return &Hub{
+		module: module,
+		key:    key,
+		conns:  make(map[*conn]bool),
+		byACP:  make(map[string]*conn),
+	}
+}
+
+// Start 启动 Hub：注册模块事件监听、启动独立 WS HTTP server。
+func (h *Hub) Start() error {
+	h.mu.Lock()
+	if h.started {
+		h.mu.Unlock()
+		return nil
+	}
+	h.started = true
+	h.unlisten = h.module.AddEventListener(h.HandleEvent)
+	h.mu.Unlock()
+
+	return h.listen()
+}
+
+// listen 启动独立 http.Server 监听 agentproxy.listenIP:port。
+// ListenAndServe 是阻塞调用，放在模块 goroutine 里；进程生命周期随模块。
+func (h *Hub) listen() error {
+	cfg := h.module.cfg
+	mux := http.NewServeMux()
+	mux.HandleFunc(wsPath, h.serveWS)
+
+	addr := net.JoinHostPort(cfg.ListenIP, strconv.Itoa(cfg.Port))
+	srv := &http.Server{
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 30 * time.Second,
+	}
+	logger.Info("agentproxy: ws server listening on %s", addr)
+	// 持有引用供 Stop 关闭（加锁写，避免与 Stop 读竞态）。
+	h.mu.Lock()
+	h.srv = srv
+	h.mu.Unlock()
+
+	// 阻塞直到 server 关闭；关闭由 Stop 触发。
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Error("agentproxy: ws server failed: %v", err)
+		h.mu.Lock()
+		if h.srv == srv {
+			h.srv = nil
+		}
+		h.mu.Unlock()
+		return err
+	}
+	return nil
+}
+
+// Stop 关闭 Hub：注销事件监听、关闭 WS server、关闭全部连接。
+func (h *Hub) Stop() {
+	h.mu.Lock()
+	if !h.started {
+		h.mu.Unlock()
+		return
+	}
+	h.started = false
+	if h.unlisten != nil {
+		h.unlisten()
+		h.unlisten = nil
+	}
+	srv := h.srv
+	h.srv = nil
+	conns := make([]*conn, 0, len(h.conns))
+	for c := range h.conns {
+		conns = append(conns, c)
+	}
+	h.conns = make(map[*conn]bool)
+	h.byACP = make(map[string]*conn)
+	h.mu.Unlock()
+
+	if srv != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		_ = srv.Shutdown(ctx)
+		cancel()
+	}
+	for _, c := range conns {
+		c.close()
+	}
+}
+
+// HandleEvent 模块事件回调：把 ACP 事件路由到绑定该 ACP 会话的连接。
+// 由 Module.dispatchEvent 在模块 goroutine 调用。
+func (h *Hub) HandleEvent(ev *ACPSessionUpdate) {
+	if ev == nil {
+		return
+	}
+	h.mu.Lock()
+	c := h.byACP[ev.SessionID]
+	h.mu.Unlock()
+	if c == nil {
+		// 事件先于绑定或已断线：忽略（多连接各管各的会话）
+		return
+	}
+	c.enqueue(ev)
+}
+
+// serveWS WebSocket 升级 + 子协议认证 + 连接生命周期。
+func (h *Hub) serveWS(w http.ResponseWriter, r *http.Request) {
+	if !h.authSubprotocol(r) {
+		logger.Warn("agentproxy: ws auth failed from %s", r.RemoteAddr)
+		http.Error(w, "unauthorized", http.StatusForbidden)
+		return
+	}
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  4096,
+		WriteBufferSize: 4096,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+	wsConn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return
+	}
+	c := &conn{
+		ws:      wsConn,
+		send:    make(chan []WSFrame, 128),
+		done:    make(chan struct{}),
+		addr:    r.RemoteAddr,
+		hub:     h,
+		module:  h.module,
+		adapter: NewMessageAdapter(h.module.cfg.Model),
+	}
+	h.mu.Lock()
+	h.conns[c] = true
+	h.mu.Unlock()
+
+	logger.Info("agentproxy: ws connected from %s", c.addr)
+	go c.writeLoop()
+	c.readLoop()
+}
+
+// authSubprotocol 校验客户端子协议 token.<key> 与配置转发 key 一致。
+// key 未配置（空）时放行（MYS-171 放宽策略对齐：本地回环适配器暴露面可控）。
+func (h *Hub) authSubprotocol(r *http.Request) bool {
+	if h.key == "" {
+		return true
+	}
+	protos := r.Header.Values("Sec-WebSocket-Protocol")
+	for _, p := range protos {
+		for _, proto := range strings.Split(p, ",") {
+			proto = strings.TrimSpace(proto)
+			if strings.HasPrefix(proto, "token.") &&
+				strings.TrimPrefix(proto, "token.") == h.key {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// enqueue 把 ACP 事件映射的帧投递给连接（异步）。
+func (c *conn) enqueue(ev *ACPSessionUpdate) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.session == nil {
+		return
+	}
+	frames := c.adapter.OnACPEvent(ev, c.session.ID)
+	if len(frames) == 0 {
+		return
+	}
+	select {
+	case c.send <- frames:
+	case <-c.done:
+	default:
+		// 发送缓冲满：慢消费者，关闭连接防内存膨胀
+		logger.Warn("agentproxy: ws send buffer full, closing %s", c.addr)
+		go c.close()
+	}
+}
+
+// readLoop 主循环：读客户端帧，按类型处理；含心跳与空闲超时。
+func (c *conn) readLoop() {
+	defer c.close()
+
+	// 心跳：定期 ping
+	ticker := time.NewTicker(wsPingInterval)
+	defer ticker.Stop()
+	go func() {
+		for {
+			select {
+			case <-ticker.C:
+				_ = c.writePing()
+			case <-c.done:
+				return
+			}
+		}
+	}()
+
+	_ = c.ws.SetReadDeadline(time.Now().Add(wsIdleTimeout))
+	c.ws.SetPongHandler(func(string) error {
+		return c.ws.SetReadDeadline(time.Now().Add(wsIdleTimeout))
+	})
+	c.ws.SetPingHandler(func(string) error {
+		return c.ws.SetReadDeadline(time.Now().Add(wsIdleTimeout))
+	})
+
+	for {
+		msgType, data, err := c.ws.ReadMessage()
+		if err != nil {
+			return
+		}
+		if msgType != websocket.TextMessage {
+			continue
+		}
+		var frame clientFrame
+		if err := json.Unmarshal(data, &frame); err != nil {
+			logger.Warn("agentproxy: invalid ws frame from %s: %v", c.addr, err)
+			continue
+		}
+		if frame.Type == "" {
+			continue
+		}
+		c.handleFrame(frame)
+	}
+}
+
+// handleFrame 处理一条客户端帧（持 c.mu）。
+func (c *conn) handleFrame(frame clientFrame) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	switch frame.Type {
+	case "message.send":
+		c.handleMessageSendLocked(frame)
+	case "session.switch":
+		c.handleSessionSwitchLocked(frame)
+	case "session.delete":
+		c.handleSessionDeleteLocked(frame)
+	case "session.cancel":
+		c.handleSessionCancelLocked()
+	case "session.new":
+		c.handleSessionNewLocked()
+	default:
+		logger.Warn("agentproxy: unknown ws frame type %s from %s", frame.Type, c.addr)
+	}
+}
+
+// handleMessageSendLocked message.send：新建/复用会话 → prompt。
+// 前置：持 c.mu。
+func (c *conn) handleMessageSendLocked(frame clientFrame) {
+	var msg clientMessage
+	if b, err := json.Marshal(frame.Payload); err == nil {
+		_ = json.Unmarshal(b, &msg)
+	}
+	content := strings.TrimSpace(msg.Content)
+	if content == "" {
+		return
+	}
+	if c.session == nil {
+		if err := c.ensureSessionLocked(); err != nil {
+			c.enqueueErrorLocked("无法创建会话："+err.Error(), "session_new")
+			return
+		}
+	} else {
+		c.adapter.ResetRound()
+	}
+	if err := c.promptLocked(content); err != nil {
+		c.enqueueErrorLocked("发送失败："+err.Error(), "prompt")
+	}
+}
+
+// ensureSessionLocked 确保连接已绑定 webchat 会话（首次发送时自动创建）。
+// 前置：持 c.mu。
+func (c *conn) ensureSessionLocked() error {
+	if c.session != nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	client := c.module.Client()
+	if client == nil {
+		return fmt.Errorf("reasonix 未就绪")
+	}
+	s, err := c.module.Sessions().New(ctx, client, "新会话")
+	if err != nil {
+		return err
+	}
+	c.bindSessionLocked(s)
+	// 绑定 ACP sessionId → 本连接，事件路由生效
+	c.hub.mu.Lock()
+	c.hub.byACP[s.ACPSessionID] = c
+	c.hub.mu.Unlock()
+	return nil
+}
+
+// bindSessionLocked 绑定会话并通知前端。前置：持 c.mu。
+func (c *conn) bindSessionLocked(s *WebchatSession) {
+	c.session = s
+	select {
+	case c.send <- c.adapter.OnSessionCreate(s.ID):
+	case <-c.done:
+	}
+}
+
+// promptLocked 发起 session/prompt。前置：持 c.mu。
+// 用一个自增 roundToken 标记当前回合：等待更新流关闭的 goroutine 仅当自己仍是
+// 最新回合时清理 promptCancel 并发送 typing.stop（避免旧回合覆盖新回合状态）。
+func (c *conn) promptLocked(content string) error {
+	// 在途回合：先取消旧的
+	if c.promptCancel != nil {
+		_ = c.promptCancel()
+	}
+
+	s := c.session
+	if s == nil {
+		return fmt.Errorf("no session")
+	}
+	updates, cancel, err := c.module.Client().Prompt(context.Background(), s.ACPSessionID, content)
+	if err != nil {
+		return err
+	}
+	c.promptCancel = cancel
+	c.roundToken++
+	token := c.roundToken
+	c.adapter.ResetRound()
+
+	// typing.start + 用户消息历史快照
+	select {
+	case c.send <- c.adapter.OnPromptStart(s.ID):
+	case <-c.done:
+		return nil
+	}
+	c.module.Sessions().AppendMessage(s.ID, ChatMessage{Role: "user", Content: content})
+
+	go func(acpID string, tok int64) {
+		// 等待更新流关闭（prompt 响应 stopReason 到达）
+		for range updates {
+		}
+		c.mu.Lock()
+		if c.roundToken == tok {
+			c.promptCancel = nil
+			if c.session != nil && c.session.ACPSessionID == acpID {
+				select {
+				case c.send <- c.adapter.OnPromptEnd(c.session.ID):
+				case <-c.done:
+				}
+			}
+		}
+		c.mu.Unlock()
+	}(s.ACPSessionID, token)
+	return nil
+}
+
+// handleSessionNewLocked 显式新建会话（前端「+ 新对话」）。前置：持 c.mu。
+func (c *conn) handleSessionNewLocked() {
+	if err := c.ensureSessionLocked(); err != nil {
+		c.enqueueErrorLocked("无法创建会话："+err.Error(), "session_new")
+	}
+}
+
+// handleSessionSwitchLocked 切换会话。前置：持 c.mu。
+// 前端切换会话已重开连接（协议约束：会话绑定连接生命周期），本连接只绑定当前会话。
+func (c *conn) handleSessionSwitchLocked(frame clientFrame) {
+	sid := frame.SessionID
+	if sid == "" {
+		if p, ok := frame.Payload["session_id"].(string); ok {
+			sid = p
+		}
+	}
+	if sid == "" {
+		return
+	}
+	if _, ok := c.module.Sessions().Get(sid); !ok {
+		c.enqueueErrorLocked("会话不存在", "session_not_found")
+		return
+	}
+	c.enqueueErrorLocked("切换会话需重新连接", "switch_reconnect")
+}
+
+// handleSessionDeleteLocked 删除会话。前置：持 c.mu。
+// 前端当前不发该帧（switch/delete 为本地操作 + 重连），保留协议兼容：
+// 若删除的是本连接绑定的会话，同步解绑事件路由。
+func (c *conn) handleSessionDeleteLocked(frame clientFrame) {
+	sid := frame.SessionID
+	if sid == "" {
+		if p, ok := frame.Payload["session_id"].(string); ok {
+			sid = p
+		}
+	}
+	if sid == "" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	if err := c.module.Sessions().Delete(ctx, c.module.Client(), sid); err != nil {
+		logger.Warn("agentproxy: delete session %s failed: %v", sid, err)
+	}
+	if c.session != nil && c.session.ID == sid {
+		acpID := c.session.ACPSessionID
+		c.hub.mu.Lock()
+		if c.hub.byACP[acpID] == c {
+			delete(c.hub.byACP, acpID)
+		}
+		c.hub.mu.Unlock()
+		c.session = nil
+	}
+}
+
+// handleSessionCancelLocked 取消当前回合。前置：持 c.mu。
+func (c *conn) handleSessionCancelLocked() {
+	if c.promptCancel != nil {
+		_ = c.promptCancel()
+	}
+}
+
+// enqueueErrorLocked 发送错误帧。前置：持 c.mu。
+func (c *conn) enqueueErrorLocked(message, code string) {
+	f := WSFrame{Type: "error", Payload: map[string]any{"message": message, "code": code}}
+	if c.session != nil {
+		f.SessionID = c.session.ID
+	}
+	select {
+	case c.send <- []WSFrame{f}:
+	case <-c.done:
+	}
+}
+
+// writeLoop 串行写下行帧（gorilla 不允许并发写）。
+func (c *conn) writeLoop() {
+	for {
+		select {
+		case frames := <-c.send:
+			for _, f := range frames {
+				if err := c.writeJSON(f); err != nil {
+					c.close()
+					return
+				}
+			}
+		case <-c.done:
+			return
+		}
+	}
+}
+
+func (c *conn) writeJSON(v any) error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	return c.ws.WriteJSON(v)
+}
+
+func (c *conn) writePing() error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	_ = c.ws.SetWriteDeadline(time.Now().Add(10 * time.Second))
+	return c.ws.WriteMessage(websocket.PingMessage, nil)
+}
+
+// close 关闭连接并清理绑定。
+// 锁顺序：先 close(done)（触发 writeLoop/心跳 goroutine 退出），
+// 再 c.mu 清理本地状态（不碰 hub），最后 hub.mu 解绑——避免 c.mu→hub.mu 与
+// HandleEvent 的 hub.mu→c.mu 成环。
+func (c *conn) close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+
+		c.mu.Lock()
+		s := c.session
+		if c.promptCancel != nil {
+			_ = c.promptCancel()
+			c.promptCancel = nil
+		}
+		c.session = nil
+		c.mu.Unlock()
+
+		c.hub.mu.Lock()
+		if s != nil && c.hub.byACP[s.ACPSessionID] == c {
+			delete(c.hub.byACP, s.ACPSessionID)
+		}
+		delete(c.hub.conns, c)
+		c.hub.mu.Unlock()
+
+		_ = c.ws.Close()
+		logger.Info("agentproxy: ws closed from %s", c.addr)
+	})
+}

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -1,0 +1,459 @@
+package agentproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// startTestHub 启动一个测试 Hub（不绑定固定端口，用 httptest 服务器暴露）。
+// 返回 Hub、服务器 URL 与转发 key。
+func startTestHub(t *testing.T, module *Module, key string) *Hub {
+	t.Helper()
+	h := newHub(module, key)
+	// 手动注册事件回调（Start 里也会做；测试直接复用 serveWS）
+	module.SetEventFn(h.HandleEvent)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(wsPath, h.serveWS)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	t.Cleanup(func() { h.Stop() })
+
+	t.Cleanup(func() {
+		// 恢复模块事件回调，避免影响其他测试
+		module.SetEventFn(nil)
+	})
+	return h
+}
+
+// wsURL 把 httptest http URL 转为 ws URL。
+func wsURL(u string) string {
+	return "ws" + strings.TrimPrefix(u, "http")
+}
+
+// dialWS 建立测试 WS 连接（带可选子协议）。
+func dialWS(t *testing.T, url, subproto string) *websocket.Conn {
+	t.Helper()
+	d := websocket.Dialer{}
+	if subproto != "" {
+		d.Subprotocols = []string{subproto}
+	}
+	conn, resp, err := d.Dial(url, nil)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("dial %s: %v (status %d)", url, err, resp.StatusCode)
+		}
+		t.Fatalf("dial %s: %v", url, err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return conn
+}
+
+// readFrame 读一条 WS 帧并解析为 map。
+func readFrame(t *testing.T, conn *websocket.Conn) map[string]any {
+	t.Helper()
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("read frame: %v", err)
+	}
+	var m map[string]any
+	if err := jsonUnmarshal(data, &m); err != nil {
+		t.Fatalf("parse frame %s: %v", string(data), err)
+	}
+	return m
+}
+
+func jsonUnmarshal(b []byte, v any) error {
+	return json.Unmarshal(b, v)
+}
+
+func bufioNewScanner(r io.Reader) *bufio.Scanner {
+	return bufio.NewScanner(r)
+}
+
+func TestWSAuthSubprotocol(t *testing.T) {
+	mod := NewModule(DefaultConfig(), nil, nil)
+	h := newHub(mod, "secret-key-123")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	// 正确子协议 → 升级成功
+	d := websocket.Dialer{Subprotocols: []string{"token.secret-key-123"}}
+	conn, resp, err := d.Dial(wsURL(srv.URL)+wsPath, nil)
+	if err != nil {
+		t.Fatalf("valid subproto dial failed: %v", err)
+	}
+	conn.Close()
+	_ = resp
+
+	// 错误子协议 → 403（无升级）
+	d2 := websocket.Dialer{Subprotocols: []string{"token.wrong"}}
+	_, resp2, err := d2.Dial(wsURL(srv.URL)+wsPath, nil)
+	if err == nil {
+		t.Fatal("wrong subproto should fail")
+	}
+	if resp2 == nil || resp2.StatusCode != http.StatusForbidden {
+		t.Fatalf("wrong subproto status = %v, want 403", resp2)
+	}
+
+	// 无子协议 → 403
+	d3 := websocket.Dialer{}
+	_, resp3, err := d3.Dial(wsURL(srv.URL)+wsPath, nil)
+	if err == nil {
+		t.Fatal("no subproto should fail")
+	}
+	if resp3 == nil || resp3.StatusCode != http.StatusForbidden {
+		t.Fatalf("no subproto status = %v, want 403", resp3)
+	}
+}
+
+func TestWSAuthEmptyKeyAllowsAll(t *testing.T) {
+	// key 为空 → 认证放行
+	mod := NewModule(DefaultConfig(), nil, nil)
+	h := newHub(mod, "")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(srv.URL)+wsPath, nil)
+	if err != nil {
+		t.Fatalf("empty key dial failed: %v", err)
+	}
+	conn.Close()
+}
+
+// mockModuleForWS 构造一个带 ACP client 的模块（Client() 可交互）。
+// client 的事件回调链到模块 dispatchEvent（与真实装配一致），
+// Hub 通过 SetEventFn 注入后事件可路由到连接。
+func mockModuleForWS(t *testing.T) (*Module, *stdIOTransport) {
+	t.Helper()
+	tr, pm := newStdIOTransport(t)
+	mod := &Module{
+		cfg:      Config{Enabled: true, Model: "test-model", Port: DefaultPort},
+		sessions: NewSessionManager(nil, t.TempDir()),
+		pm:       pm,
+		hub:      nil,
+	}
+	client := NewClient(pm, mod.dispatchEvent, mod.dispatchNotify)
+	mod.client = client
+	return mod, tr
+}
+
+// TestWSMessageSendStreaming 集成测试：
+// 客户端 WS 发送 message.send → 服务端调 ACP session/new + session/prompt →
+// mock 回 agent_message_chunk → WS 收到 message.create / message.update → typing.stop。
+func TestWSMessageSendStreaming(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	// 构造 ACP 交互：session/new 返回 sid，prompt 流式返回。
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		// 首次请求应为 session/new
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		if req.Method != "session/new" {
+			t.Errorf("first request = %s, want session/new", req.Method)
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-1"}})
+
+		// 第二个请求：session/prompt
+		req2, err := tr.readRequestErr(sc)
+		if err != nil || req2.Method != "session/prompt" {
+			t.Errorf("second request = %v, want session/prompt", req2)
+			return
+		}
+		// 流式通知 + 响应
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0", "method": "session/update",
+			"params": map[string]any{
+				"sessionId": "acp-1",
+				"update":    map[string]any{"sessionUpdate": map[string]any{"agent_message_chunk": map[string]any{"messageId": "m1", "content": map[string]any{"text": "你好"}}}},
+			},
+		})
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+
+	// 发送 message.send
+	_ = conn.WriteJSON(map[string]any{
+		"type": "message.send",
+		"payload": map[string]any{"content": "你好"},
+	})
+
+	// 期望收到：typing.start → message.create → message.update（或直接 create）→ typing.stop
+	var gotCreate, gotUpdate, gotTypingStop bool
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		switch m["type"] {
+		case "typing.start":
+		case "message.create":
+			gotCreate = true
+			p := m["payload"].(map[string]any)
+			if p["kind"] != "text" {
+				t.Errorf("create kind = %v, want text", p["kind"])
+			}
+			if p["content"] != "你好" {
+				t.Errorf("create content = %v, want 你好", p["content"])
+			}
+			if p["message_id"] != "m1" {
+				t.Errorf("create message_id = %v, want m1", p["message_id"])
+			}
+		case "message.update":
+			gotUpdate = true
+		case "typing.stop":
+			gotTypingStop = true
+		}
+		if gotCreate && gotTypingStop {
+			break
+		}
+	}
+	if !gotCreate {
+		t.Fatal("no message.create received")
+	}
+	if !gotTypingStop {
+		t.Fatal("no typing.stop received")
+	}
+	_ = gotUpdate
+}
+
+// TestWSDisconnectCleansUp 断线清理：关闭连接后，事件不再投递给该连接。
+func TestWSDisconnectCleansUp(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-1"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "hi"}})
+
+	// 等会话创建完成
+	waitFor(t, 3*time.Second, "session created", func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return len(h.byACP) == 1
+	})
+
+	conn.Close()
+	// 等待清理
+	waitFor(t, 3*time.Second, "conn cleaned", func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return len(h.byACP) == 0
+	})
+}
+
+// TestWSNewSessionBinding 验证 session.new 帧类型绑定（首个 message.send 自动建会话）。
+func TestWSNewSessionBinding(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-9"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "开始"}})
+
+	// 期望收到 typing.start 前有 session.create（绑定 webchat id）
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "session.create" {
+			sid, _ := m["session_id"].(string)
+			if sid == "" {
+				t.Fatal("session.create without session_id")
+			}
+			return
+		}
+	}
+	t.Fatal("no session.create received")
+}
+
+// TestWSUnknownTypeIgnored 未知帧类型不导致连接关闭。
+func TestWSUnknownTypeIgnored(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-ign"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "foo.bar", "payload": map[string]any{"x": 1}})
+
+	// 连接仍存活：发一个 session.new 应能收到 session.create
+	_ = conn.WriteJSON(map[string]any{"type": "session.new"})
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("connection should stay alive after unknown frame: %v", err)
+	}
+	if !strings.Contains(string(data), "session.create") {
+		t.Errorf("after session.new got %s, want session.create", string(data))
+	}
+}
+
+// TestHubEventRouting 验证 Hub 按 ACP sessionId 把事件路由到对应连接。
+func TestHubEventRouting(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-route"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "hi"}})
+
+	// 等会话绑定
+	waitFor(t, 3*time.Second, "bind", func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return len(h.byACP) == 1
+	})
+
+	// 直接调 Hub.HandleEvent（模拟模块 dispatchEvent）
+	h.HandleEvent(&ACPSessionUpdate{
+		SessionID: "acp-route", Discriminator: "agent_message_chunk",
+		MessageID: "m1", Content: "路由成功",
+	})
+
+	deadline := time.Now().Add(3 * time.Second)
+	found := false
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "message.create" {
+			p := m["payload"].(map[string]any)
+			if p["content"] == "路由成功" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatal("event not routed to connection")
+	}
+}
+
+// TestWSMultiSession 多会话验证：
+//   - 同一连接连续发送两条消息 → 复用同一 ACP 会话（只创建一个 session/new）
+//   - 新连接发送 → 创建新的 ACP 会话（第二个 session/new）
+func TestWSMultiSession(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	var newCalls int32
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		for {
+			req, err := tr.readRequestErr(sc)
+			if err != nil {
+				return
+			}
+			// notification（无 id，如 session/cancel）不回复
+			if req.ID == nil {
+				continue
+			}
+			switch req.Method {
+			case "session/new":
+				atomic.AddInt32(&newCalls, 1)
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-" + strconv.FormatInt(*req.ID, 10)}})
+			case "session/prompt":
+				// 静默返回 stopReason（无流式通知，避免事件路由干扰）
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"stopReason": "end_turn"}})
+			default:
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "error": map[string]any{"code": -32601, "message": "Method not found"}})
+			}
+		}
+	}()
+
+	// 连接 1：两条连续消息
+	conn1 := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn1.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "第一条"}})
+	// 等 session.create
+	waitFrame := func(t *testing.T, conn *websocket.Conn, wantType string) {
+		t.Helper()
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			m := readFrame(t, conn)
+			if m["type"] == wantType {
+				return
+			}
+		}
+		t.Fatalf("no %s frame", wantType)
+	}
+	waitFrame(t, conn1, "session.create")
+	waitFrame(t, conn1, "typing.start")
+
+	_ = conn1.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "第二条"}})
+	waitFrame(t, conn1, "typing.start")
+
+	// 连接 2：新会话
+	conn2 := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn2.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "新连接"}})
+	waitFrame(t, conn2, "session.create")
+
+	// 等待所有 session/new 处理完
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && atomic.LoadInt32(&newCalls) < 2 {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&newCalls); got != 2 {
+		t.Errorf("session/new calls = %d, want 2 (connection1 reuses session, connection2 creates new)", got)
+	}
+}


### PR DESCRIPTION
## Summary
在 `mvc/agentproxy` 上暴露 `ws://host:18990/agent/ws` WebSocket 端点，把 Reasonix ACP 流式消息转发为 webchatUI 可消费的 pico 协议帧，前端零改造。

- **ws.go**：gorilla/websocket 端点，子协议 `token.<forward_key>` 认证（复用 `llm_proxy_config.forward_key`，空 key 放行对齐 MYS-171）；连接管理、30s 心跳、30min 空闲超时、断线清理；Hub 按 ACP sessionId 路由事件到连接；`message.send` 自动创建/复用会话，多连接各自独立会话
- **protocol.go**：ACP `session/update` → WS 帧映射（`message.create`/`message.update`，kind `text`/`thought`/`tool_calls` 折叠块，`typing.start`/`typing.stop`，`error`，`session.create`）；tool_call 状态按 toolCallId 聚合
- **module.go**：事件分发从单 `eventFn` 槽改为监听者列表（广播）；Start 拉起 WS 服务、Shutdown 关闭；`forwardKey()` 读取转发 key
- **acp.go**：修复 `session/update` 事件丢失外层 `sessionId`（破坏事件路由）；把会话更新同时推给在途 Prompt 的 updates 流（驱动 typing.stop + 防 goroutine 泄漏）
- **测试**：协议映射全分支、WS 子协议认证/流式回包/多会话/断线清理/事件路由；`go test -race ./mvc/agentproxy/...` 全通过

## 依赖
基于 MYS-167 分支 `feat/agentproxy-mys167`（T2 ACP 客户端，PR #67），T2 合入 main 后此 PR 可改 base。

## 验证
- [x] `go build ./...` 通过
- [x] `go test ./mvc/agentproxy/...` 全通过
- [x] `go test -race ./mvc/agentproxy/...` 通过
- [x] WS 子协议认证生效（正确 token 升级、错误 403）
- [x] message.send → 流式 message.create/update → typing.stop
- [x] thought/tool_calls 折叠块映射
- [x] 多会话创建/复用
- [x] 断线清理（byACP/conns 无泄漏）

## 待办（后续任务）
- T4（MYS-169）前端设置面板加「后端」切换
- T5（MYS-170）部署 reasonix 到测试机端到端验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)