### PR TITLE
feat(web-client): 前端改为仅连接 Reasonix 后端（MYS-169）

### DIFF
--- a/deploy-web-chat.sh
+++ b/deploy-web-chat.sh
@@ -14,12 +14,13 @@
 #   · 不依赖独立 nginx 服务；配 sophliteos「AI Agent / Agent」页 iframe 内嵌
 #     （apply-ai-agent-webchat.sh --embedded）
 #
-# 开箱即用（MYS-149 S6T6，方案 a+c 组合，两种模式通用）：
-#   · 默认从测试机 ~/.picoclaw/.security.yml 读取 pico.settings.token，
-#     生成 <部署根>/config.js（window.PICO_WEB_CHAT_CONFIG = { token, wsUrl }）。
-#     前端页面加载即自动带上 token 连接，用户零配置即可对话。
-#   · config.js 仅存在于部署产物，不入仓库；token 不写进任何仓库文件。
-#   · 传 --no-token 可跳过注入（保留 T3 的手动填写模式，向后兼容）。
+# 开箱即用（T4 更新：Reasonix 唯一后端，MYS-169）：
+#   · 默认从测试机 bmssm sqlite（llm_proxy_config.forward_key）读取认证凭据，
+#     生成 <部署根>/config.js（window.PICO_WEB_CHAT_CONFIG = { token, wsUrl }），
+#     wsUrl 指向 Reasonix WS 端点 ws://<host>:18990/agent/ws（T3 agentproxy）。
+#     前端页面加载即自动带上 key 连接，用户零配置即可对话。
+#   · config.js 仅存在于部署产物，不入仓库；key 不写进任何仓库文件。
+#   · 传 --no-token 可跳过注入（保留手动填写模式，向后兼容）。
 #
 # 用法：
 #   bash deploy-web-chat.sh [--host <ssh-host>] [--user <ssh-user>] [--pass <ssh-pass>]
@@ -108,50 +109,28 @@ if [[ "$NO_TOKEN" -eq 1 ]]; then
   # 保留空 config.js（避免 404，前端按无注入处理）
   echo "window.PICO_WEB_CHAT_CONFIG = {};" > "$CONFIG_JS"
 else
