### PR TITLE
feat(ai-agent): 会话历史服务端持久化 + 跨浏览器恢复（MYS-178）

### DIFF
--- a/source/pbmssm/mvc/agentproxy/protocol.go
+++ b/source/pbmssm/mvc/agentproxy/protocol.go
@@ -28,12 +28,18 @@ type ToolCallState struct {
 	Status string `json:"status,omitempty"`
 }
 
+// streamedContent 一条流式消息（text/thought）的聚合状态，含渲染 kind。
+type streamedContent struct {
+	Kind string // text / thought
+	Text string
+}
+
 // StreamState 连接级流式累积状态：一个 WS 连接一个实例。
 // 同一 messageId 的内容按 ACP chunk 增量累积，发送全量（前端 accumulate 前缀替换语义）。
 type StreamState struct {
 	mu        sync.Mutex
 	created   map[string]bool            // messageId / toolCallId -> 已发 message.create
-	content   map[string]string          // messageId -> 当前完整内容
+	content   map[string]streamedContent // messageId -> 当前完整内容（含 kind）
 	toolCalls map[string]*ToolCallState  // toolCallId -> 聚合
 	typingOn  bool                       // 当前回合是否仍显示「输入中…」
 }
@@ -42,7 +48,7 @@ type StreamState struct {
 func NewStreamState() *StreamState {
 	return &StreamState{
 		created:   make(map[string]bool),
-		content:   make(map[string]string),
+		content:   make(map[string]streamedContent),
 		toolCalls: make(map[string]*ToolCallState),
 		typingOn:  true,
 	}
@@ -141,8 +147,18 @@ func (a *MessageAdapter) messageChunk(ev *ACPSessionUpdate, webchatID, kind stri
 	a.mu.Unlock()
 
 	a.state.mu.Lock()
-	cur := a.state.content[id] + ev.Content
-	a.state.content[id] = cur
+	sc := a.state.content[id]
+	var merged string
+	if sc.Kind == "" {
+		// 首个 chunk：记 kind（text/thought），内容即本段
+		sc.Kind = kind
+		merged = ev.Content
+	} else {
+		// 后续 chunk：增量累积
+		merged = sc.Text + ev.Content
+	}
+	sc.Text = merged
+	a.state.content[id] = sc
 	already := a.state.created[id]
 	a.state.created[id] = true
 	typing := a.state.typingOn
@@ -159,7 +175,7 @@ func (a *MessageAdapter) messageChunk(ev *ACPSessionUpdate, webchatID, kind stri
 			SessionID: webchatID,
 			Payload: map[string]any{
 				"message_id": id,
-				"content":    cur,
+				"content":    merged,
 				"kind":       kind,
 				"model_name": a.modelName(),
 			},
@@ -170,7 +186,7 @@ func (a *MessageAdapter) messageChunk(ev *ACPSessionUpdate, webchatID, kind stri
 			SessionID: webchatID,
 			Payload: map[string]any{
 				"message_id": id,
-				"content":    cur,
+				"content":    merged,
 				"kind":       kind,
 			},
 		})
@@ -242,6 +258,27 @@ func (a *MessageAdapter) toolCall(ev *ACPSessionUpdate, webchatID string, update
 		})
 	}
 	return frames
+}
+
+// RoundAssistants 返回本回合已聚合的 assistant 消息（落库用），并清空聚合状态后重开。
+// text/thought 按 messageId 归并全文，kind 保留；tool_call 按 toolCallId 归并为折叠块摘要。
+// 调用时机：回合结束（prompt stopReason 到达），由连接层追加进会话历史。
+func (a *MessageAdapter) RoundAssistants() []ChatMessage {
+	a.state.mu.Lock()
+	defer a.state.mu.Unlock()
+	out := make([]ChatMessage, 0, len(a.state.content)+len(a.state.toolCalls))
+	for id, sc := range a.state.content {
+		out = append(out, ChatMessage{Role: "assistant", Kind: sc.Kind, Content: sc.Text, ID: id})
+	}
+	for id, tc := range a.state.toolCalls {
+		out = append(out, ChatMessage{Role: "assistant", Kind: "tool_calls", Content: toolCallSummary(tc), ID: id})
+	}
+	// 清空聚合状态但保留同一把锁（不能整体替换 a.state——会换掉正在持有的 mutex）。
+	a.state.content = make(map[string]streamedContent)
+	a.state.toolCalls = make(map[string]*ToolCallState)
+	a.state.created = make(map[string]bool)
+	a.state.typingOn = true
+	return out
 }
 
 // modelName 返回 message.create 的 model_name。

