### PR TITLE
feat(reasonix): Reasonix 部署 + agentproxy 适配真实 ACP bug 修复 + 端到端验证（MYS-170）

### DIFF
--- a/reasonix-deploy/README.md
+++ b/reasonix-deploy/README.md
@@ -1,0 +1,105 @@
+# Reasonix 部署（sophon-tools MYS-170）
+
+把 **Reasonix** 部署到 SOPHON 测试机（aarch64/SE7，`172.26.166.185`），作为 bmssm
+AI Agent 适配器（`mvc/agentproxy`）的唯一 ACP 后端。**放弃 picoclaw** 作为 AI Agent 链路。
+
+不改 Reasonix 源码，只通过 ACP v1（NDJSON JSON-RPC 2.0 over stdin/stdout）对接。
+
+## 架构
+
+```
+浏览器 (web-client / sophliteos Agent 页内嵌)
+   │  WS :18990  /agent/ws （子协议 token.<forward_key>）
+   ▼
+bmssm.mvc/agentproxy  (ws.go 端点 + protocol.go 协议映射 + session 管理)
+   │  ACP v1 (stdin/stdout)
+   ▼
+reasonix acp  (进程由 agentproxy os/exec 托管，崩溃自动重启)
+   │  OpenAI over HTTP（provider=sophnet，base_url=本机 llmproxy）
+   ▼
+bmssm.llmproxy (:18080/v1/chat/completions)  →  sophnet DeepSeek-V4-Flash-0731
+```
+
+## 组件与关键配置
+
+### 1. Reasonix 二进制
+
+- 交叉编译 arm64：`GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o reasonix-arm64 ./cmd/reasonix`
+- 部署位置：`/opt/sophon/reasonix/bin/reasonix`
+- Reasonix 由 `bmssm` 的 `mvc/agentproxy`（process.go）以 `reasonix acp` 托管，
+  崩溃退避自动重启（1s→30s）。
+
+### 2. Reasonix 用户配置 `/root/.reasonix/config.toml`
+
+reasonix acp 以 root（bmssm systemd 环境）运行，读 `$HOME/.reasonix/config.toml`。
+
+```toml
+default_model = "sophnet"
+
+[[providers]]
+name           = "sophnet"
+kind           = "openai"
+base_url       = "http://127.0.0.1:18080/v1"   # 本机 llmproxy（OpenAI shim）
+model          = "DeepSeek-V4-Flash-0731"
+api_key_env    = "DEEPSEEK_API_KEY"
+reasoning_protocol = "openai"
+context_window = 131072
+
+[sandbox]
+bash = "off"   # 测试机无 bubblewrap；关闭 bash 沙箱（不关则 turn 以 error 结束）
+```
+
+关键点：
+- **`base_url` 必须带 `/v1`**：reasonix kind=openai 在 base_url 后追加 `/chat/completions`，
+  不带 `/v1` 会 404（llmproxy 只暴露 `/v1/chat/completions`）。
+- **`[sandbox] bash = "off"`**：本机无 bubblewrap，reasonix 默认 `enforce` 会拒绝
+  unconfined shell，导致整个 turn 以 `stopReason=error` 结束。必须关闭才能产出消息。
+- **`DEEPSEEK_API_KEY` 由 bmssm systemd 注入**（值 = `forward_key`），reasonix 原子进程
+  继承该环境，实现 forward key 透传认证 llmproxy，`config.toml` 不写明文密钥。
+
+### 3. bmssm `agentproxy` 段（`/opt/sophon/bmssm/config/bmssm.yaml`）
+
+```yaml
+agentproxy:
+  enabled: true          # Reasonix 为唯一 AI Agent 后端
+  listenIP: 0.0.0.0      # WS 绑定全部网卡（浏览器经外网 IP 访问 18990）
+  port: 18990            # WS 端点端口 /agent/ws
+  binaryPath: /opt/sophon/reasonix/bin/reasonix
+  workDir: /home/linaro  # reasonix 会话 cwd
+  model: ""              # 空 = reasonix 默认（sophnet 提供商）
+  restartBackoffMax: 30s
+```
+
+- `listenIP: 0.0.0.0`：浏览器从外部 IP（如 `172.26.166.185`）连 WS，`127.0.0.1` 会
+  `ERR_CONNECTION_REFUSED`。
+- bmssm 需用 **cgo musl 静态**交叉编译（`go-sqlite3` 依赖 cgo）：脚本
+  `source/pbmssm/build/build-bmssm-arm64.sh`。`CGO_ENABLED=0` 无法打开 sqlite，
+  llmproxy 配置/会话持久化会失效。
+- 若本机 8080/sophliteos 已由内嵌 web-chat 承载，前端 `wsUrl` 指向 `:18990/agent/ws`。
+
+### 4. web-client / sophliteos 内嵌
+
+- 部署 reasonix 版 web-client：`bash deploy-web-chat.sh --embedded`（注 forward key 生成 config.js）
+- 让 sophliteos「AI Agent / Agent」页 iframe 指向内嵌 web-chat：
+  `bash web-client-deploy/apply-ai-agent-webchat.sh --embedded`
+
+## 验证（端到端）
+
+1. **ACP 握手**：bmssm 日志出现 `agentproxy: initialize ok protocolVersion=1`。
+2. **WS 直连**：子协议 `token.<forward_key>` 连 `ws://<host>:18990/agent/ws`，
+   发 `message.send`，应陆续收到 `session.create → typing.start → message.create(kind=thought) →
+   message.create(kind=text)`。
+3. **浏览器**：访问 sophliteos Agent 页（或 `http://<host>:8080/resource/web-chat/`），
+   发消息，验证：文本流式 / 思考过程折叠 / 工具调用折叠 / Markdown+代码高亮 /
+   多会话 / 断线重连 / 浅深主题 / 图片上传按钮隐藏。
+4. **工具调用**：reasonix 以 `bash · execute · completed` 形态出现在展开的工具调用折叠块。
+
+## 部署脚本
+
+`reasonix-deploy/deploy-reasonix.sh` 一键完成：传 `--reasonix-bin <本地 arm64 二进制>`
+`--bmssm-bin <本地 bmssm arm64 二进制>` 即可在全新测试机上复现本部署。
+
+## 注意
+
+- 不卸载 picoclaw，仅不再作为 AI Agent 后端（gateway 18790 / launcher 18800 保留可访问）。
+- Reasonix 无 VLM 图片能力：前端图片上传按钮已隐藏。

