### PR TITLE
feat(bmssm): AI Agent 切到 Reasonix + deb 内嵌 + 覆盖下游请求开关 + chatUI 拆泡修复

### DIFF
--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 # bmssm .deb 打包：交叉编译 arm64 静态二进制 + 组装 deb 数据树 + dpkg-deb。
-# 用法: bash build/build-deb-bmssm.sh [VERSION] [ARCH]
-#   VERSION 默认 2.1.0（与 build/version.sh 一致）
-#   ARCH   默认 arm64（设备）；amd64 用于 PCIE/开发机
+# 用法: bash build/build-deb-bmssm.sh [VERSION] [ARCH] [REASONIX_BIN]
+#   VERSION      默认 2.1.0（与 build/version.sh 一致）
+#   ARCH         默认 arm64（设备）；amd64 用于 PCIE/开发机
+#   REASONIX_BIN 可选：reasonix arm64 二进制路径。提供则把 Reasonix 一并嵌入 deb，
+#               安装到 /opt/sophon/reasonix/bin/reasonix，并在 bmssm.yaml 里把
+#               agentproxy.binaryPath 指向它（出厂即带 AI Agent 后端）。
+#               省略则只打 bmssm（Reasonix 需后续单独部署）。
 # 产物: release/bmssm_${VERSION}_${ARCH}.deb
 set -e
 
@@ -11,6 +15,7 @@ VERSION="${1:-2.1.0}"
 # 版本号不允许进入 sed 替换分隔符；若含 / 则替换为 -（同时保持产物名一致）
 VERSION="${VERSION//\//-}"
 ARCH="${2:-arm64}"
+REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
 
 # 1. 交叉编译静态二进制 + 打包 bmssm.yaml 到 release/
 #    arm64 走 musl 静态；amd64 用宿主 gcc 动态链接（开发机用）
@@ -32,6 +37,24 @@ cp release/bmssm "$DEBROOT/opt/sophon/bmssm/bin/bmssm"
 chmod 0755 "$DEBROOT/opt/sophon/bmssm/bin/bmssm"
 cp release/bmssm.yaml "$DEBROOT/opt/sophon/bmssm/config/bmssm.yaml"
 cp build/bmssm.service "$DEBROOT/usr/lib/systemd/system/bmssm.service"
+
+# 嵌入 Reasonix：若指定了二进制，铺到 /opt/sophon/reasonix/bin/reasonix，
+# 并把打包的 bmssm.yaml agentproxy.binaryPath 指向它（一并启用 AI Agent 后端）。
+if [ -n "$REASONIX_BIN" ]; then
+  if [ ! -f "$REASONIX_BIN" ]; then
+    echo "ERROR: REASONIX_BIN 不存在: $REASONIX_BIN" >&2
+    exit 1
+  fi
+  mkdir -p "$DEBROOT/opt/sophon/reasonix/bin"
+  cp "$REASONIX_BIN" "$DEBROOT/opt/sophon/reasonix/bin/reasonix"
+  chmod 0755 "$DEBROOT/opt/sophon/reasonix/bin/reasonix"
+  # bmssm.yaml：启用 agentproxy 并指向内嵌 reasonix
+  sed -i \
+    -e 's|^  enabled: false.*|  enabled: true|' \
+    -e "s|^  binaryPath: \"\".*|  binaryPath: \"/opt/sophon/reasonix/bin/reasonix\"|" \
+    "$DEBROOT/opt/sophon/bmssm/config/bmssm.yaml"
+  echo "✓ 已嵌入 Reasonix: /opt/sophon/reasonix/bin/reasonix（agentproxy 已启用）"
+fi
 
 # 3. DEBIAN 控制文件（Version/Architecture 注入）
 #    注: ARCH 未过 dpkg-architecture 映射，当前 arm64/amd64 即 Debian 架构名；