--- a/source/pbmssm/mvc/agentproxy/protocol_test.go
+++ b/source/pbmssm/mvc/agentproxy/protocol_test.go
@@ -2,6 +2,7 @@ package agentproxy
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -203,5 +204,42 @@ func TestFrameSerialization(t *testing.T) {
 	}
 	if _, ok := m["payload"]; !ok {
 		t.Errorf("json payload missing")
+	}
+}
+
+func TestRoundAssistants(t *testing.T) {
+	a := NewMessageAdapter("m")
+	// 模拟一次 round 的 ACP 事件流：两条 text chunk 归并为一条，一个 thought，一个 tool_call
+	sid := "web-1"
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "m1", Content: "你"}, sid)
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "m1", Content: "好"}, sid)
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_thought_chunk", MessageID: "t1", Content: "思考"}, sid)
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "tool_call", ToolCallID: "tc1", ToolCallTitle: "bash", ToolCallKind: "execute", ToolCallStatus: "completed"}, sid)
+
+	msgs := a.RoundAssistants()
+	byKind := map[string]int{}
+	var textContent, toolSummary string
+	for _, m := range msgs {
+		byKind[m.Kind]++
+		switch m.Kind {
+		case "text":
+			textContent = m.Content
+		case "tool_calls":
+			toolSummary = m.Content
+		}
+	}
+	if byKind["text"] != 1 || byKind["thought"] != 1 || byKind["tool_calls"] != 1 {
+		t.Fatalf("RoundAssistants kinds = %+v, want text=1 thought=1 tool_calls=1", byKind)
+	}
+	if textContent != "你好" {
+		t.Errorf("text content = %q, want 你好 (chunks merged)", textContent)
+	}
+	if !strings.Contains(toolSummary, "bash") {
+		t.Errorf("tool summary = %q, want contains bash", toolSummary)
+	}
+	for _, m := range msgs {
+		if m.Role != "assistant" {
+			t.Errorf("role = %q, want assistant", m.Role)
+		}
 	}
 }