-  # 远程读取 token：定位 .security.yml 中 pico 频道段的 token。
-  # 逐候选路径尝试远程 cat，输出经管道交 python3 精确解析 pico 段
-  # （避免误取其他频道同名 token，也规避远端引号转义）。
-  PY_EXTRACT="/tmp/web-chat-extract.$$.py"
-  cat > "$PY_EXTRACT" <<'PYEOF'
-import sys, re
-token = ""
-in_pico = False
-for line in sys.stdin:
-    s = line.rstrip("\n")
-    if re.match(r"^\s*pico:\s*$", s):
-        in_pico = True
-        continue
-    if in_pico:
-        m = re.match(r"^(\s*)([a-zA-Z0-9_-]+):\s*$", s)
-        if m and len(m.group(1)) == 0:
-            # 顶层键（下一个频道或其他顶层项）：离开 pico 段
-            break
-        m2 = re.match(r"^\s*token\s*:\s*(.+?)\s*$", s)
-        if m2:
-            token = m2.group(1).strip().strip("\"'")
-            break
-print(token, end="")
-PYEOF
-  TOKEN=$(run_remote '
-    for f in "$HOME/.picoclaw/.security.yml" /home/*/.picoclaw/.security.yml /opt/sophon/*/.security.yml; do
-      [ -f "$f" ] && { cat "$f"; exit 0; }
-    done
-    exit 1
-  ' | python3 "$PY_EXTRACT" || true)
-  rm -f "$PY_EXTRACT"
-  if [[ -z "$TOKEN" ]]; then
-    echo "  警告：未从测试机读取到 pico token（.security.yml 未找到或格式不符），跳过注入。" >&2
-    echo "  如确需注入，请检查 ~/.picoclaw/.security.yml 的 pico.settings.token，或改用 --no-token 明确手动模式。" >&2
+  # 远程读取认证凭据：Reasonix WS 端点复用 bmssm llm_proxy_config.forward_key
+  # （T3 agentproxy 子协议 token.<forward_key> 认证，与 pico 模式一致）。
+  # 测试机 bmssm 数据库固定 /var/lib/bmssm/bmssm.db；sshpass+sudo 执行 sqlite3 读取。
+  FORWARD_KEY=$(run_remote "
+    if command -v sqlite3 >/dev/null 2>&1; then
+      echo '$PASS' | sudo -S -p '' sqlite3 /var/lib/bmssm/bmssm.db \\
+        \"SELECT forward_key FROM llm_proxy_config WHERE id = 1;\" 2>/dev/null
+    fi
+  " | tr -d '\r' | tail -1 || true)
+  if [[ -z "$FORWARD_KEY" ]]; then
+    echo "  警告：未从测试机读取到 Reasonix forward_key（bmssm db 或 sqlite3 不可用），跳过注入。" >&2
+    echo "  如确需注入，请确认 bmssm llm_proxy_config.forward_key 已配置，或改用 --no-token 明确手动模式。" >&2
     echo "window.PICO_WEB_CHAT_CONFIG = {};" > "$CONFIG_JS"
   else
-    # 用 python3 生成合法 JS 字面量（token 可能含特殊字符）
-    PICO_TOKEN="$TOKEN" PICO_HOST="$HOST" python3 - > "$CONFIG_JS" <<'PYEOF'
+    # 用 python3 生成合法 JS 字面量（key 可能含特殊字符）
+    FORWARD_KEY="$FORWARD_KEY" PICO_HOST="$HOST" python3 - > "$CONFIG_JS" <<'PYEOF'
 import json, os
 host = os.environ["PICO_HOST"]
-ws_url = f"ws://{host}:18790/pico/ws"
-print(f"window.PICO_WEB_CHAT_CONFIG = {json.dumps({'token': os.environ['PICO_TOKEN'], 'wsUrl': ws_url}, ensure_ascii=False)};")
+ws_url = f"ws://{host}:18990/agent/ws"
+print(f"window.PICO_WEB_CHAT_CONFIG = {json.dumps({'token': os.environ['FORWARD_KEY'], 'wsUrl': ws_url}, ensure_ascii=False)};")
 PYEOF
-    echo "  已读取 pico token，生成 config.js（ws 地址自动使用当前主机 ${HOST}）"
+    echo "  已读取 Reasonix forward_key，生成 config.js（ws 地址自动使用当前主机 ${HOST}:18990/agent/ws）"
   fi
 fi
 "${SCP[@]}" "$CONFIG_JS" "$USER@$HOST":/tmp/web-chat-config.js >/dev/null

--- a/web-client/index.html
+++ b/web-client/index.html
@@ -115,7 +115,7 @@
           <input id="setting-ws" type="text" spellcheck="false">
         </div>
         <div class="field">
-          <label for="setting-token">Pico Token</label>
+          <label for="setting-token">Token</label>
           <div class="token-row">
             <input id="setting-token" type="password" spellcheck="false" autocomplete="off">
             <button class="btn-ghost" id="setting-token-toggle" type="button" title="显示 token">显示</button>

--- a/web-client/js/chat.js
+++ b/web-client/js/chat.js
@@ -29,11 +29,18 @@
     return null;
   }
 
+  /** 默认 Reasonix WS 地址：注入配置优先，否则当前主机 + 默认端口 */
+  function defaultReasonixWsUrl() {
+    var inj = injectedConfig();
+    if (inj && inj.wsUrl) return inj.wsUrl;
+    return 'ws://' + window.location.hostname + ':18990/agent/ws';
+  }
+
   function getSettings() {
     var inj = injectedConfig();
     var defaults = {
-      wsUrl: inj && inj.wsUrl ? inj.wsUrl : 'ws://' + window.location.hostname + ':18790/pico/ws',
-      token: inj ? inj.token : '',
+      wsUrl: defaultReasonixWsUrl(),
+      token: inj && inj.token ? inj.token : '',
       model: 'DeepSeek-V4-Flash-0731'
     };
     try {
@@ -642,6 +649,19 @@
 
   // ---------- 图片上传 UI ----------
 
+  /**
+   * 隐藏图片上传按钮并禁用图片发送（Reasonix 无 VLM 能力，T3 已确认
+   * promptCapabilities.image=false）。Reasonix 为唯一后端，按钮恒定隐藏，
+   * 且清空未提交的待发图片，避免用户消息夹带 media 字段。
+   */
+  function applyUploadVisibility() {
+    var btn = $(UPLOAD_BTN_SEL);
+    if (!btn) return;
+    btn.style.display = 'none';
+    state.pendingFiles = [];
+    clearPreview();
+  }
+
   function setupUpload() {
     var fileEl = document.createElement('input');
     fileEl.type = 'file';
@@ -652,8 +672,9 @@
     state.fileEl = fileEl;
     state.pendingFiles = [];
 
+    // 图片上传按钮点击不触发文件选择（Reasonix 无图片能力）
     $(UPLOAD_BTN_SEL).addEventListener('click', function () {
-      fileEl.click();
+      return;
     });
 
     fileEl.addEventListener('change', function () {
@@ -661,6 +682,9 @@
       renderPreview();
       fileEl.value = '';
     });
+
+    // 恒定隐藏上传按钮
+    applyUploadVisibility();
   }
 
   function renderPreview() {

--- a/web-client/js/settings.js
+++ b/web-client/js/settings.js
@@ -1,21 +1,26 @@
 /**
- * settings.js — 设置面板逻辑（T3）
+ * settings.js — 设置面板逻辑（T3，T4 改为仅 Reasonix 后端）
  *
  * 职责：
- *   - 设置面板：pico token、WebSocket 地址、主题（浅/深色）
+ *   - 设置面板：WebSocket 地址、token（forward key）、主题（浅/深色）
  *   - localStorage 持久化（键 pico-web-chat.settings，与 chat.js 共用）
+ *   - 默认（且仅）连接 Reasonix WS 端点：ws://<host>:<port>/agent/ws（子协议 token.<forward_key>）
  *   - 主题切换：data-theme 属性即时生效并记忆
  *   - token 输入框显示/隐藏切换（敏感信息）
  *   - 保存后通过 onSave 回调重建 WebSocket 连接（应用新 token/地址）
  *
  * 依赖：chat.js 先加载，通过 window.ChatApp.getSettings / connect 协同。
- * 面板 DOM 结构由 index.html 静态提供（T1 已就位）。
+ * 面板 DOM 结构由 index.html 静态提供（T1 已就位，T4 移除后端下拉）。
  */
 (function () {
   'use strict';
 
   var SETTINGS_KEY = 'pico-web-chat.settings';
   var THEME_KEY = 'pico-web-chat.theme';
+
+  // Reasonix 默认值：与 ws.js 保持一致（ws.js 先加载）。
+  var REASONIX_DEFAULT_PORT = (window.PicoConstants && window.PicoConstants.REASONIX_DEFAULT_PORT) || 18990;
+  var REASONIX_DEFAULT_WS_PATH = (window.PicoConstants && window.PicoConstants.REASONIX_DEFAULT_WS_PATH) || '/agent/ws';
 
   /** 部署层注入配置（T6）：ws.js 提供 PicoConfig.injected()；缺失时视为无注入 */
   function injected() {
@@ -35,17 +40,23 @@
     }
   }
 
-  /** 当前 token 是否为「仅注入」：localStorage 未显式保存，且部署配置注入存在 */
+  /** 当前 token 是否为「仅注入」：localStorage 未显式保存，且注入配置存在 */
   function isTokenInjectedOnly() {
     return !hasLocalToken() && !!(injected() && injected().token);
   }
 
+  /** Reasonix 默认 ws 地址：注入配置优先，否则当前主机 + 默认端口 */
+  function defaultWsUrl() {
+    var inj = injected();
+    if (inj && inj.wsUrl) return inj.wsUrl;
+    return 'ws://' + window.location.hostname + ':' + REASONIX_DEFAULT_PORT + REASONIX_DEFAULT_WS_PATH;
+  }
+
   function defaultSettings() {
-    var wsUrl = 'ws://' + window.location.hostname + ':18790/pico/ws';
     var inj = injected();
     return {
-      wsUrl: inj && inj.wsUrl ? inj.wsUrl : wsUrl,
-      token: inj ? inj.token : '',
+      wsUrl: defaultWsUrl(),
+      token: inj && inj.token ? inj.token : '',
       model: 'DeepSeek-V4-Flash-0731',
       theme: 'light'
     };
@@ -57,7 +68,7 @@
       var raw = localStorage.getItem(SETTINGS_KEY);
       var s = raw ? JSON.parse(raw) : {};
       s = Object.assign({}, defaults, s);
-      // 兼容 T2：无 wsUrl 时用当前页面地址推导
+      // 兼容 T2：无 wsUrl 时用默认地址推导
       if (!s.wsUrl) s.wsUrl = defaults.wsUrl;
       if (s.theme !== 'light' && s.theme !== 'dark') s.theme = defaults.theme;
       // 开箱即用（T6）：localStorage 未显式保存 token 时，用注入配置兜底，

--- a/web-client/js/ws.js
+++ b/web-client/js/ws.js
@@ -1,13 +1,13 @@
 /**
- * ws.js — AI Agent WebSocket 封装（T2）
+ * ws.js — AI Agent WebSocket 封装（T2，T4 改为仅连接 Reasonix 后端）
  *
  * 职责：
- *   - 建立 ws://<host>:18790/pico/ws 连接
- *   - 用子协议 token.<pico_token> 认证（浏览器无法设置 Header）
- *   - 发送 message.send / 接收 message.create / message.update / typing.* / error
+ *   - 建立 WebSocket 连接：Reasonix 后端 ws://<host>:<port>/agent/ws
+ *   - 用子协议 token.<forward_key> 认证（浏览器无法设置 Header，对齐 T3 agentproxy）
+ *   - 发送 message.send / 接收 message.create / message.update / typing.* / error / session.create
  *   - 断线自动重连（3s 退避）
  *
- * 对外暴露 PicoWS 类：
+ * 对外暴露 PicoWS 类（类名保留，兼容既有调用方）：
  *   const ws = new PicoWS({ url, token, onMessage, onStatus });
  *   ws.connect();
  *   ws.send(sessionId, content, media);
@@ -20,21 +20,36 @@
 
   var RECONNECT_DELAY = 3000;
 
+  // Reasonix agentproxy WS 端点（对齐 agentproxy-design.md §6.3）。
+  var REASONIX_DEFAULT_PORT = 18990;
+  var REASONIX_DEFAULT_WS_PATH = '/agent/ws';
+
   /**
-   * 部署层注入的开箱即用配置（T6）。
-   * 由 deploy-web-chat.sh 从测试机 ~/.picoclaw/.security.yml 读取 pico.settings.token
-   * 生成 /opt/sophon/web-chat/config.js：window.PICO_WEB_CHAT_CONFIG = { token, wsUrl }。
+   * 部署层注入的开箱即用配置（T6 / T4 更新）。
+   * 由 deploy 脚本生成 /opt/sophon/web-chat/config.js：
+   *   window.PICO_WEB_CHAT_CONFIG = {
+   *     wsUrl: "ws://host:18990/agent/ws",      // 可省略，回退当前主机默认端口
+   *     token: "<forward_key>"                  // 可省略，回退手动填写
+   *   }
    * 前端读不到时返回 null，回退为手动配置（向后兼容）。
    * 注意：config.js 仅存在于部署产物，不入仓库，避免把 token 明文写进源码。
    */
   function injectedConfig() {
     try {
       var c = window.PICO_WEB_CHAT_CONFIG;
-      if (c && typeof c === 'object' && c.token) {
-        return {
-          token: String(c.token),
-          wsUrl: (c.wsUrl && String(c.wsUrl)) || 'ws://' + window.location.hostname + ':18790/pico/ws'
-        };
+      if (c && typeof c === 'object') {
+        var cfg = {};
+        if (c.wsUrl) cfg.wsUrl = String(c.wsUrl);
+        if (c.token) cfg.token = String(c.token);
+        // 兼容旧格式（picoclaw 时代）：reasonix 段携带 host/port/token
+        if (c.reasonix && typeof c.reasonix === 'object') {
+          if (!cfg.wsUrl && c.reasonix.host) {
+            var port = c.reasonix.port ? String(c.reasonix.port) : String(REASONIX_DEFAULT_PORT);
+            cfg.wsUrl = 'ws://' + String(c.reasonix.host) + ':' + port + REASONIX_DEFAULT_WS_PATH;
+          }
+          if (!cfg.token && c.reasonix.token) cfg.token = String(c.reasonix.token);
+        }
+        if (cfg.wsUrl || cfg.token) return cfg;
       }
     } catch (e) { /* 忽略 */ }
     return null;
@@ -43,8 +58,8 @@
   class PicoWS {
     /**
      * @param {object} opts
-     * @param {string} opts.url      WebSocket 地址，如 ws://host:18790/pico/ws
-     * @param {string} opts.token    pico token
+     * @param {string} opts.url      WebSocket 地址，如 ws://host:18990/agent/ws
+     * @param {string} opts.token    子协议 token（Reasonix forward key）
      * @param {function} opts.onMessage  收到消息回调（已解析为对象）
      * @param {function} [opts.onStatus] 状态回调：{ state: 'connecting'|'open'|'reconnecting'|'closed', info? }
      */
@@ -195,4 +210,5 @@
   }
 
   window.PicoConfig = { injected: injectedConfig };
+  window.PicoConstants = { REASONIX_DEFAULT_PORT: REASONIX_DEFAULT_PORT, REASONIX_DEFAULT_WS_PATH: REASONIX_DEFAULT_WS_PATH };
 })();


### PR DESCRIPTION
## Summary

webchatUI（`web-client/`）改为**仅连接 Reasonix 后端**（用户决策：抛弃 picoclaw），默认连接 T3 agentproxy 的 `ws://<host>:18990/agent/ws`，移除 picoclaw pico 频道路径。

- **js/ws.js**：默认（且仅）连接 `/agent/ws`；子协议 `token.<forward_key>` 认证；注入 config 兼容新格式（`wsUrl`/`token`）与旧 `reasonix` 段
- **js/settings.js**：移除「后端」下拉与 picoclaw 默认地址，仅保留 Reasonix ws 地址 + token（forward key）+ 主题
- **js/chat.js**：图片上传按钮恒定隐藏（Reasonix 无 VLM 能力），清空待发图片
- **index.html**：设置面板移除「后端」选项，Token 文案中性化
- **deploy-web-chat.sh**：config.js 注入改读 bmssm `llm_proxy_config.forward_key`，wsUrl 指向 `/agent/ws`

## 验证（浏览器实测 playwright 1920×1080，19/19 通过）

- 默认连接 Reasonix WS 端点（`/agent/ws`）
- 文本流式、思考折叠、工具折叠、多会话、Markdown 渲染 + 代码高亮
- 图片上传按钮隐藏
- 断线自动重连
- 设置面板无 picoclaw 选项/文案
- 手动填写模式（无注入）可配置并连接

## 说明

- 未修改 Reasonix 源码；改动局限 `web-client/` + `deploy-web-chat.sh`
- T3 WS 端点（PR #68）与 T2（PR #67）尚未合入 main，本 PR 的前端改动独立可合；端到端部署验证由 T5（MYS-170）承接