--- a/source/pbmssm/mvc/agentproxy/controller.go
+++ b/source/pbmssm/mvc/agentproxy/controller.go
@@ -1,0 +1,154 @@
+package agentproxy
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+
+	"bmssm/pkg/response"
+)
+
+// ServiceStatus Reasonix 进程服务状态快照（供前端「服务管理」展示）。
+// 语义对齐旧 sophpicoclaw 上报结构，前端无需大改。
+type ServiceStatus struct {
+	Active       bool   `json:"active"`       // Reasonix 进程是否存活
+	ActiveState  string `json:"activeState"`  // 语义值：running / stopped
+	SubState     string `json:"subState"`     // process manager 生命周期状态串
+	EnabledState string `json:"enabledState"` // agentproxy.enabled → enabled / disabled
+	MainPID      string `json:"mainPid"`      // reasonix acp 进程 pid
+	Ports        []int  `json:"ports"`        // 监听端口（agentproxy WS 端口）
+	Running      bool   `json:"running"`      // 端口可达/进程存活
+	Healthy      bool   `json:"healthy"`      // 健康检查（initialize 成功 + stdin 可写）
+	LogTail      string `json:"logTail"`      // reasonix 最近 stderr 日志尾部
+	SessionCount int    `json:"sessionCount"` // 当前活动会话数
+}
+
+// currentModule 返回全局 agentproxy 单例（与 module.go 同一包，直接用 globalMod）。
+func currentModule() *Module {
+	globalMu.Lock()
+	defer globalMu.Unlock()
+	return globalMod
+}
+
+// GetServiceStatus GET /api/v1/agent/service/status
+// 返回 Reasonix（agentproxy）进程的服务状态。
+func (c *Controller) GetServiceStatus(g *gin.Context) {
+	st := c.buildStatus()
+	g.JSON(http.StatusOK, response.OK(st))
+}
+
+func (c *Controller) buildStatus() *ServiceStatus {
+	mod := currentModule()
+	out := &ServiceStatus{
+		Active:  false,
+		Ports:   []int{},
+		Running: false,
+	}
+	if mod == nil {
+		out.ActiveState = "stopped"
+		out.SubState = "not_started"
+		out.EnabledState = "disabled"
+		return out
+	}
+
+	sts := mod.Status()
+	enabled, _ := sts["enabled"].(bool)
+	alive, _ := sts["alive"].(bool)
+	healthy, _ := sts["healthy"].(bool)
+	pid, _ := sts["pid"].(int)
+	sessionCount, _ := sts["sessionCount"].(int)
+	stderr, _ := sts["stderr"].(string)
+
+	out.Active = alive
+	out.Running = alive
+	out.Healthy = healthy
+	out.SessionCount = sessionCount
+	out.MainPID = intToStr(pid)
+	out.LogTail = stderr
+	out.Ports = []int{mod.cfg.Port}
+	if enabled {
+		out.EnabledState = "enabled"
+	} else {
+		out.EnabledState = "disabled"
+	}
+	if alive {
+		out.ActiveState = "active"
+		out.SubState = "running"
+	} else if enabled {
+		out.ActiveState = "inactive"
+		out.SubState = "stopped"
+	} else {
+		out.ActiveState = "inactive"
+		out.SubState = "disabled"
+	}
+	return out
+}
+
+// ServiceAction POST /api/v1/agent/service/action  body: {"action":"restart"}
+// 对 Reasonix（agentproxy 托管进程）执行 start/stop/restart。
+// Reasonix 由 bmssm 进程内 ProcessManager 托管（非 systemd），故
+// enable/disable 由 bmssm 配置 agentproxy.enabled 决定，此处不支持（返回提示）。
+func (c *Controller) ServiceAction(g *gin.Context) {
+	var req struct {
+		Action string `json:"action" binding:"required"`
+	}
+	if err := g.ShouldBindJSON(&req); err != nil {
+		g.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
+		return
+	}
+	if err := c.action(req.Action); err != nil {
+		g.JSON(http.StatusBadRequest, response.Fail(err.Error()))
+		return
+	}
+	g.JSON(http.StatusOK, response.OK(gin.H{"message": "action " + req.Action + " executed"}))
+}
+
+func (c *Controller) action(action string) error {
+	mod := currentModule()
+	if mod == nil {
+		return errModuleNotStarted
+	}
+	pm := mod.Process()
+	if pm == nil {
+		return errModuleNotStarted
+	}
+	switch action {
+	case "start":
+		return pm.Start()
+	case "stop":
+		pm.Stop()
+		return nil
+	case "restart":
+		pm.Restart()
+		return nil
+	case "enable":
+		return errNoDisableSupport(action)
+	case "disable":
+		return errNoDisableSupport(action)
+	default:
+		return errInvalidAction(action)
+	}
+}
+
+var (
+	errModuleNotStarted = fmt.Errorf("agent 服务未启动（agentproxy 未初始化）")
+	errNoDisableSupport = func(a string) error {
+		return fmt.Errorf("Reasonix 随 bmssm 托管，不支持 %s；请通过 bmssm 配置 agentproxy.enabled 控制", a)
+	}
+	errInvalidAction = func(a string) error {
+		return fmt.Errorf("invalid action: %q", a)
+	}
+)
+
+// Controller Reasonix（agentproxy）服务状态与操作 handler。
+// 通过全局 module（currentModule）读取/驱动 reasonix 进程。
+type Controller struct{}
+
+// DefaultController 创建 Controller。
+func DefaultController() *Controller {
+	return &Controller{}
+}
+
+func intToStr(n int) string { return strconv.Itoa(n) }