--- a/source/pbmssm/mvc/agentproxy/types.go
+++ b/source/pbmssm/mvc/agentproxy/types.go
@@ -62,10 +62,14 @@ type WebchatSession struct {
 func (WebchatSession) TableName() string { return "agent_session" }
 
 // ChatMessage 会话历史消息快照（渲染用；reasonix 侧 transcript 是权威上下文）。
+// Role 取值：user / assistant。Kind 区分渲染形态：text / thought / tool_calls
+//（user 消息 Kind 一般留空）。Model 记录 assistant 文本来源模型名。
 type ChatMessage struct {
-	Role    string `json:"role"`    // user / assistant / thought / tool_calls
-	Content string `json:"content"` // 文本或 JSON 摘要
-	ID      string `json:"id,omitempty"`
+	Role     string `json:"role"`     // user / assistant
+	Content  string `json:"content"`  // 文本或折叠块摘要
+	Kind     string `json:"kind,omitempty"`     // text / thought / tool_calls
+	Model    string `json:"model,omitempty"`    // assistant 模型名
+	ID       string `json:"id,omitempty"`       // 消息/工具 id（messageId / toolCallId）
 }
 
 // ACPSessionUpdate ACP session/update 通知的通用载荷（判别子见 Discriminator）。

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -319,6 +319,10 @@ func (c *conn) handleFrame(frame clientFrame) {
 		c.handleSessionSwitchLocked(frame)
 	case "session.delete":
 		c.handleSessionDeleteLocked(frame)
+	case "session.list":
+		c.handleSessionListLocked()
+	case "session.history":
+		c.handleSessionHistoryLocked(frame)
 	case "session.cancel":
 		c.handleSessionCancelLocked()
 	case "session.new":
@@ -458,6 +462,54 @@ func (c *conn) handleSessionSwitchLocked(frame clientFrame) {
 		return
 	}
 	c.enqueueErrorLocked("切换会话需重新连接", "switch_reconnect")
+}
+
+// handleSessionListLocked session.list：返回服务端全部会话摘要（不含全量消息）。
+// 前置：持 c.mu。
+func (c *conn) handleSessionListLocked() {
+	summaries := make([]map[string]any, 0, 16)
+	for _, s := range c.module.Sessions().List() {
+		summaries = append(summaries, map[string]any{
+			"id":           s.ID,
+			"title":        s.Title,
+			"acpSessionId": s.ACPSessionID,
+			"updatedAt":    s.UpdatedAt,
+			"messageCount": len(s.Messages),
+		})
+	}
+	f := WSFrame{Type: "session.list", Payload: map[string]any{"sessions": summaries}}
+	select {
+	case c.send <- []WSFrame{f}:
+	case <-c.done:
+	}
+}
+
+// handleSessionHistoryLocked session.history：返回指定 webchat 会话的全量消息。
+// 前置：持 c.mu。
+func (c *conn) handleSessionHistoryLocked(frame clientFrame) {
+	sid := frame.SessionID
+	if sid == "" {
+		if p, ok := frame.Payload["session_id"].(string); ok {
+			sid = p
+		}
+	}
+	if sid == "" {
+		return
+	}
+	s, ok := c.module.Sessions().Get(sid)
+	if !ok {
+		c.enqueueErrorLocked("会话不存在", "session_not_found")
+		return
+	}
+	f := WSFrame{
+		Type:      "session.history",
+		SessionID: sid,
+		Payload:   map[string]any{"session_id": sid, "messages": s.Messages},
+	}
+	select {
+	case c.send <- []WSFrame{f}:
+	case <-c.done:
+	}
 }
 
 // handleSessionDeleteLocked 删除会话。前置：持 c.mu。

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -343,6 +343,31 @@ func (c *conn) handleMessageSendLocked(frame clientFrame) {
 	if content == "" {
 		return
 	}
+	// 携带已存在 webchat 会话 id → 先绑定并 resume 该会话（跨连接/跨浏览器续聊）
+	wid := frame.SessionID
+	if wid == "" {
+		if p, ok := frame.Payload["session_id"].(string); ok {
+			wid = p
+		}
+	}
+	if wid != "" {
+		if _, ok := c.module.Sessions().Get(wid); ok {
+			ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+			defer cancel()
+			client := c.module.Client()
+			if client == nil {
+				c.enqueueErrorLocked("reasonix 未就绪", "prompt")
+				return
+			}
+			sw, err := c.module.Sessions().Switch(ctx, client, wid)
+			if err != nil {
+				c.enqueueErrorLocked("恢复会话失败："+err.Error(), "session_resume")
+				return
+			}
+			c.resumeSessionLocked(sw)
+		}
+		// wid 存在但 Get 未命中 → 视为未知会话，落回新建分支（向后兼容）
+	}
 	if c.session == nil {
 		if err := c.ensureSessionLocked(); err != nil {
 			c.enqueueErrorLocked("无法创建会话："+err.Error(), "session_new")
@@ -354,6 +379,15 @@ func (c *conn) handleMessageSendLocked(frame clientFrame) {
 	if err := c.promptLocked(content); err != nil {
 		c.enqueueErrorLocked("发送失败："+err.Error(), "prompt")
 	}
+}
+
+// resumeSessionLocked 把连接绑定到已存在的 webchat 会话（resume 后绑定并注册事件路由）。
+// 前置：持 c.mu。
+func (c *conn) resumeSessionLocked(s *WebchatSession) {
+	c.bindSessionLocked(s)
+	c.hub.mu.Lock()
+	c.hub.byACP[s.ACPSessionID] = c
+	c.hub.mu.Unlock()
 }
 
 // ensureSessionLocked 确保连接已绑定 webchat 会话（首次发送时自动创建）。

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -419,7 +419,7 @@ func (c *conn) promptLocked(content string) error {
 	}
 	c.module.Sessions().AppendMessage(s.ID, ChatMessage{Role: "user", Content: content})
 
-	go func(acpID string, tok int64) {
+	go func(acpID string, tok int64, webchatID string) {
 		// 等待更新流关闭（prompt 响应 stopReason 到达）
 		for range updates {
 		}
@@ -431,10 +431,14 @@ func (c *conn) promptLocked(content string) error {
 				case c.send <- c.adapter.OnPromptEnd(c.session.ID):
 				case <-c.done:
 				}
+				// 回合结束：把本回合 assistant（text/thought/tool_calls）全量落库
+				for _, am := range c.adapter.RoundAssistants() {
+					c.module.Sessions().AppendMessage(webchatID, am)
+				}
 			}
 		}
 		c.mu.Unlock()
-	}(s.ACPSessionID, token)
+	}(s.ACPSessionID, token, s.ID)
 	return nil
 }
 

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -574,3 +574,53 @@ func TestWSMultiSession(t *testing.T) {
 		t.Errorf("session/new calls = %d, want 2 (connection1 reuses session, connection2 creates new)", got)
 	}
 }