--- a/reasonix-deploy/deploy-reasonix.sh
+++ b/reasonix-deploy/deploy-reasonix.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# deploy-reasonix.sh — 部署 Reasonix 到测试机并接入 bmssm agentproxy（MYS-170）
+#
+# 目标：让 Reasonix 成为唯一 AI Agent 后端（抛弃 picoclaw）。流程：
+#   1) 把 reasonix (linux-arm64) 二进制放到 /opt/sophon/reasonix/bin/reasonix
+#   2) 写 Reasonix 用户配置 /root/.reasonix/config.toml：
+#      · provider 指向本机 llmproxy（127.0.0.1:18080，OpenAI shim，转发 sophnet DeepSeek）
+#      · [sandbox] bash="off"（测试机无 bubblewrap；不关则 turn 以 error 结束）
+#   3) 把 DEEPSEEK_API_KEY（= bmssm llm_proxy_config.forward_key）注入 bmssm systemd 环境
+#      （reasonix 子进程继承该环境，实现 forward key 透传，避免在 config 里写死 key）
+#   4) 在 bmssm.yaml 启用 agentproxy（enabled/path/port/listenIP）并重启 bmssm
+#   5) 验证：reasonix acp initialize 握手、WS 18990 监听
+#
+# 前置：本机已交叉编译出 bmssm(release/bmssm) 与 reasonix-arm64 二进制。
+# 用法：bash deploy-reasonix.sh [--host <ssh-host>] [--user <ssh-user>] [--pass <ssh-pass>]
+#       [--reasonix-bin <本地 arm64 reasonix 二进制>] [--bmssm-bin <本地 bmssm arm64 二进制>]
+#   默认 host=172.26.166.185 user=linaro pass=linaro
+#   默认在测试机原有 bmssm 上原地更新；若传 --bmssm-bin 则一并更新 bmssm 二进制。
+# 依赖：sshpass、ssh、sqlite3（测试机读取 forward_key）。
+#
+# 说明：不改 Reasonix 源码；不卸载 picoclaw（仅停止作为 AI Agent 后端）。
+
+set -euo pipefail
+
+HOST="172.26.166.185"
+USER="linaro"
+PASS="linaro"
+REASONIX_ARM64=""
+BMSSM_ARM64=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host) HOST="$2"; shift 2 ;;
+    --user) USER="$2"; shift 2 ;;
+    --pass) PASS="$2"; shift 2 ;;
+    --reasonix-bin) REASONIX_ARM64="$2"; shift 2 ;;
+    --bmssm-bin) BMSSM_ARM64="$2"; shift 2 ;;
+    *) echo "未知参数: $1"; exit 1 ;;
+  esac
+done
+
+SSH=(sshpass -p "$PASS" ssh -o StrictHostKeyChecking=no -o ConnectTimeout=15 "$USER@$HOST")
+SCP=(sshpass -p "$PASS" scp -o StrictHostKeyChecking=no -o ConnectTimeout=15)
+run() { "${SSH[@]}" "$@"; }
+
+REASONIX_DIR="/opt/sophon/reasonix"
+REASONIX_BIN="$REASONIX_DIR/bin/reasonix"
+REASONIX_CFG="/root/.reasonix/config.toml"
+BMSSM_YAML="/opt/sophon/bmssm/config/bmssm.yaml"
+DR="${REASONIX_DIR%%/}"
+
+echo "==> [1/6] 准备 reasonix 目录"
+run "echo '$PASS' | sudo -S -p '' mkdir -p '$REASONIX_DIR/bin' /root/.reasonix"
+
+if [[ -n "$REASONIX_ARM64" ]]; then
+  echo "==> [2/6] 上传 reasonix (arm64) 二进制"
+  "${SCP[@]}" "$REASONIX_ARM64" "$USER@$HOST":/tmp/reasonix-arm64
+  run "echo '$PASS' | sudo -S -p '' mv /tmp/reasonix-arm64 '$REASONIX_BIN' && echo '$PASS' | sudo -S -p '' chmod +x '$REASONIX_BIN'"
+else
+  echo "==> [2/6] 跳过 reasonix 二进制上传（--reasonix-bin 未指定，沿用现有 $REASONIX_BIN）"
+fi
+
+echo "==> [3/6] 读取 bmssm forward_key（Reasonix provider 的透传凭据）"
+FORWARD_KEY=$(run "echo '$PASS' | sudo -S -p '' sqlite3 /var/lib/bmssm/bmssm.db 'SELECT forward_key FROM llm_proxy_config WHERE id=1;' 2>/dev/null" | tr -d '\r' | tail -1)
+if [[ -z "$FORWARD_KEY" ]]; then
+  echo "  警告：未读到 forward_key；Reasonix 将无法认证 llmproxy。" >&2
+  exit 1
+fi
+
+echo "==> [4/6] 写入 Reasonix 用户配置（provider → 本机 llmproxy，sandbox off）"
+cat > "/tmp/reasonix-config.toml.$$" <<CFG
+# Reasonix ACP provider config（sophon-tools MYS-170）
+# Upstream = 本机 llmproxy（127.0.0.1:18080/v1，OpenAI shim），转发 sophnet DeepSeek-V4-Flash-0731。
+# 集中 egress，无嵌套密钥；forward key 经 bmssm systemd 环境注入（DEEPSEEK_API_KEY）。
+default_model = "sophnet"
+
+[[providers]]
+name           = "sophnet"
+kind           = "openai"
+base_url       = "http://127.0.0.1:18080/v1"
+model          = "DeepSeek-V4-Flash-0731"
+api_key_env    = "DEEPSEEK_API_KEY"
+reasoning_protocol = "openai"
+context_window = 131072
+
+[sandbox]
+bash = "off"     # 测试机无 bubblewrap；关闭 bash 沙箱以允许 unconfined shell
+CFG
+"${SCP[@]}" "/tmp/reasonix-config.toml.$$" "$USER@$HOST":/tmp/reasonix-config.toml >/dev/null
+run "echo '$PASS' | sudo -S -p '' cp /tmp/reasonix-config.toml '$REASONIX_CFG'"
+run "echo '$PASS' | sudo -S -p '' chmod 600 '$REASONIX_CFG'"
+rm -f "/tmp/reasonix-config.toml.$$"
+
+echo "==> [5/6] 配置 bmssm agentproxy + 环境变量，重启 bmssm"
+run "echo '$PASS' | sudo -S -p '' mkdir -p /etc/systemd/system/bmssm.service.d"
+run "echo '$PASS' | sudo -S -p '' bash -c 'cat > /etc/systemd/system/bmssm.service.d/env-reasonix.conf <<ENVEOF
+[Service]
+Environment=DEEPSEEK_API_KEY=$FORWARD_KEY
+ENVEOF'"
+# 幂等注入 agentproxy 段（不存在才追加；不改动已有 agentproxy 配置之外的字段）
+run "echo '$PASS' | sudo -S -p '' bash -c '
+if grep -q \"^agentproxy:\" \"$BMSSM_YAML\"; then
+  echo skip-agentproxy-section
+else
+  echo -e \"\n# Reasonix ACP 适配器（agentproxy）\nagentproxy:\n  enabled: true\n  listenIP: 0.0.0.0\n  port: 18990\n  binaryPath: $REASONIX_BIN\n  workDir: /home/linaro\n  model: \"\"\n  restartBackoffMax: 30s\" >> \"$BMSSM_YAML\"
+fi'"
+if [[ -n "$BMSSM_ARM64" ]]; then
+  echo "==> [5b] 上传 bmssm (arm64) 二进制"
+  "${SCP[@]}" "$BMSSM_ARM64" "$USER@$HOST":/tmp/bmssm-arm64
+  run "echo '$PASS' | sudo -S -p '' mv /tmp/bmssm-arm64 /opt/sophon/bmssm/bin/bmssm && echo '$PASS' | sudo -S -p '' chmod +x /opt/sophon/bmssm/bin/bmssm"
+fi
+run "echo '$PASS' | sudo -S -p '' systemctl daemon-reload && echo '$PASS' | sudo -S -p '' systemctl restart bmssm"
+
+echo "==> [6/6] 验证"
+# 等 bmssm 起来 + agentproxy 拉 reasonix acp 握手
+for i in $(seq 1 15); do
+  INIT_OK=$(run "echo '$PASS' | sudo -S -p '' grep -E 'agentproxy: initialize ok' /var/log/bmssm/bmssm.log 2>/dev/null | tail -1" || true)
+  [[ -n "$INIT_OK" ]] && break
+  sleep 1
+done
+echo "  agentproxy 握手: ${INIT_OK:-未检测到（请查看 /var/log/bmssm/bmssm.log）}"
+PORT_OK=$(run "ss -tlnp 2>/dev/null | grep 18990 | head -1" || true)
+echo "  WS 18990: ${PORT_OK:-未监听}"
+echo "==> 完成。浏览器访问 http://\$HOST:8080/resource/web-chat/（sophliteos Agent 页内嵌）即可对话。"