--- a/source/pbmssm/mvc/agentproxy/controller_test.go
+++ b/source/pbmssm/mvc/agentproxy/controller_test.go
@@ -1,0 +1,75 @@
+package agentproxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// TestServiceStatusModuleNotStarted 未初始化 agentproxy 时 status 应给出 disabled/stopped，
+// 不 panic。
+func TestServiceStatusModuleNotStarted(t *testing.T) {
+	globalMu.Lock()
+	old := globalMod
+	globalMod = nil
+	globalMu.Unlock()
+	defer func() {
+		globalMu.Lock()
+		globalMod = old
+		globalMu.Unlock()
+	}()
+
+	ctrl := &Controller{}
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/v1/agent/service/status", nil)
+	ctrl.GetServiceStatus(ctx)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d, want 200", rec.Code)
+	}
+	if s := rec.Body.String(); s == "" {
+		t.Fatal("empty body")
+	}
+}
+
+// TestServiceActionValidation invalid/不支持动作应报错，不 panic。
+func TestServiceActionValidation(t *testing.T) {
+	globalMu.Lock()
+	old := globalMod
+	globalMod = nil
+	globalMu.Unlock()
+	defer func() {
+		globalMu.Lock()
+		globalMod = old
+		globalMu.Unlock()
+	}()
+
+	cases := []struct {
+		action string
+		code   int
+	}{
+		{"", 400},   // 空动作
+		{"rm", 400}, // 非法动作
+		{"enable", 400},
+		{"disable", 400},
+	}
+	for _, c := range cases {
+		rec := httptest.NewRecorder()
+		ctx, _ := gin.CreateTestContext(rec)
+		body := `{"action": "` + c.action + `"}`
+		ctx.Request = httptest.NewRequest(http.MethodPost, "/api/v1/agent/service/action", strings.NewReader(body))
+		ctx.Request.Header.Set("Content-Type", "application/json")
+		ctrl := &Controller{}
+		ctrl.ServiceAction(ctx)
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("action %q: code = %d, want 400", c.action, rec.Code)
+		}
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/process.go
+++ b/source/pbmssm/mvc/agentproxy/process.go
@@ -29,8 +29,8 @@ type ProcessManager struct {
 	onReady func() // 每次进程成功启动后被回调（acp client 重跑 initialize + 恢复会话）
 
 	mu      sync.Mutex
-	cmd     *exec.Cmd      // 当前进程（Wait goroutine 退出前有效）
-	waitCh  chan struct{}  // 当前进程退出信号（close 表示已退出）
+	cmd     *exec.Cmd     // 当前进程（Wait goroutine 退出前有效）
+	waitCh  chan struct{} // 当前进程退出信号（close 表示已退出）
 	state   ProcessState
 	started time.Time
 	stdin   io.WriteCloser // 写请求（NDJSON 行），写时需加 writeMu
@@ -356,6 +356,20 @@ func (pm *ProcessManager) ReadLine() ([]byte, error) {
 func (pm *ProcessManager) GracefulStop() {
 	pm.stopping.Store(true)
 	pm.stopProc(true)
+}
+
+// Stop 停止进程但不标记 stopping（之后再调用 Start 可重新拉起）。
+// 供服务管理接口「停止」用：不同于 GracefulStop（其置 stopping 后不可再起）。
+func (pm *ProcessManager) Stop() {
+	pm.stopProc(true)
+}
+
+// Restart 重启进程（stop + start）。供服务管理接口「重启」用。
+func (pm *ProcessManager) Restart() {
+	pm.mu.Lock()
+	pm.stopping.Store(false)
+	pm.mu.Unlock()
+	pm.restart()
 }
 
 // stopProc 停止当前进程并等待退出（不改变 stopping 状态，由调用方决定）。

--- a/source/pbmssm/mvc/llmproxy/migrate.go
+++ b/source/pbmssm/mvc/llmproxy/migrate.go
@@ -25,10 +25,12 @@ func Migrate(db *gorm.DB) {
 		{"llm_api_key", "text"},
 		{"llm_model", "text"},
 		{"llm_enabled", "bool"},
+		{"llm_override_model", "bool"},
 		{"vlm_api_base", "text"},
 		{"vlm_api_key", "text"},
 		{"vlm_model", "text"},
 		{"vlm_enabled", "bool"},
+		{"vlm_override_model", "bool"},
 		{"forward_key", "text"},
 		{"forward_key_written", "bool"},
 	}

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -246,6 +246,67 @@ func TestForwardModelPrecedence(t *testing.T) {
 	}
 }
 
+// TestForwardModelOverride 验证「覆盖下游请求」开关（override）：
+// 开启后，无论下游请求带什么 model，转发时一律强制替换为默认模型名；
+// 关闭时保留下游 model（由 TestForwardModelPrecedence 覆盖）。
+func TestForwardModelOverride(t *testing.T) {
+	var gotModels []string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if m, _ := req["model"].(string); m != "" {
+			gotModels = append(gotModels, m)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-default",
+		LLMOverride: boolPtr(true),
+		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+
+	send := func(model interface{}) {
+		m := map[string]interface{}{
+			"messages": []map[string]interface{}{
+				{"role": "user", "content": "hi"},
+			},
+		}
+		if model != nil {
+			m["model"] = model
+		}
+		body, _ := json.Marshal(m)
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		handleChatCompletions(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+		}
+	}
+
+	// override 开启：请求带任意 model → 一律替换为 llm-default
+	send("request-model-a")
+	if len(gotModels) != 1 || gotModels[0] != "llm-default" {
+		t.Fatalf("override on, with model: got = %v, want [llm-default]", gotModels)
+	}
+	// 请求无 model → 也补为 llm-default
+	send(nil)
+	if len(gotModels) != 2 || gotModels[1] != "llm-default" {
+		t.Fatalf("override on, no model: got = %v, want [llm-default llm-default]", gotModels)
+	}
+}
+
+func boolPtr(b bool) *bool { return &b }
+
 // TestForwardModelKeptForImage 验证带图请求：model 保留请求值，图片仍走 VLM 描述化后整体路由 LLM。
 func TestForwardModelKeptForImage(t *testing.T) {
 	var gotLLMModel string

--- a/source/pbmssm/mvc/llmproxy/service.go
+++ b/source/pbmssm/mvc/llmproxy/service.go
@@ -77,17 +77,19 @@ func (s *Service) SaveConfig(req SaveRequest) (Config, error) {
 		return def
 	}
 	c := Config{
-		ID:         1,
-		LLMApiBase: nonEmpty(req.LLMApiBase, cur.LLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
-		LLMApiKey:  nonEmpty(req.LLMApiKey, cur.LLMApiKey, ""),
-		LLMModel:   nonEmpty(req.LLMModel, cur.LLMModel, "sophnet-deepseek"),
-		LLMEnabled: enabled(req.LLMEnabled, cur.LLMEnabled),
-		VLMApiBase: nonEmpty(req.VLMApiBase, cur.VLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
-		VLMApiKey:  nonEmpty(req.VLMApiKey, cur.VLMApiKey, ""),
-		VLMModel:   nonEmpty(req.VLMModel, cur.VLMModel, "sophnet-vl-flash"),
-		VLMEnabled: enabled(req.VLMEnabled, cur.VLMEnabled),
-		ForwardKey: cur.ForwardKey,
-		UpdatedAt:  time.Now(),
+		ID:          1,
+		LLMApiBase:  nonEmpty(req.LLMApiBase, cur.LLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
+		LLMApiKey:   nonEmpty(req.LLMApiKey, cur.LLMApiKey, ""),
+		LLMModel:    nonEmpty(req.LLMModel, cur.LLMModel, "sophnet-deepseek"),
+		LLMEnabled:  enabled(req.LLMEnabled, cur.LLMEnabled),
+		LLMOverride: enabled(req.LLMOverride, cur.LLMOverride),
+		VLMApiBase:  nonEmpty(req.VLMApiBase, cur.VLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
+		VLMApiKey:   nonEmpty(req.VLMApiKey, cur.VLMApiKey, ""),
+		VLMModel:    nonEmpty(req.VLMModel, cur.VLMModel, "sophnet-vl-flash"),
+		VLMEnabled:  enabled(req.VLMEnabled, cur.VLMEnabled),
+		VLMOverride: enabled(req.VLMOverride, cur.VLMOverride),
+		ForwardKey:  cur.ForwardKey,
+		UpdatedAt:   time.Now(),
 	}
 	if s == nil || s.db == nil {
 		return c, errors.New("database unavailable")
@@ -133,10 +135,12 @@ func (c Config) ToResponse(written bool) ConfigResponse {
 		LLMApiBase:      c.LLMApiBase,
 		LLMModel:        c.LLMModel,
 		LLMEnabled:      c.LLMEnabled,
+		LLMOverride:     c.LLMOverride,
 		LLMHasKey:       c.LLMApiKey != "",
 		VLMApiBase:      c.VLMApiBase,
 		VLMModel:        c.VLMModel,
 		VLMEnabled:      c.VLMEnabled,
+		VLMOverride:     c.VLMOverride,
 		VLMHasKey:       c.VLMApiKey != "",
 		ForwardKey:      c.ForwardKey,
 		ForwardKeyReady: written,

--- a/source/pbmssm/mvc/llmproxy/test.go
+++ b/source/pbmssm/mvc/llmproxy/test.go
@@ -117,10 +117,15 @@ func forwardLLM(ctx context.Context, req map[string]interface{}, llm, vlm Provid
 	if err := describeImagesInRequest(req, vlm); err != nil {
 		return nil, 0, fmt.Errorf("image describe failed: %w", err)
 	}
-	// MYS-171：model 名称支持——请求带非空 model 则保留（不替换），
-	// 否则用默认配置的 LLM 模型名兜底。
-	if model, _ := req["model"].(string); model == "" {
+	// 覆盖下游请求（OverrideModel）控制转发的 model 取值：
+	//   - true：无论下游请求里 model 是什么，转发时一律强制替换为配置的默认模型名；
+	//   - false：保留下游 model，仅当下游未指定（model 为空）时用默认模型名兜底。
+	if llm.OverrideModel {
 		req["model"] = llm.ModelName
+	} else {
+		if model, _ := req["model"].(string); model == "" {
+			req["model"] = llm.ModelName
+		}
 	}
 	body, _ := json.Marshal(req)
 

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -13,27 +13,30 @@ import "time"
 
 // ProviderConfig 单套上游模型配置（LLM / VLM 各一份）。
 type ProviderConfig struct {
-	ApiBase   string `json:"apiBase"`   // OpenAI 兼容 base，转发时拼 /chat/completions
-	ApiKey    string `json:"-"`         // 上游供应商 key（不输出）
-	ModelName string `json:"modelName"` // 目标模型名
-	Enabled   bool   `json:"enabled"`
+	ApiBase       string `json:"apiBase"`   // OpenAI 兼容 base，转发时拼 /chat/completions
+	ApiKey        string `json:"-"`         // 上游供应商 key（不输出）
+	ModelName     string `json:"modelName"` // 目标模型名（默认模型名称）
+	Enabled       bool   `json:"enabled"`
+	OverrideModel bool   `json:"overrideModel"` // 覆盖下游请求：转发时强制用默认模型名
 }
 
 // Config 数据库模型：LLM 转发配置（单例，ID 固定为 1）。
 // LLM/VLM 各自独立的上游配置；ForwardKey 是客户端调用代理的凭据（独立于上游 key）。
 type Config struct {
-	ID          uint      `gorm:"column:id;primary_key" json:"-"`
-	LLMApiBase  string    `gorm:"column:llm_api_base" json:"llmApiBase"`
-	LLMApiKey   string    `gorm:"column:llm_api_key" json:"-"`
-	LLMModel    string    `gorm:"column:llm_model" json:"llmModel"`
-	LLMEnabled  bool      `gorm:"column:llm_enabled" json:"llmEnabled"`
-	VLMApiBase  string    `gorm:"column:vlm_api_base" json:"vlmApiBase"`
-	VLMApiKey   string    `gorm:"column:vlm_api_key" json:"-"`
-	VLMModel    string    `gorm:"column:vlm_model" json:"vlmModel"`
-	VLMEnabled  bool      `gorm:"column:vlm_enabled" json:"vlmEnabled"`
-	ForwardKey  string    `gorm:"column:forward_key" json:"-"`
-	ForwardKeyWritten bool `gorm:"column:forward_key_written" json:"-"`
-	UpdatedAt   time.Time `gorm:"column:updated_at" json:"updatedAt"`
+	ID                uint      `gorm:"column:id;primary_key" json:"-"`
+	LLMApiBase        string    `gorm:"column:llm_api_base" json:"llmApiBase"`
+	LLMApiKey         string    `gorm:"column:llm_api_key" json:"-"`
+	LLMModel          string    `gorm:"column:llm_model" json:"llmModel"`
+	LLMEnabled        bool      `gorm:"column:llm_enabled" json:"llmEnabled"`
+	LLMOverride       bool      `gorm:"column:llm_override_model" json:"llmOverrideModel"`
+	VLMApiBase        string    `gorm:"column:vlm_api_base" json:"vlmApiBase"`
+	VLMApiKey         string    `gorm:"column:vlm_api_key" json:"-"`
+	VLMModel          string    `gorm:"column:vlm_model" json:"vlmModel"`
+	VLMEnabled        bool      `gorm:"column:vlm_enabled" json:"vlmEnabled"`
+	VLMOverride       bool      `gorm:"column:vlm_override_model" json:"vlmOverrideModel"`
+	ForwardKey        string    `gorm:"column:forward_key" json:"-"`
+	ForwardKeyWritten bool      `gorm:"column:forward_key_written" json:"-"`
+	UpdatedAt         time.Time `gorm:"column:updated_at" json:"updatedAt"`
 }
 
 // TableName 指定表名。
@@ -63,12 +66,12 @@ const (
 
 // LLM 返回 LLM 上游配置。
 func (c Config) LLM() ProviderConfig {
-	return ProviderConfig{ApiBase: c.LLMApiBase, ApiKey: c.LLMApiKey, ModelName: c.LLMModel, Enabled: c.LLMEnabled}
+	return ProviderConfig{ApiBase: c.LLMApiBase, ApiKey: c.LLMApiKey, ModelName: c.LLMModel, Enabled: c.LLMEnabled, OverrideModel: c.LLMOverride}
 }
 
 // VLM 返回 VLM 上游配置。
 func (c Config) VLM() ProviderConfig {
-	return ProviderConfig{ApiBase: c.VLMApiBase, ApiKey: c.VLMApiKey, ModelName: c.VLMModel, Enabled: c.VLMEnabled}
+	return ProviderConfig{ApiBase: c.VLMApiBase, ApiKey: c.VLMApiKey, ModelName: c.VLMModel, Enabled: c.VLMEnabled, OverrideModel: c.VLMOverride}
 }
 
 // Provider 按类型取上游配置。
@@ -86,10 +89,12 @@ type SaveRequest struct {
 	LLMApiKey   string `json:"llmApiKey"`
 	LLMModel    string `json:"llmModel"`
 	LLMEnabled  *bool  `json:"llmEnabled"`
+	LLMOverride *bool  `json:"llmOverrideModel"`
 	VLMApiBase  string `json:"vlmApiBase"`
 	VLMApiKey   string `json:"vlmApiKey"`
 	VLMModel    string `json:"vlmModel"`
 	VLMEnabled  *bool  `json:"vlmEnabled"`
+	VLMOverride *bool  `json:"vlmOverrideModel"`
 }
 
 // ConfigResponse 配置响应（各 key 脱敏为 hasKey 布尔；ForwardKey 明文返回供前端展示）。
@@ -97,10 +102,12 @@ type ConfigResponse struct {
 	LLMApiBase      string    `json:"llmApiBase"`
 	LLMModel        string    `json:"llmModel"`
 	LLMEnabled      bool      `json:"llmEnabled"`
+	LLMOverride     bool      `json:"llmOverrideModel"`
 	LLMHasKey       bool      `json:"llmHasKey"`
 	VLMApiBase      string    `json:"vlmApiBase"`
 	VLMModel        string    `json:"vlmModel"`
 	VLMEnabled      bool      `json:"vlmEnabled"`
+	VLMOverride     bool      `json:"vlmOverrideModel"`
 	VLMHasKey       bool      `json:"vlmHasKey"`
 	ForwardKey      string    `json:"forwardKey"`
 	ForwardKeyReady bool      `json:"forwardKeyReady"` // 是否已写入本地 picoclaw

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # pbmssm 统一构建接口 (M1 规范 v0.1)
-# 用法: bash release.sh [ARCH] [VERSION]
-#   ARCH:    arm64 | amd64 | all（默认 arm64）
-#   VERSION: 显式版本号（默认 2.1.0，与 build/version.sh 一致）
+# 用法: bash release.sh [ARCH] [VERSION] [REASONIX_BIN]
+#   ARCH:          arm64 | amd64 | all（默认 arm64）
+#   VERSION:       显式版本号（默认 2.1.0，与 build/version.sh 一致）
+#   REASONIX_BIN:  可选 reasonix arm64 二进制路径；与 build-deb-bmssm.sh 语义一致，
+#                  传入则把 Reasonix 一并打进 deb。
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbmssm/）
 set -euo pipefail
 
@@ -11,6 +13,7 @@ cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
 VERSION="${2:-2.1.0}"
+REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pbmssm}"
 
 case "$ARCH" in
@@ -23,8 +26,8 @@ mkdir -p "$OUTPUT_DIR"
 
 build_one() {
   local arch="$1"
-  echo "==> pbmssm build arch=$arch version=$VERSION"
-  bash build/build-deb-bmssm.sh "$VERSION" "$arch"
+  echo "==> pbmssm build arch=$arch version=$VERSION reasonix=${REASONIX_BIN:-<none>}"
+  bash build/build-deb-bmssm.sh "$VERSION" "$arch" "$REASONIX_BIN"
   local deb="release/bmssm_${VERSION}_${arch}.deb"
   if [ ! -f "$deb" ]; then
     echo "ERROR: 未找到产物 $deb" >&2

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	"bmssm/middleware"
+	agentproxyCtrl "bmssm/mvc/agentproxy"
 	"bmssm/mvc/alarm"
 	"bmssm/mvc/audit"
 	"bmssm/mvc/compat"
@@ -51,6 +52,7 @@ func Register(r *gin.Engine) {
 	portsC := portsCtrl.DefaultController()
 	fwCtrl := firewallCtrl.DefaultController()
 	llmproxyCtrl := llmproxyCtrl.DefaultController()
+	agentCtrl := agentproxyCtrl.DefaultController()
 
 	// 公开：仅 login（含独立防爆破限流，约 5 次/12s/IP）
 	public := r.Group("/api/v1")
@@ -114,8 +116,8 @@ func Register(r *gin.Engine) {
 		api.GET("/llm-proxy/config", llmproxyCtrl.GetConfig)
 		// 模型列表（从供应商拉取，供前端弹窗选择）
 		api.GET("/llm-proxy/models", llmproxyCtrl.ListModels)
-		// sophpicoclaw 服务状态（读）
-		api.GET("/llm-proxy/service/status", llmproxyCtrl.GetServiceStatus)
+		// Reasonix 服务状态（读）——AI agent 后端由 agentproxy 管理
+		api.GET("/llm-proxy/service/status", agentCtrl.GetServiceStatus)
 
 		// Docker
 		api.GET("/docker/container", dockerCtrl.ListContainers)
@@ -171,8 +173,8 @@ func Register(r *gin.Engine) {
 		admin.POST("/llm-proxy/forward-key/reset", llmproxyCtrl.ResetForwardKey)
 		admin.POST("/llm-proxy/forward-key/write-picoclaw", llmproxyCtrl.WriteForwardKey)
 		admin.POST("/llm-proxy/test", llmproxyCtrl.RunTest)
-		// sophpicoclaw 服务操作（写）
-		admin.POST("/llm-proxy/service/action", llmproxyCtrl.ServiceAction)
+		// Reasonix 服务操作（写）——AI agent 后端由 agentproxy 管理
+		admin.POST("/llm-proxy/service/action", agentCtrl.ServiceAction)
 
 		// 软件/OTA（写）
 		admin.POST("/software/install", softwareCtrl.Install)

--- a/source/psophliteos/frontend/src/api/aiAgent/index.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/index.ts
@@ -28,10 +28,12 @@ export interface AgentConfig {
   llmApiBase: string;
   llmModel: string;
   llmEnabled: boolean;
+  llmOverrideModel: boolean;
   llmHasKey: boolean;
   vlmApiBase: string;
   vlmModel: string;
   vlmEnabled: boolean;
+  vlmOverrideModel: boolean;
   vlmHasKey: boolean;
   forwardKey: string;
   forwardKeyReady: boolean;
@@ -58,10 +60,12 @@ export async function saveAgentConfig(cfg: {
   llmApiKey: string;
   llmModel: string;
   llmEnabled: boolean;
+  llmOverrideModel: boolean;
   vlmApiBase: string;
   vlmApiKey: string;
   vlmModel: string;
   vlmEnabled: boolean;
+  vlmOverrideModel: boolean;
 }): Promise<{ ok: boolean; message?: string }> {
   try {
     const res = await defHttp.put(
@@ -172,7 +176,7 @@ export interface ServiceStatus {
   logTail: string;
 }
 
-// 查询 sophpicoclaw 服务状态。
+// 查询 Reasonix（agentproxy 托管）服务状态。
 export async function getServiceStatus(): Promise<ServiceStatus | null> {
   try {
     const res = await defHttp.get<ServiceStatus>(
@@ -188,7 +192,7 @@ export async function getServiceStatus(): Promise<ServiceStatus | null> {
   }
 }
 
-// 对 sophpicoclaw 执行操作（start/stop/restart/enable/disable）。
+// 对 Reasonix（agentproxy 托管）执行操作（start/stop/restart）。
 export async function serviceAction(action: string): Promise<{ ok: boolean; message?: string }> {
   try {
     const res = await defHttp.post(

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -40,11 +40,14 @@
             autocomplete="new-password"
           />
         </a-form-item>
-        <a-form-item label="模型名称">
+        <a-form-item label="默认模型名称">
           <a-input-group compact>
             <a-input v-model:value="form.llmModel" style="width: 60%" placeholder="sophnet-deepseek" />
             <a-button style="width: 20%" @click="openModelPicker('llm')">选择</a-button>
           </a-input-group>
+        </a-form-item>
+        <a-form-item label="覆盖下游请求" tooltip="开启后，无论下游请求中的 model 是什么，转接上游时都强制使用上述默认模型名称；关闭时，仅当下游未指定 model 才使用默认模型名称。">
+          <a-switch v-model:checked="form.llmOverrideModel" />
         </a-form-item>
         <a-form-item label="启用">
           <a-switch v-model:checked="form.llmEnabled" />
@@ -84,11 +87,14 @@
             autocomplete="new-password"
           />
         </a-form-item>
-        <a-form-item label="模型名称">
+        <a-form-item label="默认模型名称">
           <a-input-group compact>
             <a-input v-model:value="form.vlmModel" style="width: 60%" placeholder="sophnet-vl-flash" />
             <a-button style="width: 20%" @click="openModelPicker('vlm')">选择</a-button>
           </a-input-group>
+        </a-form-item>
+        <a-form-item label="覆盖下游请求" tooltip="开启后，无论下游请求中的 model 是什么，转接上游时都强制使用上述默认模型名称；关闭时，仅当下游未指定 model 才使用默认模型名称。">
+          <a-switch v-model:checked="form.vlmOverrideModel" />
         </a-form-item>
         <a-form-item label="启用">
           <a-switch v-model:checked="form.vlmEnabled" />
@@ -120,44 +126,11 @@
 
       <a-divider />
 
-      <!-- 转发 key 管理 -->
-      <div class="mt-4">
-        <div class="font-medium mb-2">转发 Key（客户端调用代理的凭据）</div>
-        <a-alert
-          v-if="form.forwardKeyReady"
-          type="success"
-          show-icon
-          message="已写入本地 picoclaw（devproxy.key）"
-          class="mb-2"
-        />
-        <a-input-group compact class="max-w-xl">
-          <a-input
-            v-model:value="form.forwardKey"
-            read-only
-            style="width: 60%"
-            placeholder="转发 key 尚未生成"
-          />
-          <a-button style="width: 12%" @click="copyForwardKey">拷贝</a-button>
-          <a-button style="width: 12%" :loading="resetting" @click="handleResetKey">重置</a-button>
-          <a-button
-            style="width: 16%"
-            type="primary"
-            :loading="writing"
-            @click="handleWriteKey"
-            >写入本地</a-button
-          >
-        </a-input-group>
-        <div class="text-gray-400 text-xs mt-1">
-          重置会生成新 key；「写入本地」将覆盖 /opt/sophon/picoclaw/.picoclaw/devproxy.key 并重启 sophpicoclaw 服务
-        </div>
-      </div>
-
-      <a-divider />
 
       <!-- 服务监控与管理 -->
       <div class="mt-4">
         <div class="mb-2 flex items-center justify-between">
-          <span class="font-medium">服务管理（sophpicoclaw）</span>
+          <span class="font-medium">服务管理（Reasonix）</span>
           <a-space>
             <a-button size="small" :loading="svcLoading" @click="refreshService">刷新</a-button>
           </a-space>
@@ -169,7 +142,7 @@
                 {{ svc.active ? '运行中' : '已停止' }}
               </a-tag>
             </a-descriptions-item>
-            <a-descriptions-item label="开机自启">
+            <a-descriptions-item label="Agent Proxy 启用">
               <a-tag :color="svc.enabledState === 'enabled' ? 'green' : 'orange'">
                 {{ svc.enabledState === 'enabled' ? '已启用' : '未启用' }}
               </a-tag>
@@ -190,9 +163,10 @@
               <a-button size="small" type="primary" :loading="svcActing" @click="doServiceAction('restart')">重启</a-button>
               <a-button size="small" :loading="svcActing" @click="doServiceAction('start')">启动</a-button>
               <a-button size="small" danger :loading="svcActing" @click="doServiceAction('stop')">停止</a-button>
-              <a-button size="small" :loading="svcActing" @click="doServiceAction('enable')">启用自启</a-button>
-              <a-button size="small" :loading="svcActing" @click="doServiceAction('disable')">关闭自启</a-button>
             </a-space>
+            <div class="text-gray-400 text-xs mt-1">
+              Reasonix 由 bmssm（agentproxy）托管，启停无需配置自启；启用与否取决于 bmssm 配置 agentproxy.enabled。
+            </div>
           </div>
           <a-collapse class="mt-2" :bordered="false">
             <a-collapse-panel key="log" header="最近日志">
@@ -201,7 +175,7 @@
           </a-collapse>
         </a-card>
         <a-card v-else size="small" class="max-w-2xl">
-          <a-empty description="未获取到服务状态（sophpicoclaw 未安装或 bmssm 不可达）" />
+          <a-empty description="未获取到服务状态（bmssm 不可达或 agentproxy 未初始化）" />
         </a-card>
       </div>
     </a-card>
@@ -259,8 +233,6 @@
     getAgentConfig,
     saveAgentConfig,
     getProviderModels,
-    resetForwardKey,
-    writeForwardKeyToPicoclaw,
     testAgentConfig,
     getServiceStatus,
     serviceAction,
@@ -294,13 +266,11 @@
 
   const activeKey = ref('llm');
   const saving = ref(false);
-  const resetting = ref(false);
-  const writing = ref(false);
   const testing = ref(false);
   const testResults = ref<TestResult[]>([]);
   const testAllOK = ref(true);
 
-  // sophpicoclaw 服务监控与管理
+  // Reasonix（agentproxy）服务监控与管理
   const svc = ref<ServiceStatus | null>(null);
   const svcLoading = ref(false);
   const svcActing = ref(false);
@@ -348,15 +318,15 @@
     llmApiKey: '',
     llmModel: '',
     llmEnabled: true,
+    llmOverrideModel: false,
     llmHasKey: false,
     vlmApiBase: '',
     vlmApiBaseType: 'sophnet',
     vlmApiKey: '',
     vlmModel: '',
     vlmEnabled: true,
+    vlmOverrideModel: false,
     vlmHasKey: false,
-    forwardKey: '',
-    forwardKeyReady: false,
   });
 
   // 根据已存 apiBase 推断类型（匹配预设则对应类型，否则兜底 sophnet）
@@ -395,14 +365,14 @@
       form.llmApiBaseType = inferApiBaseType(cfg.llmApiBase || '');
       form.llmModel = cfg.llmModel || '';
       form.llmEnabled = cfg.llmEnabled !== false;
+      form.llmOverrideModel = !!cfg.llmOverrideModel;
       form.llmHasKey = !!cfg.llmHasKey;
       form.vlmApiBase = cfg.vlmApiBase || SOPHNET_API_BASE;
       form.vlmApiBaseType = inferApiBaseType(cfg.vlmApiBase || '');
       form.vlmModel = cfg.vlmModel || '';
       form.vlmEnabled = cfg.vlmEnabled !== false;
+      form.vlmOverrideModel = !!cfg.vlmOverrideModel;
       form.vlmHasKey = !!cfg.vlmHasKey;
-      form.forwardKey = cfg.forwardKey || '';
-      form.forwardKeyReady = !!cfg.forwardKeyReady;
     }
   }
 
@@ -417,10 +387,12 @@
       llmApiKey: form.llmApiKey,
       llmModel: form.llmModel.trim() || 'sophnet-deepseek',
       llmEnabled: form.llmEnabled,
+      llmOverrideModel: form.llmOverrideModel,
       vlmApiBase: form.vlmApiBase.trim(),
       vlmApiKey: form.vlmApiKey,
       vlmModel: form.vlmModel.trim() || 'sophnet-vl-flash',
       vlmEnabled: form.vlmEnabled,
+      vlmOverrideModel: form.vlmOverrideModel,
     });
     saving.value = false;
     if (res.ok) {
@@ -487,56 +459,6 @@
     }
     picker.visible = false;
     message.success(`已选择模型 ${name}`);
-  }
-
-  // --- 转发 key 操作 ---
-  async function copyForwardKey() {
-    if (!form.forwardKey) {
-      message.warning('转发 key 尚未生成');
-      return;
-    }
-    try {
-      await navigator.clipboard.writeText(form.forwardKey);
-      message.success('已拷贝到剪贴板');
-    } catch {
-      // 兼容非 https 环境
-      const ta = document.createElement('textarea');
-      ta.value = form.forwardKey;
-      document.body.appendChild(ta);
-      ta.select();
-      document.execCommand('copy');
-      document.body.removeChild(ta);
-      message.success('已拷贝到剪贴板');
-    }
-  }
-
-  async function handleResetKey() {
-    resetting.value = true;
-    const res = await resetForwardKey();
-    resetting.value = false;
-    if (res.ok && res.key) {
-      form.forwardKey = res.key;
-      form.forwardKeyReady = false;
-      message.success('转发 key 已重置（尚未写入本地 picoclaw）');
-    } else {
-      message.error(res.message || '重置失败');
-    }
-  }
-
-  async function handleWriteKey() {
-    if (!form.forwardKey) {
-      message.warning('转发 key 尚未生成');
-      return;
-    }
-    writing.value = true;
-    const res = await writeForwardKeyToPicoclaw();
-    writing.value = false;
-    if (res.ok) {
-      form.forwardKeyReady = true;
-      message.success('已写入本地 picoclaw 并重启');
-    } else {
-      message.error(res.message || '写入失败');
-    }
   }
 
   onMounted(() => {

--- a/web-client/js/chat.js
+++ b/web-client/js/chat.js
@@ -119,7 +119,11 @@
     live: {},
     typingEl: null,
     sending: false,
-    pendingSendSessionId: null   // 最近一次发送消息的前端会话 id，用于正确绑定服务端 session_id
+    pendingSendSessionId: null,   // 最近一次发送消息的前端会话 id，用于正确绑定服务端 session_id
+    // 合并状态：一轮无用户打断的连续 text 归并到同一气泡（修复连续信息拆泡问题）。
+    // 服务端（agentproxy）可能把同一回复拆成多个 text message_id（如 text-1/text-2），
+    // 若逐条 create 会各建泡。用该状态把相邻 text create 累积到同一个气泡。
+    merge: null   // { id, el, content, model }
   };
   state.activeId = loadActiveId(state.sessions);
 
@@ -254,6 +258,9 @@
       appendToSession({ role: 'user', content: content, media: media || [], time: Date.now() });
     }
 
+    // 用户消息打断 AI text 流：之后到达的 text 应另起气泡，清除合并上下文
+    clearMerge();
+
     var wrap = document.createElement('div');
     wrap.className = 'msg msg-user';
 
@@ -282,6 +289,11 @@
   }
 
   // ---------- AI 消息渲染 ----------
+
+  /** 清除 AI text 合并上下文。会话切换/新建、用户发消息时调用。 */
+  function clearMerge() {
+    state.merge = null;
+  }
 
   /**
    * 处理 message.create：首次创建消息气泡。
@@ -313,13 +325,48 @@
       if (!model) model = state.settings.model || 'AI';
     }
 
+    // 合并策略：一段连续 assistant 输出可能被服务端拆成多个 text message_id
+    //（如 text-1/text-2，中间无用户消息）。这种情况下追加到上一个 text 气泡，
+    // 避免同一轮回复被拆进不同气泡。
+    if (kind === 'text' && state.merge && state.merge.el) {
+      var mergedContent = state.merge.content + content;
+      state.merge.content = mergedContent;
+      // 更新合并根气泡 DOM 内容
+      var mergedBubble = state.merge.el.querySelector('.msg-bubble');
+      if (mergedBubble) mergedBubble.innerHTML = renderMarkdown(mergedContent);
+      // 根条目 content 同步为合并后全量（后续 update 都在此累积）
+      var rootEntry = state.live[state.merge.id];
+      if (rootEntry) rootEntry.content = mergedContent;
+      // 新 message_id 也映射到同一根气泡，便于后续 update/create 命中
+      state.live[messageId] = {
+        el: state.merge.el,
+        content: mergedContent,
+        kind: 'text',
+        model: model,
+        messageIdKey: messageId,
+        sessionId: state.activeId,
+        mergeRootId: state.merge.id,   // 本条目是合并别名：指向根气泡
+        mergeAlias: true
+      };
+      // 同步与会话历史里该 assistant text 消息（累加）
+      mergePersistToSession(mergedContent, model);
+      scrollToBottom();
+      return;
+    }
+
     var el;
     if (kind === 'thought') {
       el = buildCollapse('思考过程', content);
+      // 折叠块（思考/工具）打断连续正文：其后新 text 另起一组
+      clearMerge();
     } else if (kind === 'tool_calls') {
       el = buildCollapse('工具调用', formatToolCalls(payload));
+      // 工具调用片段不应与正文合并
+      clearMerge();
     } else {
       el = buildTextMessage(content, model);
+      // 记录 text 气泡为后续合并目标（thought/tool_calls 不参与合并）
+      state.merge = { id: messageId, el: el, content: content, model: model };
     }
 
     state.live[messageId] = {
@@ -367,6 +414,23 @@
   }
 
   /**
+   * 合并 text 后把最新完整内容写回会话历史（合并到该 assistant 最近一条 text 消息）。
+   */
+  function mergePersistToSession(content, model) {
+    var s = getActiveSession();
+    if (!s) return;
+    for (var i = s.messages.length - 1; i >= 0; i--) {
+      var m = s.messages[i];
+      if (m.role === 'assistant' && (m.kind || 'text') === 'text') {
+        m.content = content;
+        if (model) m.model = model;
+        saveSessions();
+        return;
+      }
+    }
+  }
+
+  /**
    * 处理 message.update：更新同一 message_id 的气泡内容。
    * 兼容两种语义：
    *   - 全量扩展：update.content 是当前内容的前缀扩展 → 直接替换
@@ -374,14 +438,32 @@
    */
   function handleUpdate(payload) {
     var messageId = payload.message_id;
-    if (!messageId || !state.live[messageId]) {
+    var entry = messageId ? state.live[messageId] : null;
+
+    // 合并别名：同轮连续 text 归并到同一根气泡后，其余 message_id 的 update
+    // 也应对根气泡累积，避免只更新别名本条造成内容割裂。
+    if (entry && entry.mergeRootId && state.merge && state.merge.content !== undefined) {
+      var rootEntry = state.live[entry.mergeRootId];
+      if (rootEntry) {
+        var mNext = accumulate(state.merge.content, payload.content || '');
+        state.merge.content = mNext;
+        rootEntry.content = mNext;
+        updateBubbleContent(rootEntry.el, 'text', mNext, rootEntry.model);
+        persistAssistantUpdate(rootEntry, mNext);
+        scrollToBottom();
+        return;
+      }
+    }
+
+    if (!messageId || !entry) {
       // 未跟踪的 update：当作 create 兜底
       handleCreate(payload);
       return;
     }
-    var entry = state.live[messageId];
     var next = accumulate(entry.content, payload.content || '');
     entry.content = next;
+    // 若命中当前合并根气泡，同步合并累积值
+    if (state.merge && state.merge.id === messageId) state.merge.content = next;
     updateBubbleContent(entry.el, entry.kind, next, entry.model);
     // 同步持久化消息内容（流式 update 结束后刷新历史仍是最新内容）
     persistAssistantUpdate(entry, next);
@@ -775,6 +857,7 @@
     state.messagesEl.innerHTML = '';
     state.live = {};
     state.typingEl = null;
+    clearMerge();
 
     // 标题
     var titleEl = $('.chat-title');


### PR DESCRIPTION
## Summary

sophliteos+bmssm 对接的 AI Agent 后端整体切到 **Reasonix**，并补齐 5 项能力（MYS-177）：deb 内嵌 Reasonix、配置页服务管理改管 Reasonix、删除随机 key、默认模型名称 +「覆盖下游请求」开关、chatUI 连续信息拆泡修复。

## 变更点

### 1. deb 打包内嵌 Reasonix
- `source/pbmssm/build/build-deb-bmssm.sh`：新增可选参数 `REASONIX_BIN`，传入即把 reasonix 打进 deb 的 `/opt/sophon/reasonix/bin/reasonix`，并把打包 yaml 设为 `agentproxy.enabled: true`、`binaryPath` 指向内嵌二进制。
- `source/pbmssm/release.sh`：透传 `REASONIX_BIN`（`$3` / env）。

### 2. 配置页服务管理改管 Reasonix（非 picoclaw）
- 新增 `source/pbmssm/mvc/agentproxy/controller.go`：`GetServiceStatus`（enabled/存活/pid/端口18990/日志/健康）+ `ServiceAction`（start/stop/restart；enable/disable 因随 bmssm 托管返回清晰提示）。
- `agentproxy/process.go`：新增公开 `Stop()`、`Restart()`。
- `router.go`：把 `/llm-proxy/service/status`、`/llm-proxy/service/action` 从 sophpicoclaw 重指到 agentproxy 控制器。
- 前端 `apiConfig`：服务管理块改为 Reasonix 文案，移除「启用自启/关闭自启」按钮。
- 新增 `controller_test.go`。

### 3. 删除配置页随机 key
- `apiConfig/index.vue` 删除整个「转发 Key 管理」块及相关函数/字段（后端 llm-proxy 本就放行不校验 key，MYS-171 已放宽）。

### 4. 默认模型名称 +「覆盖下游请求」开关
- 后端：`types.go` Config 增 `llm/vlm_override_model` 列；`test.go` `forwardLLM` 转发逻辑——开关开→强制替换为默认模型名，关→仅无 model 时兜底；`migrate.go` 补列；`service.go`/`controller.go` 透传。
- 前端：label「模型名称」→「默认模型名称」，新增「覆盖下游请求」开关。
- 新增 `TestForwardModelOverride`。

### 5. chatUI 连续信息拆泡修复
- 根因：agentproxy 把同一回复拆成多个 text message_id，前端逐 create 建泡。
- `web-client/js/chat.js`：无用户打断的相邻 text create 合并到同一气泡（根条目 + 别名映射，同步 update 与会话持久化）；用户消息/切会话/thought/tool_calls 打断则另起组。

## 测试

- 后端 `go build ./...` 通过；`mvc/llmproxy`、`mvc/agentproxy`、`router` 测试全绿（含新增 `TestForwardModelOverride`、`controller_test.go`）。
- deb 试打（amd64 + 测试机 arm64 reasonix）：验证了内嵌路径、权限、`bmssm.yaml` 的 `agentproxy` 已启用、`md5sums` 含 reasonix。
- chat.js 合并逻辑已用 node 模拟三种场景（连续 text 合并 / 用户打断另起 / text-tool-text 独立）。

> 前端未跑完整 `pnpm build`（worktree 无 node_modules）；改动已做模板平衡 + TS 语法（@ts-nocheck）+ `node --check` 校验，建议在完整前端构建环境再验一次。