+
+func TestWSPersistAssistantOnRoundEnd(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		if req.Method != "session/new" {
+			t.Errorf("first = %s, want session/new", req.Method)
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-p1"}})
+		req2, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0", "method": "session/update",
+			"params": map[string]any{"sessionId": "acp-p1", "update": map[string]any{"sessionUpdate": map[string]any{"agent_message_chunk": map[string]any{"messageId": "a1", "content": map[string]any{"text": "回答"}}}}},
+		})
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "问题"}})
+	// 一直读到 typing.stop（round 结束）
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "typing.stop" {
+			break
+		}
+	}
+	// round 落库后校验：Messages = [user问题, assistant回答]
+	waitFor(t, 3*time.Second, "assistant persisted", func() bool {
+		for _, s := range mod.sessions.List() {
+			if s.ACPSessionID == "acp-p1" && len(s.Messages) == 2 {
+				return s.Messages[1].Role == "assistant" && s.Messages[1].Content == "回答"
+			}
+		}
+		return false
+	})
+}

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -462,6 +462,50 @@ func TestWSSessionList(t *testing.T) {
 	}
 }
 
+func TestWSSessionHistory(t *testing.T) {
+	mod, _ := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	sm := mod.sessions
+	sm.mu.Lock()
+	sm.sessions["web-9"] = &WebchatSession{
+		ID: "web-9", ACPSessionID: "acp-9", Title: "历史",
+		Messages: []ChatMessage{
+			{Role: "user", Content: "你好"},
+			{Role: "assistant", Kind: "text", Content: "很高兴", Model: "m1"},
+			{Role: "assistant", Kind: "thought", Content: "思考中"},
+		},
+	}
+	sm.mu.Unlock()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-9"})
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.history" {
+			continue
+		}
+		p := m["payload"].(map[string]any)
+		if p["session_id"] != "web-9" {
+			t.Fatalf("history echoed session_id = %v, want web-9", p["session_id"])
+		}
+		raw, _ := p["messages"].([]any)
+		if len(raw) != 3 {
+			t.Fatalf("history messages len = %d, want 3", len(raw))
+		}
+		msg1, _ := raw[1].(map[string]any)
+		if msg1["kind"] != "text" || msg1["content"] != "很高兴" {
+			t.Errorf("msg[1] = %v, want kind=text content=很高兴", msg1)
+		}
+		return
+	}
+	t.Fatal("no session.history frame received")
+}
+
 func TestWSMultiSession(t *testing.T) {
 	mod, tr := mockModuleForWS(t)
 	h := newHub(mod, "key")

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -401,6 +401,67 @@ func TestHubEventRouting(t *testing.T) {
 // TestWSMultiSession 多会话验证：
 //   - 同一连接连续发送两条消息 → 复用同一 ACP 会话（只创建一个 session/new）
 //   - 新连接发送 → 创建新的 ACP 会话（第二个 session/new）
+// sessionSummaries 从 session.list 帧提取摘要列表。
+func sessionSummaries(t *testing.T, conn *websocket.Conn) []map[string]any {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.list" {
+			continue
+		}
+		raw, ok := m["payload"].(map[string]any)["sessions"].([]any)
+		if !ok {
+			t.Fatalf("session.list payload.sessions not array: %v", m["payload"])
+		}
+		out := make([]map[string]any, 0, len(raw))
+		for _, item := range raw {
+			mm, ok := item.(map[string]any)
+			if !ok {
+				t.Fatalf("session.list item not object: %v", item)
+			}
+			out = append(out, mm)
+		}
+		return out
+	}
+	t.Fatal("no session.list frame received")
+	return nil
+}
+
+func TestWSSessionList(t *testing.T) {
+	mod, _ := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	// 预置两个服务端会话（直接写 SessionManager，不经过 ACP）
+	sm := mod.sessions
+	first := &WebchatSession{ID: "web-1", ACPSessionID: "acp-1", Title: "标题A", Messages: []ChatMessage{{Role: "user", Content: "hi"}}}
+	second := &WebchatSession{ID: "web-2", ACPSessionID: "acp-2", Title: "标题B", Messages: []ChatMessage{}}
+	sm.mu.Lock()
+	sm.sessions["web-1"] = first
+	sm.sessions["web-2"] = second
+	sm.mu.Unlock()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "session.list"})
+
+	list := sessionSummaries(t, conn)
+	if len(list) != 2 {
+		t.Fatalf("session.list len = %d, want 2: %v", len(list), list)
+	}
+	found := map[string]bool{}
+	for _, s := range list {
+		found[s["id"].(string)] = true
+		if s["title"] == "标题A" && s["messageCount"].(float64) != 1 {
+			t.Errorf("标题A messageCount = %v, want 1", s["messageCount"])
+		}
+	}
+	if !found["web-1"] || !found["web-2"] {
+		t.Errorf("session.list missing ids: %v", list)
+	}
+}
+
 func TestWSMultiSession(t *testing.T) {
 	mod, tr := mockModuleForWS(t)
 	h := newHub(mod, "key")

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -623,4 +624,78 @@ func TestWSPersistAssistantOnRoundEnd(t *testing.T) {
 		}
 		return false
 	})