--- a/source/pbmssm/mvc/agentproxy/acp.go
+++ b/source/pbmssm/mvc/agentproxy/acp.go
@@ -201,8 +201,14 @@ func (c *Client) ListSessions(ctx context.Context, cwd string) ([]SessionInfo, e
 
 // Prompt 发起 session/prompt（长驻请求）。返回更新流与取消函数。
 // 不设普通超时；用 promptTimeout（10min）防悬挂。
+// promptBlocks 按 ACP v1 把纯文本编码为 ContentBlock 数组（reasonix 要求
+// session/prompt.prompt 是 []acp.ContentBlock，非裸字符串）。
+func promptBlocks(text string) []map[string]string {
+	return []map[string]string{{"type": "text", "text": text}}
+}
+
 func (c *Client) Prompt(ctx context.Context, id, text string) (<-chan *ACPSessionUpdate, func() error, error) {
-	params, _ := json.Marshal(map[string]any{"sessionId": id, "prompt": text})
+	params, _ := json.Marshal(map[string]any{"sessionId": id, "prompt": promptBlocks(text)})
 	// 注册 pending，不阻塞等待（响应即 stopReason）
 	call := c.register()
 	if err := c.pm.WriteRequest(mustMarshal(RPCRequest{
@@ -430,39 +436,88 @@ func (c *Client) failPending(err error) {
 }
 
 // parseSessionUpdate 解析 session/update 通知为通用结构。
-// ACP v1 载荷形如：
 //
-//	{"sessionId":"...","update":{"sessionUpdate":{...}}}
+// reasonix 的 ACP v1 通知形如（sessionUpdate 为字符串判别子，载荷字段并列其下）：
 //
-// 判别子位于 sessionUpdate 对象首键（agent_message_chunk / agent_thought_chunk /
-// tool_call / tool_call_update / plan / user_message_chunk / usage_update / session_info_update …）。
-// sessionId 取外层（标准 ACP 载荷）；sessionUpdate 内部带 sessionId 时以内部为准。
+//	{"sessionId":"...","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"..."}}}
+//	{"sessionId":"...","update":{"sessionUpdate":"tool_call","toolCallId":"...","title":"...","status":"..."}}
+//
+// 兼容旧式嵌套对象（判别子作为 sessionUpdate 对象的首键）：
+//
+//	{"sessionId":"...","update":{"sessionUpdate":{"agent_message_chunk":{"messageId":"...","content":{"text":"..."}}}}}
 func parseSessionUpdate(raw json.RawMessage) *ACPSessionUpdate {
 	if len(raw) == 0 {
 		return nil
 	}
 	var outer struct {
-		SessionID string `json:"sessionId"`
-		Update    struct {
-			SessionUpdate json.RawMessage `json:"sessionUpdate"`
-		} `json:"update"`
+		SessionID string          `json:"sessionId"`
+		Update    json.RawMessage `json:"update"`
 	}
 	if err := json.Unmarshal(raw, &outer); err != nil {
-		// 兼容扁平载荷
-		return parseFlatUpdate(raw)
+		return nil
 	}
-	if len(outer.Update.SessionUpdate) == 0 {
-		// 尝试扁平
-		return parseFlatUpdate(raw)
+	if len(outer.Update) == 0 {
+		return nil
 	}
-	ev := parseFlatUpdate(outer.Update.SessionUpdate)
-	if ev != nil && ev.SessionID == "" {
+	ev := parseUpdateBody(outer.Update)
+	if ev == nil {
+		return nil
+	}
+	if ev.SessionID == "" {
 		ev.SessionID = outer.SessionID
 	}
 	return ev
 }
 
-// parseFlatUpdate 从 sessionUpdate 对象提取判别子与公共字段。
+// parseUpdateBody 从 update 对象提取判别子与公共字段。update 可能是
+// reasonix 的字符串判别子形态（recommend），也可能是旧式嵌套对象形态：
+//
+//	{"sessionUpdate":"agent_message_chunk","content":{...}}   // 字符串形态
+//	{"sessionUpdate":{"agent_message_chunk":{...}}}           // 嵌套对象形态
+func parseUpdateBody(raw json.RawMessage) *ACPSessionUpdate {
+	// 先探测是否为字符串判别子形态：update.sessionUpdate 是字符串，载荷字段并列。
+	var str struct {
+		SessionUpdate string          `json:"sessionUpdate"`
+		Content       json.RawMessage `json:"content"`
+		MessageID     string          `json:"messageId"`
+		ToolCallID    string          `json:"toolCallId"`
+		Title         string          `json:"title"`
+		Kind          string          `json:"kind"`
+		Status        string          `json:"status"`
+		Entries       json.RawMessage `json:"entries"`
+	}
+	if json.Unmarshal(raw, &str) == nil && str.SessionUpdate != "" {
+		ev := &ACPSessionUpdate{Discriminator: str.SessionUpdate, Raw: map[string]any{}}
+		_ = json.Unmarshal(raw, &ev.Raw)
+		// content 可能是单块 {type,text} 或数组；text 取单块文本。
+		if len(str.Content) > 0 {
+			var block struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			}
+			if json.Unmarshal(str.Content, &block) == nil {
+				ev.Content = block.Text
+			}
+		}
+		ev.MessageID = str.MessageID
+		ev.ToolCallID = str.ToolCallID
+		ev.ToolCallTitle = str.Title
+		ev.ToolCallKind = str.Kind
+		ev.ToolCallStatus = str.Status
+		return ev
+	}
+	// 兼容旧式嵌套对象形态：判别子作为 sessionUpdate 对象的首键。
+	var m map[string]json.RawMessage
+	if json.Unmarshal(raw, &m) == nil {
+		if inner, ok := m["sessionUpdate"]; ok {
+			return parseFlatUpdate(inner)
+		}
+		return parseFlatUpdate(raw)
+	}
+	return nil
+}
+
+// parseFlatUpdate 从旧式嵌套对象提取判别子与公共字段（保留向后兼容与既有单测）。
 func parseFlatUpdate(raw json.RawMessage) *ACPSessionUpdate {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -484,17 +539,7 @@ func parseFlatUpdate(raw json.RawMessage) *ACPSessionUpdate {
 	_ = json.Unmarshal(raw, &ev.Raw)
 
 	switch disc {
-	case "agent_message_chunk":
-		var body struct {
-			MessageID string `json:"messageId"`
-			Content   struct {
-				Text string `json:"text"`
-			} `json:"content"`
-		}
-		_ = json.Unmarshal(m[disc], &body)
-		ev.MessageID = body.MessageID
-		ev.Content = body.Content.Text
-	case "agent_thought_chunk":
+	case "agent_message_chunk", "agent_thought_chunk":
 		var body struct {
 			MessageID string `json:"messageId"`
 			Content   struct {
@@ -506,10 +551,10 @@ func parseFlatUpdate(raw json.RawMessage) *ACPSessionUpdate {
 		ev.Content = body.Content.Text
 	case "tool_call":
 		var body struct {
-			ToolCallID    string `json:"toolCallId"`
-			Title         string `json:"title"`
-			Kind          string `json:"kind"`
-			Status        string `json:"status"`
+			ToolCallID string `json:"toolCallId"`
+			Title      string `json:"title"`
+			Kind       string `json:"kind"`
+			Status     string `json:"status"`
 		}
 		_ = json.Unmarshal(m[disc], &body)
 		ev.ToolCallID = body.ToolCallID

--- a/source/pbmssm/mvc/agentproxy/acp_test.go
+++ b/source/pbmssm/mvc/agentproxy/acp_test.go
@@ -390,6 +390,63 @@ func TestParseSessionUpdate(t *testing.T) {
 	}
 }
 
+// TestParseSessionUpdate_ReasonixStringTag 验证 reasonix 真实 ACP 通知形态：
+// sessionUpdate 为字符串判别子，内容块 {type,text} 与载荷字段并列在 update 下。
+func TestParseSessionUpdate_ReasonixStringTag(t *testing.T) {
+	cases := []struct {
+		name       string
+		payload    string
+		disc       string
+		content    string
+		toolCallID string
+		toolStatus string
+	}{
+		{
+			name:    "agent_message_chunk",
+			payload: `{"sessionId":"s1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"你好！有什么我可以帮你的吗？"}}}`,
+			disc: "agent_message_chunk", content: "你好！有什么我可以帮你的吗？",
+		},
+		{
+			name:    "agent_thought_chunk",
+			payload: `{"sessionId":"s1","update":{"sessionUpdate":"agent_thought_chunk","content":{"type":"text","text":"用户要求我打招呼"}}}`,
+			disc: "agent_thought_chunk", content: "用户要求我打招呼",
+		},
+		{
+			name:       "tool_call",
+			payload:    `{"sessionId":"s1","update":{"sessionUpdate":"tool_call","toolCallId":"tc1","title":"grep","kind":"bash","status":"pending"}}`,
+			disc: "tool_call", toolCallID: "tc1", toolStatus: "pending",
+		},
+		{
+			name:       "tool_call_update",
+			payload:    `{"sessionId":"s1","update":{"sessionUpdate":"tool_call_update","toolCallId":"tc1","status":"completed"}}`,
+			disc: "tool_call_update", toolCallID: "tc1", toolStatus: "completed",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ev := parseSessionUpdate(json.RawMessage(tc.payload))
+			if ev == nil {
+				t.Fatal("parse returned nil")
+			}
+			if ev.Discriminator != tc.disc {
+				t.Fatalf("disc = %s, want %s", ev.Discriminator, tc.disc)
+			}
+			if ev.SessionID != "s1" {
+				t.Fatalf("sessionId = %s, want s1", ev.SessionID)
+			}
+			if tc.content != "" && ev.Content != tc.content {
+				t.Fatalf("content = %s, want %s", ev.Content, tc.content)
+			}
+			if tc.toolCallID != "" && ev.ToolCallID != tc.toolCallID {
+				t.Fatalf("toolCallId = %s, want %s", ev.ToolCallID, tc.toolCallID)
+			}
+			if tc.toolStatus != "" && ev.ToolCallStatus != tc.toolStatus {
+				t.Fatalf("status = %s, want %s", ev.ToolCallStatus, tc.toolStatus)
+			}
+		})
+	}
+}
+
 // TestStreamClosedOnEOF 验证读循环读到 EOF 时未决请求失败、流关闭。
 func TestStreamClosedOnEOF(t *testing.T) {
 	tr, pm := newStdIOTransport(t)

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -194,6 +194,10 @@ func (h *Hub) serveWS(w http.ResponseWriter, r *http.Request) {
 		ReadBufferSize:  4096,
 		WriteBufferSize: 4096,
 		CheckOrigin:     func(r *http.Request) bool { return true },
+		// 回显客户端请求的子协议（token.<key>），浏览器强制要求服务端回显
+		// Sec-WebSocket-Protocol，否则握手失败。认证在 authSubprotocol 已通过，
+		// 这里直接把客户端列表透传给 selectSubprotocol 以回显首项。
+		Subprotocols: websocket.Subprotocols(r),
 	}
 	wsConn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -179,6 +179,15 @@ func TestWSMessageSendStreaming(t *testing.T) {
 			t.Errorf("second request = %v, want session/prompt", req2)
 			return
 		}
+		// prompt 必须是 ContentBlock 数组（ACP v1 / reasonix 要求），非裸字符串
+		var p2 struct {
+			Prompt []map[string]string `json:"prompt"`
+		}
+		if err := json.Unmarshal(req2.Params, &p2); err != nil || len(p2.Prompt) != 1 ||
+			p2.Prompt[0]["type"] != "text" || p2.Prompt[0]["text"] != "你好" {
+			t.Errorf("session/prompt params = %s, want content-block array", req2.Params)
+			return
+		}
 		// 流式通知 + 响应
 		_ = tr.reply(map[string]any{
 			"jsonrpc": "2.0", "method": "session/update",

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -95,7 +95,10 @@ func TestWSAuthSubprotocol(t *testing.T) {
 		t.Fatalf("valid subproto dial failed: %v", err)
 	}
 	conn.Close()
-	_ = resp
+	// 浏览器强制要求服务端回显所选子协议，否则握手失败。
+	if got := resp.Header.Get("Sec-Websocket-Protocol"); got != "token.secret-key-123" {
+		t.Fatalf("echoed subproto = %q, want token.secret-key-123", got)
+	}
 
 	// 错误子协议 → 403（无升级）
 	d2 := websocket.Dialer{Subprotocols: []string{"token.wrong"}}


### PR DESCRIPTION
## Summary

**Reasonix 部署到测试机 + 端到端验证（MYS-170 / chatUI 对接 Reasonix Stage 5 T5 最终任务）**。

把 Reasonix 部署为唯一 AI Agent 后端（抛弃 picoclaw），接入 bmssm `mvc/agentproxy`，
并修复端到端验证中发现的 3 个 agentproxy 适配真实 Reasonix 的 bug。

### 端到端验证中发现并修复的 bug（T5 部署前不可用的根因）

1. **`session/prompt` 编码错误**（acp.go）：bmssm 把 `prompt` 作为裸字符串发送，
   但 reasonix ACP v1 要求 `prompt: [{type:"text",text:"..."}]`（ContentBlock 数组），
   不修则无法产出任何消息。新增 `promptBlocks()` 编码 + 单测覆盖参数形状。
2. **`session/update` 通知解析错误**（acp.go）：reasonix 的判别子 `sessionUpdate` 是
   字符串值、载荷字段并列（`{"sessionUpdate":"agent_message_chunk","content":{...}}`），
   原适配器只支持嵌套对象形态（判别子作对象首键），导致 thought/message/tool 事件全部
   丢失。重写 `parseSessionUpdate`/`parseUpdateBody` 同时兼容字符串判别子 + 旧式嵌套，
   保留原单测并新增 reasonix 真实格式单测。
3. **WS 子协议未回显**（ws.go）：agentproxy 的 gorilla Upgrader 未设置 `Subprotocols`，
   浏览器强制要求服务端回显所选子协议否则握手失败（`Sent non-empty ... no response`），
   非浏览器客户端不报错故此前单测未暴露。设置 `Subprotocols: websocket.Subprotocols(r)`
   + 单测断言回显。

### 交付内容

- 部署脚本：`reasonix-deploy/deploy-reasonix.sh`（装 reasonix arm64 二进制 → 写
  `/root/.reasonix/config.toml` → 配 bmssm agentproxy → 注入 forward key 环境 → 重启验证）
- 部署文档：`reasonix-deploy/README.md`（架构、关键配置点、端到端验证步骤）
- agentproxy 三个 bug 修复 + 单测（见上）

## Test plan

- `go test ./mvc/agentproxy/` 全通过（含新增 reasonix 真实格式 / prompt ContentBlock / WS 子协议回显断言）
- `go build ./...` 通过
- 测试机 `172.26.166.185`（aarch64/SE7）端到端实测通过：
  - Reasonix `reasonix acp` initialize 握手成功（bmssm 日志 `initialize ok`）
  - 浏览器经 sophliteos Agent 页内嵌 web-chat 实测：文本流式、思考过程折叠、工具调用折叠、
    Markdown+代码高亮、多会话、断线自动重连、浅/深主题、图片上传按钮隐藏
  - 工具调用实测：`ls /home/linaro` → 工具调用折叠 `bash · execute · completed`，返回 `Desktop`

## Notes

- 未修改 Reasonix 源码；未卸载 picoclaw（仅不再作为 AI Agent 后端）。
- T2/T3/T4 代码已在 PR #67/#68/#69 合入 main，本 PR 在其上叠加部署脚本与修复。