+}
+
+func TestWSSendResumeExistingSession(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	// 预置已有会话（含 ACP session id，state=closed 才会触发 resume）
+	sm := mod.sessions
+	sm.mu.Lock()
+	sm.sessions["web-r1"] = &WebchatSession{ID: "web-r1", ACPSessionID: "acp-r1", Title: "续聊", State: SessionClosed}
+	sm.mu.Unlock()
+
+	var mu sync.Mutex
+	var calls []string
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		for {
+			req, err := tr.readRequestErr(sc)
+			if err != nil {
+				return
+			}
+			if req.ID == nil {
+				continue
+			}
+			mu.Lock()
+			calls = append(calls, req.Method)
+			mu.Unlock()
+			switch req.Method {
+			case "session/resume":
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{}})
+			case "session/prompt":
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"stopReason": "end_turn"}})
+			default:
+				_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "error": map[string]any{"code": -32601, "message": "Method not found"}})
+			}
+		}
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	// 携带 webchat id 发送 → 应 resume 而非 session/new
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "session_id": "web-r1", "payload": map[string]any{"content": "继续"}})
+
+	// 等待 prompt 发生
+	waitFor(t, 3*time.Second, "prompt called", func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		for _, m := range calls {
+			if m == "session/prompt" {
+				return true
+			}
+		}
+		return false
+	})
+	var sawNew, sawResume bool
+	mu.Lock()
+	for _, m := range calls {
+		if m == "session/new" {
+			sawNew = true
+		}
+		if m == "session/resume" {
+			sawResume = true
+		}
+	}
+	mu.Unlock()
+	if sawNew {
+		t.Error("unexpected session/new: existing webchat id should resume, not create")
+	}
+	if !sawResume {
+		t.Error("expected session/resume for existing webchat session")
+	}
 }

--- a/web-client/js/chat.js
+++ b/web-client/js/chat.js
@@ -213,19 +213,26 @@
   }
 
   /**
-   * 绑定服务端返回的 session_id 到发起请求的会话。
-   * 优先绑定到 pendingSendSessionId（发送时记录的会话），避免等待回复期间
-   * 切换会话导致绑定错乱。
+   * 绑定服务端返回的 webchat session_id 到本地会话（跨浏览器持久主键）。
+   * session.create 回传的 id 是服务端 agent_session 主键，跨设备一致；
+   * 用它替换本地临时 uuid，作为持久主键。
    */
   function bindServerSession(serverSessionId) {
     if (!serverSessionId) return;
     var targetId = state.pendingSendSessionId || state.activeId;
     var s = state.sessions.find(function (x) { return x.id === targetId; });
     if (!s) return;
-    if (s.serverSessionId === serverSessionId) return;
+    if (s.id !== serverSessionId) {
+      var idx = state.sessions.findIndex(function (x) { return x.id === s.id; });
+      if (idx >= 0) state.sessions[idx].id = serverSessionId;
+      if (state.activeId === s.id) state.activeId = serverSessionId;
+      s.id = serverSessionId;
+    }
     s.serverSessionId = serverSessionId;
     state.pendingSendSessionId = null;
     saveSessions();
+    saveActive();
+    renderSessionList();
   }
 
   /** 把一条消息追加到当前会话并持久化 */
@@ -553,6 +560,12 @@
       case 'typing.stop':
         hideTyping();
         break;
+      case 'session.list':
+        handleSessionList(payload);
+        break;
+      case 'session.history':
+        handleSessionHistory(payload);
+        break;
       case 'error':
         handleError(payload);
         break;
@@ -578,6 +591,87 @@
     scrollToBottom();
   }
 
+  // ---------- 服务端会话回读（跨浏览器/跨设备恢复） ----------
+
+  /** 连接就绪后拉取服务端会话列表，覆盖本地列表（跨设备恢复）。 */
+  function syncFromServer() {
+    if (!state.ws || !state.ws.ready) return;
+    state.ws.sendFrame({ type: 'session.list' }, { queued: true });
+  }
+
+  /** 主动拉取某会话的历史消息。 */
+  function pullHistory(sessionId) {
+    if (!state.ws || !state.ws.ready || !sessionId) return;
+    state.ws.sendFrame({ type: 'session.history', session_id: sessionId }, { queued: true });
+  }
+
+  /** session.list 下行：用服务端会话列表重建前端列表（本地未同步的新会话另起）。 */
+  function handleSessionList(payload) {
+    var serverList = payload && Array.isArray(payload.sessions) ? payload.sessions : [];
+    var byId = {};
+    state.sessions.forEach(function (s) { byId[s.id] = s; });
+
+    var stored = serverList.map(function (ss) {
+      var existing = byId[ss.id] || byId[ss.serverSessionId];
+      if (existing) {
+        existing.serverSessionId = ss.id;
+        if (existing.id !== ss.id) existing.id = ss.id;
+        if (!existing.loaded) existing.loaded = false;
+        // 用服务端 updatedAt 排序（若本地更旧则刷新 preview，消息稍后按需拉取）
+        existing.localTitle = existing.title;
+        existing.title = existing.title && existing.title !== '新会话' ? existing.title : (ss.title || '新会话');
+        return existing;
+      }
+      return {
+        id: ss.id,
+        serverSessionId: ss.id,
+        title: ss.title || '新会话',
+        messages: [],
+        loaded: false
+      };
+    });
+
+    // 合并仍是本地的、但服务端还没有的（离线兜底 / 尚未同步的新会话）
+    var storedIds = {};
+    stored.forEach(function (s) { storedIds[s.id] = true; });
+    state.sessions.forEach(function (s) {
+      if (!storedIds[s.id]) stored.push(s);
+    });
+
+    state.sessions = stored;
+    if (!state.sessions.some(function (s) { return s.id === state.activeId; })) {
+      state.activeId = state.sessions.length ? state.sessions[0].id : null;
+    }
+    saveSessions();
+    saveActive();
+    renderSessionList();
+    renderChat();
+    // 活动会话若是服务端已有但未加载历史，立即拉取
+    var act = getActiveSession();
+    if (act && act.serverSessionId && !act.loaded) pullHistory(act.serverSessionId);
+  }
+
+  /** session.history 下行：回放服务端全量消息。 */
+  function handleSessionHistory(payload) {
+    var sid = payload.session_id;
+    var raw = Array.isArray(payload.messages) ? payload.messages : [];
+    var s = state.sessions.find(function (x) { return x.id === sid || x.serverSessionId === sid; });
+    if (!s) return;
+    s.messages = raw.map(function (m) {
+      return {
+        role: m.role,
+        kind: m.kind || 'text',
+        content: m.content || '',
+        model: m.model || '',
+        message_id: m.id || m.message_id || '',
+        time: null
+      };
+    });
+    s.loaded = true;
+    saveSessions();
+    if (state.activeId === s.id) renderChat();
+  }
+
   // ---------- 发送逻辑 ----------
 
   function sendMessage() {
@@ -600,13 +694,10 @@
       try {
         // 记录本次请求归属的会话，供回包绑定 serverSessionId
         state.pendingSendSessionId = s.id;
-        // 协议约束（实测）：服务端会话绑定连接生命周期——
-        //   空 sid → 复用/创建连接当前会话；带本连接已知 sid → 保持上下文；
-        //   带本连接未知 sid（含旧连接的 sid）→ 服务端沉默无响应。
-        // 因此：切换会话已重开连接（服务端「忘记」上一会话），统一用空 sid 发送。
-        //   连接内连续消息复用同一服务端会话 → 多轮上下文保持。
-        //   当前会话首次发送 → 服务端建独立会话并回传 sid。
-        state.ws.send('', content, mediaList);
+        // 携带服务端 webchat id 续聊（跨浏览器/跨设备恢复同一会话）；
+        // 未绑定服务端 id（新会话）时发空 sid，服务端自动建独立会话。
+        var sendId = s.serverSessionId ? s.serverSessionId : '';
+        state.ws.send(sendId, content, mediaList);
         state.sending = false;
         setSendEnabled(true);
       } catch (err) {
@@ -782,6 +873,11 @@
 
     if (!s) return;
 
+    // 服务端已有但本端未加载历史的会话：拉取历史（跨设备首次打开某会话）
+    if (s.serverSessionId && !s.loaded) {
+      pullHistory(s.serverSessionId);
+    }
+
     // 重放会话历史
     s.messages.forEach(function (msg) {
       if (msg.role === 'user') {
@@ -836,6 +932,8 @@
       closed: '已断开'
     };
     sub.textContent = map[status.state] || status.state;
+    // 连接就绪后从服务端回读会话列表（跨浏览器/跨设备恢复）
+    if (status.state === 'open') syncFromServer();
   }
 
   // ---------- 初始化 ----------

--- a/web-client/js/ws.js
+++ b/web-client/js/ws.js
@@ -157,6 +157,26 @@
       return frame;
     }
 
+    /**
+     * 发送任意协议帧（如 session.list / session.history）。
+     * 仅用于无用户消息内容的控制帧；内容帧请用 send()。
+     * @param {object} frame 帧对象，如 { type: 'session.list' }
+     * @param {object} [opts] { queued: true } 连接未就绪时排队，就绪后自动发送
+     * @returns {boolean} 是否已发送（queued 时恒为 false）
+     */
+    sendFrame(frame, opts) {
+      var o = opts || {};
+      var value = JSON.stringify(frame);
+      if (this.ready && this.ws && this.ws.readyState === WebSocket.OPEN && !o.queued) {
+        this.ws.send(value);
+        return true;
+      }
+      if (o.queued) {
+        this._queue.push(JSON.parse(value));
+      }
+      return false;
+    }
+
     _flushQueue() {
       if (!this.ready || !this.ws) return;
       while (this._queue.length) {


### PR DESCRIPTION
## Summary

**AI Agent 会话历史服务端持久化 + 跨浏览器恢复（MYS-178）**。

目标「聊天记录永不丢、可跨浏览器、跨浏览器设备」：把 bmssm `agent_session`（sqlite）
升级为唯一权威存储，前端从服务端拉取会话列表与历史，并按服务端 webchat 会话 id 续聊——取代
原有「会话绑定连接生命周期 + 前端 localStorage-only」的易丢失实现。

### 变更内容（5 个逻辑步骤，每个均有 Go 单测）

1. **`session.list` WS 帧**（`ws.go`）：新增入站帧类型，服务端返回全部会话摘要
   `{id,title,acpSessionId,updatedAt,messageCount}`（不含全量消息）。
2. **`session.history` WS 帧**（`ws.go`）：按 webchat `session_id` 返回该会话全量
   `ChatMessage` 历史。
3. **assistant 全量落库**（`protocol.go` + `ws.go`）：回合结束（prompt stopReason 到达）
   时调用新增 `RoundAssistants()`，把本回合聚合的 text/thought/tool_calls 全部
   append 进 `agent_session.messages_json`（此前只落用户消息）。为此把
   `StreamState.content` 从 `map[string]string` 升级为带 kind 的 `map[string]streamedContent`；
   `ChatMessage` 快照新增 `kind/model` 字段。
4. **`message.send` 按 webchat id resume**（`ws.go`）：入站携带已存在的 webchat `session_id`
   时，绑定该会话并 `session/resume` 其 ACP 上下文后再 prompt；空 id 仍走新建（向后兼容）。
5. **前端回读与续聊**（`web-client/js/ws.js` + `chat.js`）：PicoWS 新增 `sendFrame`；
   chat.js 连接就绪后 `session.list` 回读列表、按需 `session.history` 拉取历史、发送时携带
   服务端 webchat id 续聊，并以服务端 id 为持久主键（localStorage 降级为缓存）。

## Test plan

- `go build ./...` 通过
- `go vet ./mvc/agentproxy/...` 无告警
- `go test ./... -race -count=1`（pbmssm 全模块）通过，agentproxy 覆盖新增：`TestWSSessionList`、
  `TestWSSessionHistory`、`TestRoundAssistants`、`TestWSPersistAssistantOnRoundEnd`、
  `TestWSSendResumeExistingSession`，既有流式/多会话测试无回归
- 前端 `node --check web-client/js/ws.js && node --check web-client/js/chat.js` 通过（无 JS 单测框架）

## Notes

- `agent_session` 快照仍是渲染用途；`reasonix 侧 transcript 仍是权威上下文`，本 PR 不做 ACP 侧回放。
- 向后兼容：空 `session_id` 仍新建会话；`session.list`/`session.history` 为新增帧类型，旧前端不受影响。
- 未实现多端并发实时同步（以最后一写为准），如需强一致多端同步另起任务。
- 浏览器端手工验证请在测试机确认（`172.26.166.185` 或按 README 部署后验证跨浏览器恢复）。
