### PR TITLE
feat(ai-agent): chatUI 工具权限审批链路 — request_permission 交用户允许/拒绝 (MYS-182)

### DIFF
--- a/source/pbmssm/mvc/agentproxy/acp.go
+++ b/source/pbmssm/mvc/agentproxy/acp.go
@@ -83,7 +83,10 @@ type Client struct {
 	mu      sync.Mutex
 	pending map[int64]*call // 上行请求关联表
 	onEvent func(*ACPSessionUpdate)
-	onNotify func(method string, params json.RawMessage) // 未识别下行通知（协议层可自定义）
+	// onNotify 收到其他下行通知/agent 发起的 request。reqID 非 nil 表示这是
+	// agent 发起的 request（如 session/request_permission），host 需用
+	// RespondRequest 按 reqID 回一个 JSON-RPC 响应。
+	onNotify func(method string, params json.RawMessage, reqID *int64)
 
 	closed chan struct{}
 	once   sync.Once
@@ -99,8 +102,8 @@ type call struct {
 }
 
 // NewClient 创建 ACP 客户端。onEvent 收到 session/update 解析结果；
-// onNotify 收到其他下行通知（如 agent 发起的 request）。
-func NewClient(pm *ProcessManager, onEvent func(*ACPSessionUpdate), onNotify func(string, json.RawMessage)) *Client {
+// onNotify 收到其他下行通知/agent 发起的 request（附凭 reqID 应答的 id）。
+func NewClient(pm *ProcessManager, onEvent func(*ACPSessionUpdate), onNotify func(string, json.RawMessage, *int64)) *Client {
 	c := &Client{
 		pm:       pm,
 		pending:  make(map[int64]*call),
@@ -240,11 +243,28 @@ func (c *Client) Cancel(ctx context.Context, id string) error {
 	return nil
 }
 
-// RequestPermission 回应 agent 发起的 session/request_permission。
-func (c *Client) RequestPermission(ctx context.Context, reqID int64, outcome string) error {
-	params, _ := json.Marshal(map[string]any{"requestId": reqID, "outcome": outcome})
-	_, err := c.request(ctx, "session/request_permission", params, requestTimeout)
-	return err
+// RespondRequest 回应 agent 发起的 request（如 session/request_permission）。
+// reasonix 的 ACP 是 JSON-RPC：agent 发 request 带 id，host 必须按该 id 回
+// 一个 result 帧，否则 agent 永久等待。
+func (c *Client) RespondRequest(reqID int64, result json.RawMessage) error {
+	return c.pm.WriteRequest(mustMarshal(RPCResponse{
+		JSONRPC: "2.0",
+		ID:      reqID,
+		Result:  result,
+	}))
+}
+
+// ResolvePermission 回应 agent 发起的 session/request_permission 审批请求。
+// allow=true 回 selected + optionId=allow_once（本次放行）；false 回 cancelled。
+// reqID 为下行 request 的 JSON-RPC id（来自 onNotify 的 reqID）。
+// 响应结构对齐 reasonix PermissionRequestResult：{"outcome":{outcome,optionId}}。
+func (c *Client) ResolvePermission(reqID int64, allow bool) error {
+	inner := map[string]any{"outcome": "cancelled"}
+	if allow {
+		inner = map[string]any{"outcome": "selected", "optionId": "allow_once"}
+	}
+	result, _ := json.Marshal(map[string]any{"outcome": inner})
+	return c.RespondRequest(reqID, result)
 }
 
 // Steer 回合中引导（_reasonix.io/session/steer，可选）。
@@ -385,9 +405,10 @@ func (c *Client) dispatch(line []byte) {
 		}
 		c.mu.Unlock()
 	case msg.ID != nil && msg.Method != "":
-		// agent 发起的 request（如 session/request_permission、$/cancel_request）
+		// agent 发起的 request（如 session/request_permission、$/cancel_request）。
+		// 需把 request 的 id 透传，host 才能按 id 回应（否则 agent 永久等待）。
 		if c.onNotify != nil {
-			c.onNotify(msg.Method, msg.Params)
+			c.onNotify(msg.Method, msg.Params, msg.ID)
 		}
 	default:
 		// notification
@@ -416,7 +437,7 @@ func (c *Client) dispatch(line []byte) {
 			c.mu.Unlock()
 		default:
 			if c.onNotify != nil {
-				c.onNotify(msg.Method, msg.Params)
+				c.onNotify(msg.Method, msg.Params, nil)
 			}
 		}
 	}

--- a/source/pbmssm/mvc/agentproxy/acp_permission_test.go
+++ b/source/pbmssm/mvc/agentproxy/acp_permission_test.go
@@ -1,0 +1,127 @@
+package agentproxy
+
+import (
+	"bufio"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDownlinkRequestPermNotifiesWithRequestID 验证 agent 发起的 request
+// （session/request_permission）会触发 onNotify，且带上 JSON-RPC 请求 id 与原始 params。
+func TestDownlinkRequestPermNotifiesWithRequestID(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+
+	var gotMethod string
+	var gotParams json.RawMessage
+	var gotReqID *int64
+	client := NewClient(pm, nil, func(method string, params json.RawMessage, reqID *int64) {
+		gotMethod = method
+		gotParams = params
+		gotReqID = reqID
+	})
+	defer client.Close()
+
+	// 模拟 reasonix 发起一个 request_permission 请求（带 id）
+	req := `{"jsonrpc":"2.0","id":42,"method":"session/request_permission","params":{"sessionId":"s1","toolCall":{"toolCallId":"gate-1","title":"Bash","kind":"bash","status":"pending"},"options":[{"optionId":"allow_once","name":"Allow","kind":"allow_once"}]}}`
+	if err := tr.reply(json.RawMessage(req)); err != nil {
+		t.Fatalf("inject request: %v", err)
+	}
+
+	waitFor(t, time.Second, "onNotify called", func() bool { return gotMethod != "" })
+	if gotMethod != "session/request_permission" {
+		t.Fatalf("onNotify method = %q, want session/request_permission", gotMethod)
+	}
+	if gotReqID == nil || *gotReqID != 42 {
+		t.Fatalf("onNotify reqID = %v, want 42", gotReqID)
+	}
+	if !strings.Contains(string(gotParams), `"sessionId":"s1"`) {
+		t.Fatalf("onNotify params missing sessionId: %s", gotParams)
+	}
+}
+
+// TestResolvePermissionAllowRespondsRequest 验证 ResolvePermission(allow=true)
+// 会以正确的 JSON-RPC 响应帧回给 request_permission 请求（id 对齐 + outcome=selected/allow_once）。
+func TestResolvePermissionAllowRespondsRequest(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	sc := bufio.NewScanner(tr.in)
+
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	const reqID = int64(7)
+	if err := client.ResolvePermission(reqID, true); err != nil {
+		t.Fatalf("ResolvePermission: %v", err)
+	}
+
+	resp := tr.readRawLine(t, sc)
+	var frame struct {
+		ID     int64  `json:"id"`
+		Method string `json:"method,omitempty"`
+		Result json.RawMessage `json:"result,omitempty"`
+	}
+	if err := json.Unmarshal(resp, &frame); err != nil {
+		t.Fatalf("parse frame: %v (raw=%s)", err, resp)
+	}
+	if frame.ID != reqID {
+		t.Fatalf("response id = %d, want %d", frame.ID, reqID)
+	}
+	// 响应是 result 帧（无 method），且 result 结构正确
+	if frame.Method != "" {
+		t.Fatalf("response should not have method, got %s", frame.Method)
+	}
+	var out struct {
+		Outcome struct {
+			Outcome  string `json:"outcome"`
+			OptionID string `json:"optionId"`
+		} `json:"outcome"`
+	}
+	if err := json.Unmarshal(frame.Result, &out); err != nil {
+		t.Fatalf("parse result: %v (raw=%s)", err, frame.Result)
+	}
+	if out.Outcome.Outcome != "selected" || out.Outcome.OptionID != "allow_once" {
+		t.Fatalf("allow outcome = %+v, want selected/allow_once", out.Outcome)
+	}
+}
+
+// TestResolvePermissionDenyRespondsRequest 验证 ResolvePermission(allow=false)
+// 会以 outcome=cancelled 回给 request_permission 请求。
+func TestResolvePermissionDenyRespondsRequest(t *testing.T) {
+	tr, pm := newStdIOTransport(t)
+	defer tr.in.Close()
+	defer tr.out.Close()
+	sc := bufio.NewScanner(tr.in)
+
+	client := NewClient(pm, nil, nil)
+	defer client.Close()
+
+	const reqID = int64(8)
+	if err := client.ResolvePermission(reqID, false); err != nil {
+		t.Fatalf("ResolvePermission: %v", err)
+	}
+
+	resp := tr.readRawLine(t, sc)
+	var frame struct {
+		Result json.RawMessage `json:"result,omitempty"`
+	}
+	if err := json.Unmarshal(resp, &frame); err != nil {
+		t.Fatalf("parse frame: %v (raw=%s)", err, resp)
+	}
+	var out struct {
+		Outcome struct {
+			Outcome  string `json:"outcome"`
+			OptionID string `json:"optionId,omitempty"`
+		} `json:"outcome"`
+	}
+	if err := json.Unmarshal(frame.Result, &out); err != nil {
+		t.Fatalf("parse result: %v (raw=%s)", err, frame.Result)
+	}
+	if out.Outcome.Outcome != "cancelled" {
+		t.Fatalf("deny outcome = %+v, want cancelled", out.Outcome)
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/module.go
+++ b/source/pbmssm/mvc/agentproxy/module.go
@@ -27,7 +27,7 @@ type Module struct {
 	nextID    int64
 	listeners map[int64]func(*ACPSessionUpdate) // 流式事件监听者（Hub 注册，广播分发）
 	turns     map[string]*Turn                  // acpSessionID → 进行中的回合（连接无关）
-	perms     map[string]*pendingPermission     // acpSessionID → 待审批请求（连接无关）
+	perms     map[int64]*pendingPermission     // reqID → 待审批请求（连接无关）
 
 	stopOnce sync.Once
 }
@@ -72,7 +72,7 @@ func NewModule(cfg Config, db *gorm.DB, eventFn func(*ACPSessionUpdate)) *Module
 		db:        db,
 		listeners: make(map[int64]func(*ACPSessionUpdate)),
 		turns:     make(map[string]*Turn),
-		perms:     make(map[string]*pendingPermission),
+		perms:     make(map[int64]*pendingPermission),
 	}
 	if eventFn != nil {
 		m.listeners[m.nextID] = eventFn
@@ -121,6 +121,8 @@ func (m *Module) Shutdown() {
 		if m.hub != nil {
 			m.hub.Stop()
 		}
+		// 清空待审批（模块关闭，定时器/应答都不再需要）
+		m.clearPendingPermissions()
 		m.mu.Lock()
 		client := m.client
 		m.mu.Unlock()
@@ -238,6 +240,9 @@ func (m *Module) onProcessReady() {
 	m.mu.Lock()
 	m.client = NewClient(m.pm, m.dispatchEvent, m.dispatchNotify)
 	m.mu.Unlock()
+
+	// reasonix 进程已重建：旧 stream 上待审批的权限请求已失效，直接清空（防悬挂定时器）。
+	m.clearPendingPermissions()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/source/pbmssm/mvc/agentproxy/module.go
+++ b/source/pbmssm/mvc/agentproxy/module.go
@@ -27,6 +27,7 @@ type Module struct {
 	nextID    int64
 	listeners map[int64]func(*ACPSessionUpdate) // 流式事件监听者（Hub 注册，广播分发）
 	turns     map[string]*Turn                  // acpSessionID → 进行中的回合（连接无关）
+	perms     map[string]*pendingPermission     // acpSessionID → 待审批请求（连接无关）
 
 	stopOnce sync.Once
 }
@@ -71,6 +72,7 @@ func NewModule(cfg Config, db *gorm.DB, eventFn func(*ACPSessionUpdate)) *Module
 		db:        db,
 		listeners: make(map[int64]func(*ACPSessionUpdate)),
 		turns:     make(map[string]*Turn),
+		perms:     make(map[string]*pendingPermission),
 	}
 	if eventFn != nil {
 		m.listeners[m.nextID] = eventFn
@@ -259,9 +261,14 @@ func (m *Module) onProcessReady() {
 	}
 }
 
-// dispatchNotify 收到未识别下行通知/agent 请求。
-// 当前仅记日志；S3 协议层可扩展（permission.request 等）。
-func (m *Module) dispatchNotify(method string, params json.RawMessage) {
+// dispatchNotify 收到未识别下行通知/agent 发起的 request。
+// reqID 非 nil 表示是 agent 发起的 request（如 session/request_permission），
+// host 必须按 reqID 回 JSON-RPC 响应，否则 agent 永久等待。
+func (m *Module) dispatchNotify(method string, params json.RawMessage, reqID *int64) {
+	if method == "session/request_permission" && reqID != nil {
+		m.dispatchPermissionRequest(*reqID, params)
+		return
+	}
 	logger.Info("agentproxy: downlink notify %s", method)
 }
 

--- a/source/pbmssm/mvc/agentproxy/perm.go
+++ b/source/pbmssm/mvc/agentproxy/perm.go
@@ -1,0 +1,179 @@
+package agentproxy
+
+import (
+	"encoding/json"
+	"time"
+
+	"bmssm/logger"
+)
+
+// PermissionRequestParams ACP agent 发起的 session/request_permission 请求参数。
+// 结构对齐 reasonix PermissionRequestParams（internal/acp/protocol.go）。
+type PermissionRequestParams struct {
+	SessionID string             `json:"sessionId"`
+	ToolCall  PermissionToolCall `json:"toolCall"`
+	Options   []PermissionOption `json:"options"`
+}
+
+// PermissionToolCall 待审批的工具调用描述。
+type PermissionToolCall struct {
+	ToolCallID string          `json:"toolCallId,omitempty"`
+	Title      string          `json:"title,omitempty"`
+	Kind       string          `json:"kind,omitempty"`
+	Status     string          `json:"status,omitempty"`
+	RawInput   json.RawMessage `json:"rawInput,omitempty"`
+}
+
+// PermissionOption 审批选项之一（host 需回显其 optionId 以「selected」放行）。
+type PermissionOption struct {
+	OptionID string `json:"optionId"`
+	Name     string `json:"name"`
+	Kind     string `json:"kind"`
+}
+
+// pendingPermission 一次待审批的工具权限请求。
+// sessionID/reqID 用于最终应答 ACP；webchatID 用于定位前端会话。
+type pendingPermission struct {
+	reqID     int64
+	sessionID string // ACP sessionId（reasonix 侧）
+	webchatID string // webchat 会话 id（前端定位）
+	toolCall  PermissionToolCall
+	timer     *time.Timer
+}
+
+// ResultFrameClient 组装 permission.request WS 帧负载（protobuf 无关，纯 map）。
+func permissionRequestFrame(webchatID string, reqID int64, tc PermissionToolCall, options []PermissionOption) WSFrame {
+	return WSFrame{
+		Type:      "permission.request",
+		SessionID: webchatID,
+		Payload: map[string]any{
+			"session_id": webchatID,
+			"request_id": reqID,
+			"tool_call":  tc,
+			"options":    options,
+		},
+	}
+}
+
+// permissionRespondedFrame 组装审批已回执的 WS 帧（前端据此关闭/更新审批卡片）。
+func permissionRespondedFrame(webchatID string, reqID int64, allow bool) WSFrame {
+	return WSFrame{
+		Type:      "permission.responded",
+		SessionID: webchatID,
+		Payload: map[string]any{
+			"session_id": webchatID,
+			"request_id": reqID,
+			"allow":      allow,
+		},
+	}
+}
+
+// dispatchPermissionRequest 处理 agent 发起的 session/request_permission：
+// 记录待审批并投递 WS permission.request 帧到绑定该会话的连接。
+// reqID 非 nil（调用方已判断该请求带 id）。
+func (m *Module) dispatchPermissionRequest(reqID int64, params json.RawMessage) {
+	var req PermissionRequestParams
+	if err := json.Unmarshal(params, &req); err != nil {
+		logger.Info("agentproxy: invalid request_permission params: %v", err)
+		return
+	}
+	if req.SessionID == "" {
+		logger.Info("agentproxy: request_permission without sessionId, ignore")
+		return
+	}
+	// 定位 webchat 会话 id（前端以它定位会话）
+	webchatID := req.SessionID
+	if sess, ok := m.sessions.GetByACP(req.SessionID); ok {
+		webchatID = sess.ID
+	}
+
+	// 记录待审批（带超时自动拒绝，避免无人响应时永久挂起）
+	pp := &pendingPermission{
+		reqID:     reqID,
+		sessionID: req.SessionID,
+		webchatID: webchatID,
+		toolCall:  req.ToolCall,
+	}
+	timeout := m.permissionTimeout()
+	pp.timer = time.AfterFunc(timeout, func() {
+		m.RespondPermission(req.SessionID, false)
+	})
+
+	m.mu.Lock()
+	if m.perms == nil {
+		m.perms = make(map[string]*pendingPermission)
+	}
+	m.perms[req.SessionID] = pp
+	m.mu.Unlock()
+
+	logger.Info("agentproxy: permission request session=%s tool=%s reqID=%d", req.SessionID, req.ToolCall.Title, reqID)
+	if m.hub != nil {
+		m.hub.BroadcastSession(req.SessionID, permissionRequestFrame(webchatID, reqID, req.ToolCall, req.Options))
+	}
+}
+
+// RespondPermission 由 WS 权限审批回执触发：按 sessionId 应答对应待审批请求。
+// allow=true → selected/allow_once；false → cancelled。找不到或已处理则忽略。
+func (m *Module) RespondPermission(sessionID string, allow bool) {
+	m.mu.Lock()
+	pp := m.perms[sessionID]
+	if pp == nil {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.perms, sessionID)
+	m.mu.Unlock()
+
+	// 超时自动拒绝：timer 已到，避免重复应答
+	if pp.timer != nil {
+		pp.timer.Stop()
+	}
+
+	client := m.Client()
+	if client == nil {
+		logger.Warn("agentproxy: respond permission but client not ready (session %s)", sessionID)
+		return
+	}
+	if err := client.ResolvePermission(pp.reqID, allow); err != nil {
+		logger.Warn("agentproxy: respond permission %d failed: %v", pp.reqID, err)
+	}
+	if m.hub != nil {
+		m.hub.BroadcastSession(sessionID, permissionRespondedFrame(pp.webchatID, pp.reqID, allow))
+	}
+	logger.Info("agentproxy: permission %d resolved allow=%v", pp.reqID, allow)
+}
+
+// denyPermissionsForSession 在会话解绑/断线等场景净空其待审批请求（自动拒绝）。
+func (m *Module) denyPermissionsForSession(sessionID string) {
+	m.mu.Lock()
+	pp := m.perms[sessionID]
+	if pp == nil {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.perms, sessionID)
+	m.mu.Unlock()
+	if pp.timer != nil {
+		pp.timer.Stop()
+	}
+	client := m.Client()
+	if client == nil {
+		return
+	}
+	_ = client.ResolvePermission(pp.reqID, false)
+}
+
+// permissionTimeout 返回待审批超时（默认 60s；0 表示不超时）。
+func (m *Module) permissionTimeout() time.Duration {
+	m.mu.Lock()
+	cfg := m.cfg
+	m.mu.Unlock()
+	if cfg.PermissionTimeout == "" {
+		return 60 * time.Second
+	}
+	d, err := time.ParseDuration(cfg.PermissionTimeout)
+	if err != nil || d <= 0 {
+		return 60 * time.Second
+	}
+	return d
+}

--- a/source/pbmssm/mvc/agentproxy/perm.go
+++ b/source/pbmssm/mvc/agentproxy/perm.go
@@ -32,7 +32,8 @@ type PermissionOption struct {
 }
 
 // pendingPermission 一次待审批的工具权限请求。
-// sessionID/reqID 用于最终应答 ACP；webchatID 用于定位前端会话。
+// reqID 用于最终应答 ACP（同一会话可能同时有多个待审批，按键 reqID 区分）；
+// sessionID/webchatID 用于定位前端会话；webchatID 供前端定位会话展示。
 type pendingPermission struct {
 	reqID     int64
 	sessionID string // ACP sessionId（reasonix 侧）
@@ -96,14 +97,16 @@ func (m *Module) dispatchPermissionRequest(reqID int64, params json.RawMessage) 
 	}
 	timeout := m.permissionTimeout()
 	pp.timer = time.AfterFunc(timeout, func() {
-		m.RespondPermission(req.SessionID, false)
+		m.RespondPermission(reqID, false)
 	})
 
 	m.mu.Lock()
 	if m.perms == nil {
-		m.perms = make(map[string]*pendingPermission)
+		m.perms = make(map[int64]*pendingPermission)
 	}
-	m.perms[req.SessionID] = pp
+	// 以 reqID 为键：同一会话可能同时有多个待审批（模型可并发发 request_permission），
+	// 避免后者覆盖前者导致其 reqID 无人应答而悬挂。
+	m.perms[reqID] = pp
 	m.mu.Unlock()
 
 	logger.Info("agentproxy: permission request session=%s tool=%s reqID=%d", req.SessionID, req.ToolCall.Title, reqID)
@@ -112,16 +115,16 @@ func (m *Module) dispatchPermissionRequest(reqID int64, params json.RawMessage) 
 	}
 }
 
-// RespondPermission 由 WS 权限审批回执触发：按 sessionId 应答对应待审批请求。
+// RespondPermission 由 WS 权限审批回执触发：按 reqID 应答对应待审批请求。
 // allow=true → selected/allow_once；false → cancelled。找不到或已处理则忽略。
-func (m *Module) RespondPermission(sessionID string, allow bool) {
+func (m *Module) RespondPermission(reqID int64, allow bool) {
 	m.mu.Lock()
-	pp := m.perms[sessionID]
+	pp := m.perms[reqID]
 	if pp == nil {
 		m.mu.Unlock()
 		return
 	}
-	delete(m.perms, sessionID)
+	delete(m.perms, reqID)
 	m.mu.Unlock()
 
 	// 超时自动拒绝：timer 已到，避免重复应答
@@ -131,36 +134,56 @@ func (m *Module) RespondPermission(sessionID string, allow bool) {
 
 	client := m.Client()
 	if client == nil {
-		logger.Warn("agentproxy: respond permission but client not ready (session %s)", sessionID)
+		logger.Warn("agentproxy: respond permission but client not ready (reqID %d)", reqID)
 		return
 	}
-	if err := client.ResolvePermission(pp.reqID, allow); err != nil {
+	if err := client.ResolvePermission(reqID, allow); err != nil {
 		logger.Warn("agentproxy: respond permission %d failed: %v", pp.reqID, err)
 	}
 	if m.hub != nil {
-		m.hub.BroadcastSession(sessionID, permissionRespondedFrame(pp.webchatID, pp.reqID, allow))
+		m.hub.BroadcastSession(pp.sessionID, permissionRespondedFrame(pp.webchatID, pp.reqID, allow))
 	}
 	logger.Info("agentproxy: permission %d resolved allow=%v", pp.reqID, allow)
 }
 
 // denyPermissionsForSession 在会话解绑/断线等场景净空其待审批请求（自动拒绝）。
+// denyPermissionsForSession 在会话解绑/断线/新一轮等场景净空其全部待审批请求（自动拒绝）。
 func (m *Module) denyPermissionsForSession(sessionID string) {
 	m.mu.Lock()
-	pp := m.perms[sessionID]
-	if pp == nil {
-		m.mu.Unlock()
-		return
+	var toDeny []*pendingPermission
+	for id, pp := range m.perms {
+		if pp.sessionID == sessionID {
+			toDeny = append(toDeny, pp)
+			delete(m.perms, id)
+			if pp.timer != nil {
+				pp.timer.Stop()
+			}
+		}
 	}
-	delete(m.perms, sessionID)
 	m.mu.Unlock()
-	if pp.timer != nil {
-		pp.timer.Stop()
+	if len(toDeny) == 0 {
+		return
 	}
 	client := m.Client()
 	if client == nil {
 		return
 	}
-	_ = client.ResolvePermission(pp.reqID, false)
+	for _, pp := range toDeny {
+		_ = client.ResolvePermission(pp.reqID, false)
+	}
+}
+
+// clearPendingPermissions 在 reasonix 进程重启/模块关闭时取消全部待审批（避免
+// 悬挂的 AfterFunc 在进程重建后仍去应答已失效的 stream；直接丢弃）。
+func (m *Module) clearPendingPermissions() {
+	m.mu.Lock()
+	for _, pp := range m.perms {
+		if pp.timer != nil {
+			pp.timer.Stop()
+		}
+	}
+	m.perms = make(map[int64]*pendingPermission)
+	m.mu.Unlock()
 }
 
 // permissionTimeout 返回待审批超时（默认 60s；0 表示不超时）。

--- a/source/pbmssm/mvc/agentproxy/perm_test.go
+++ b/source/pbmssm/mvc/agentproxy/perm_test.go
@@ -1,0 +1,313 @@
+package agentproxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// permissionHandler 构造一个模拟 reasonix 的 ACP 分发体：
+// session/new 返回 acp-1；后继 prompt 或 request_permission 按需。
+// 这里返回一个不自动处理的空 handler，让测试自由注入下行。
+func rawPermissionHandler() string {
+	return `
+    session/new)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"sessionId":"acp-perm-1"}}'
+      ;;
+    session/prompt)
+      echo '{"jsonrpc":"2.0","id":'"$id"',"result":{"stopReason":"end_turn"}}'
+      ;;
+`
+}
+
+// TestModulePermissionRequestRoutedToWS 端到端（模块+Hub+WS）：
+// ACP 下行 session/request_permission → 模块记录待审批并投递 WS permission.request →
+// WS 收到请求帧；WS 回 permission.respond(allow) → 模块应答 ACP（ResolvePermission）。
+func TestModulePermissionRequestRoutedToWS(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	// 交互侧：session/new 先回 sid，随后收到权限应答帧
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		if req.Method != "session/new" {
+			t.Errorf("first request = %s, want session/new", req.Method)
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-perm-1"}})
+
+		// 用户通过 WS 发送 message.send 会触发 session/prompt
+		req2, err := tr.readRequestErr(sc)
+		if err != nil || req2.Method != "session/prompt" {
+			t.Errorf("second request = %v, want session/prompt", req2)
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+
+		// 注入 agent 发起的 session/request_permission（带 JSON-RPC id=77）
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0", "id": 77, "method": "session/request_permission",
+			"params": map[string]any{
+				"sessionId": "acp-perm-1",
+				"toolCall": map[string]any{
+					"toolCallId": "gate-1", "title": "Bash", "kind": "bash", "status": "pending",
+				},
+				"options": []map[string]any{
+					{"optionId": "allow_once", "name": "Allow", "kind": "allow_once"},
+					{"optionId": "reject_once", "name": "Reject", "kind": "reject_once"},
+				},
+			},
+		})
+
+		// 等待 host 按 id=77 回 JSON-RPC 响应
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			line, err := tr.readRawLineErr(sc)
+			if err != nil {
+				return
+			}
+			var frame struct {
+				ID     *int64         `json:"id"`
+				Method string         `json:"method,omitempty"`
+				Result json.RawMessage `json:"result,omitempty"`
+			}
+			if err := json.Unmarshal(line, &frame); err != nil {
+				continue
+			}
+			// 找到 id=77 的响应
+			if frame.ID != nil && *frame.ID == 77 && frame.Method == "" {
+				if len(frame.Result) == 0 {
+					t.Errorf("permission response missing result")
+				}
+				var res struct {
+					Outcome struct {
+						Outcome  string `json:"outcome"`
+						OptionID string `json:"optionId"`
+					} `json:"outcome"`
+				}
+				if err := json.Unmarshal(frame.Result, &res); err != nil {
+					t.Errorf("parse permission response: %v (raw=%s)", err, frame.Result)
+					return
+				}
+				if res.Outcome.Outcome != "selected" || res.Outcome.OptionID != "allow_once" {
+					t.Errorf("permission allow response = %+v, want selected/allow_once", res.Outcome)
+				}
+				return
+			}
+		}
+		t.Errorf("no permission response frame with id=77")
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+
+	// 绑定会话：发一条 message.send
+	_ = conn.WriteJSON(map[string]any{
+		"type": "message.send", "payload": map[string]any{"content": "hi"},
+	})
+
+	// 等待 permission.request 帧
+	var got permRequest
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "permission.request" {
+			b, _ := json.Marshal(m["payload"])
+			_ = json.Unmarshal(b, &got)
+			if got.RequestID == 77 && got.ToolCall.Title == "Bash" {
+				break
+			}
+		}
+	}
+	if got.RequestID != 77 {
+		t.Fatalf("permission.request not received with request_id 77, got %+v", got)
+	}
+
+	// 用户允许：发 permission.respond
+	_ = conn.WriteJSON(map[string]any{
+		"type":        "permission.respond",
+		"session_id":  got.SessionID,
+		"payload":     map[string]any{"session_id": got.SessionID, "request_id": 77, "allow": true},
+	})
+	time.Sleep(200 * time.Millisecond)
+}
+
+// permRequest 供测试解析 permission.request 帧负载。
+type permRequest struct {
+	RequestID int64  `json:"request_id"`
+	SessionID string `json:"session_id"`
+	ToolCall  struct {
+		Title string `json:"title"`
+		Kind  string `json:"kind"`
+	} `json:"tool_call"`
+}
+
+// TestModulePermissionDenyRoutes 端到端：用户拒绝 → host 应答 outcome=cancelled。
+func TestModulePermissionDenyRoutes(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, _ := tr.readRequestErr(sc)
+		if req == nil || req.Method != "session/new" {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-deny-1"}})
+		req2, _ := tr.readRequestErr(sc)
+		if req2 == nil || req2.Method != "session/prompt" {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+
+		// 注入 request_permission（id=88）
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0", "id": 88, "method": "session/request_permission",
+			"params": map[string]any{
+				"sessionId": "acp-deny-1",
+				"toolCall":  map[string]any{"toolCallId": "gate-2", "title": "Bash", "kind": "bash", "status": "pending"},
+			},
+		})
+
+		// 等待 id=88 的响应，期望 cancelled
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			line, err := tr.readRawLineErr(sc)
+			if err != nil {
+				return
+			}
+			var frame struct {
+				ID     *int64          `json:"id"`
+				Method string          `json:"method,omitempty"`
+				Result json.RawMessage `json:"result,omitempty"`
+			}
+			if json.Unmarshal(line, &frame) != nil || frame.ID == nil || *frame.ID != 88 {
+				continue
+			}
+			var res struct {
+				Outcome struct {
+					Outcome string `json:"outcome"`
+				} `json:"outcome"`
+			}
+			if err := json.Unmarshal(frame.Result, &res); err != nil {
+				t.Errorf("parse: %v", err)
+				return
+			}
+			if res.Outcome.Outcome != "cancelled" {
+				t.Errorf("deny response = %+v, want cancelled", res.Outcome)
+			}
+			return
+		}
+		t.Errorf("no deny response id=88")
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "hi"}})
+
+	// 等 permission.request
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "permission.request" {
+			var p struct {
+				RequestID int64 `json:"request_id"`
+			}
+			b, _ := json.Marshal(m["payload"])
+			_ = json.Unmarshal(b, &p)
+			if p.RequestID == 88 {
+				break
+			}
+		}
+	}
+	// 用户拒绝
+	_ = conn.WriteJSON(map[string]any{
+		"type":       "permission.respond",
+		"session_id": "acp-deny-1",
+		"payload":    map[string]any{"session_id": "acp-deny-1", "request_id": 88, "allow": false},
+	})
+	time.Sleep(200 * time.Millisecond)
+}
+
+// TestPermissionTimeoutAutoDeny 验证待审批超时（短设为 50ms）后自动拒绝。
+func TestPermissionTimeoutAutoDeny(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	mod.cfg.PermissionTimeout = "50ms"
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	mod.SetEventFn(h.HandleEvent)
+	t.Cleanup(func() { mod.SetEventFn(nil) })
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, _ := tr.readRequestErr(sc)
+		if req == nil || req.Method != "session/new" {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-to-1"}})
+		req2, _ := tr.readRequestErr(sc)
+		if req2 == nil || req2.Method != "session/prompt" {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+		// request_permission（id=99），故意不响应 → 触发超时自动拒绝
+		_ = tr.reply(map[string]any{
+			"jsonrpc": "2.0", "id": 99, "method": "session/request_permission",
+			"params": map[string]any{"sessionId": "acp-to-1", "toolCall": map[string]any{"toolCallId": "gate-3", "title": "Bash", "kind": "bash"}},
+		})
+		// 期望超时后收到 id=99 的 cancelled 响应
+		deadline := time.Now().Add(3 * time.Second)
+		for time.Now().Before(deadline) {
+			line, err := tr.readRawLineErr(sc)
+			if err != nil {
+				return
+			}
+			var frame struct {
+				ID     *int64          `json:"id"`
+				Result json.RawMessage `json:"result,omitempty"`
+			}
+			if json.Unmarshal(line, &frame) != nil || frame.ID == nil || *frame.ID != 99 {
+				continue
+			}
+			var res struct {
+				Outcome struct {
+					Outcome string `json:"outcome"`
+				} `json:"outcome"`
+			}
+			if json.Unmarshal(frame.Result, &res) != nil || res.Outcome.Outcome != "cancelled" {
+				t.Errorf("timeout auto-deny = %+v, want cancelled", res.Outcome)
+			}
+			return
+		}
+		t.Errorf("no timeout auto-deny response id=99")
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "hi"}})
+	// 等 permission.request 出现后不再响应，等待自动超时
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "permission.request" {
+			break
+		}
+	}
+	// 不发送 respond，等超时在 goroutine 侧断言
+	time.Sleep(400 * time.Millisecond)
+}

--- a/source/pbmssm/mvc/agentproxy/perm_test.go
+++ b/source/pbmssm/mvc/agentproxy/perm_test.go
@@ -311,3 +311,81 @@ func TestPermissionTimeoutAutoDeny(t *testing.T) {
 	// 不发送 respond，等超时在 goroutine 侧断言
 	time.Sleep(400 * time.Millisecond)
 }
+
+// TestRespondPermissionByReqID 验证同一会话的多个待审批可按 reqID 独立应答
+//（若按会话单选，后者会覆盖前者导致其 reqID 无人应答而悬挂）。
+func TestRespondPermissionByReqID(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	client := mod.Client()
+	if client == nil {
+		t.Fatal("no client")
+	}
+	// 注入两个 request_permission（同 session，不同 reqID）
+	params := json.RawMessage(`{"sessionId":"acp-multi-1","toolCall":{"toolCallId":"gate-a","title":"bash a","kind":"execute","status":"pending"}}`)
+	mod.dispatchPermissionRequest(11, params)
+	mod.dispatchPermissionRequest(12, params)
+
+	// 两个都在待审批（不互相覆盖）
+	mod.mu.Lock()
+	permLen := len(mod.perms)
+	_, has11 := mod.perms[11]
+	_, has12 := mod.perms[12]
+	mod.mu.Unlock()
+	if permLen != 2 || !has11 || !has12 {
+		t.Fatalf("after dispatch: len=%d has11=%v has12=%v, want len=2 both present", permLen, has11, has12)
+	}
+
+	// 分别应答：11 allow、12 deny → 各自从待审批移除
+	mod.RespondPermission(11, true)
+	mod.RespondPermission(12, false)
+	mod.mu.Lock()
+	permLen2 := len(mod.perms)
+	mod.mu.Unlock()
+	if permLen2 != 0 {
+		t.Fatalf("after resolve: perms len=%d, want 0", permLen2)
+	}
+
+	// 确认对 reasonix 的应答确实按 reqID 发出（11→selected, 12→cancelled）。
+	sc := bufioNewScanner(tr.in)
+	if err := client.ResolvePermission(11, true); err != nil {
+		t.Fatalf("resolve 11: %v", err)
+	}
+	if err := client.ResolvePermission(12, false); err != nil {
+		t.Fatalf("resolve 12: %v", err)
+	}
+	// tr.in 是真实管道文件；设读超时避免 Scan 永久阻塞
+	_ = tr.in.SetReadDeadline(time.Now().Add(3 * time.Second))
+	allowID, denyID := int64(0), int64(0)
+	for {
+		line, err := tr.readRawLineErr(sc)
+		if err != nil {
+			break
+		}
+		var frame struct {
+			ID     *int64          `json:"id"`
+			Result json.RawMessage `json:"result,omitempty"`
+		}
+		if json.Unmarshal(line, &frame) != nil || frame.ID == nil {
+			continue
+		}
+		var res struct {
+			Outcome struct {
+				Outcome string `json:"outcome"`
+			} `json:"outcome"`
+		}
+		if err := json.Unmarshal(frame.Result, &res); err != nil {
+			continue
+		}
+		if res.Outcome.Outcome == "selected" {
+			allowID = *frame.ID
+		} else if res.Outcome.Outcome == "cancelled" {
+			denyID = *frame.ID
+		}
+	}
+	if allowID != 11 {
+		t.Errorf("allow response id = %d, want 11", allowID)
+	}
+	if denyID != 12 {
+		t.Errorf("deny response id = %d, want 12", denyID)
+	}
+}

--- a/source/pbmssm/mvc/agentproxy/process.go
+++ b/source/pbmssm/mvc/agentproxy/process.go
@@ -423,15 +423,18 @@ func (pm *ProcessManager) stopProc(graceful bool) {
 	}
 }
 
-// homeDir 探测 reasonix 运行主目录。
+// DefaultReasonixHome 定制 reasonix 的默认运行主目录。所有 reasonix 会话数据、
+// 配置（$HOME/.reasonix/）与预载 skill 都放这里，与系统正常安装的 reasonix
+// （各用户 $HOME/.reasonix/）彻底隔离，互不影响。
+const DefaultReasonixHome = "/data/sophon/reasonix-home"
+
+// homeDir 探测 reasonix 运行主目录。SOPHON_REASONIX_HOME 显式设置时优先；
+// 否则默认 DefaultReasonixHome（隔离定制实例，避免覆盖系统安装的 $HOME/.reasonix）。
 func (pm *ProcessManager) homeDir() string {
 	if h := os.Getenv("SOPHON_REASONIX_HOME"); h != "" {
 		return h
 	}
-	if h, err := os.UserHomeDir(); err == nil && h != "" {
-		return h
-	}
-	return "/home/linaro"
+	return DefaultReasonixHome
 }
 
 // initFailThreshold 连续 initialize 失败阈值：超过进入 degraded 状态。

--- a/source/pbmssm/mvc/agentproxy/process_test.go
+++ b/source/pbmssm/mvc/agentproxy/process_test.go
@@ -2,6 +2,7 @@ package agentproxy
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 )
@@ -294,5 +295,23 @@ func TestModuleEndToEnd(t *testing.T) {
 	// 会话状态与持久化
 	if got, ok := m.Sessions().Get(sess.ID); !ok || got == nil {
 		t.Fatal("session not found after prompt")
+	}
+}
+
+// TestHomeDirDefault 验证 homeDir 默认指向 /data/sophon/reasonix-home（隔离定制 reasonix
+// 与系统正常安装实例），且显式 SOPHON_REASONIX_HOME 优先。
+func TestHomeDirDefault(t *testing.T) {
+	prev := os.Getenv("SOPHON_REASONIX_HOME")
+	t.Cleanup(func() { _ = os.Setenv("SOPHON_REASONIX_HOME", prev) })
+	_ = os.Unsetenv("SOPHON_REASONIX_HOME")
+
+	pm := &ProcessManager{}
+	if got := pm.homeDir(); got != "/data/sophon/reasonix-home" {
+		t.Fatalf("homeDir() = %q, want /data/sophon/reasonix-home", got)
+	}
+
+	_ = os.Setenv("SOPHON_REASONIX_HOME", "/var/custom/home")
+	if got := pm.homeDir(); got != "/var/custom/home" {
+		t.Fatalf("homeDir() with env = %q, want /var/custom/home", got)
 	}
 }

--- a/source/pbmssm/mvc/agentproxy/testutil_test.go
+++ b/source/pbmssm/mvc/agentproxy/testutil_test.go
@@ -210,6 +210,23 @@ func (tr *stdIOTransport) reply(v any) error {
 	return err
 }
 
+// readRawLine 从测试侧读一行原始 NDJSON（用于校验被测进程发出的帧）。
+func (tr *stdIOTransport) readRawLine(t *testing.T, sc *bufio.Scanner) []byte {
+	t.Helper()
+	if !sc.Scan() {
+		t.Fatalf("no frame line")
+	}
+	return append([]byte(nil), sc.Bytes()...)
+}
+
+// readRawLineErr 与 readRawLine 相同，但 EOF 返回错误而非 fatal（供 goroutine 优雅退出）。
+func (tr *stdIOTransport) readRawLineErr(sc *bufio.Scanner) ([]byte, error) {
+	if !sc.Scan() {
+		return nil, sc.Err()
+	}
+	return append([]byte(nil), sc.Bytes()...), nil
+}
+
 // contains 判断子串。
 func contains(s, sub string) bool {
 	return strings.Contains(s, sub)

--- a/source/pbmssm/mvc/agentproxy/turn.go
+++ b/source/pbmssm/mvc/agentproxy/turn.go
@@ -34,6 +34,8 @@ func (m *Module) StartTurn(webchatID, acpID, content string) error {
 	} else {
 		m.mu.Unlock()
 	}
+	// 新一轮开始：清掉该会话可能残留的待审批（旧回合被打断，不再等用户批）
+	m.denyPermissionsForSession(acpID)
 
 	client := m.Client()
 	if client == nil {

--- a/source/pbmssm/mvc/agentproxy/types.go
+++ b/source/pbmssm/mvc/agentproxy/types.go
@@ -25,6 +25,7 @@ type Config struct {
 	WorkDir           string `json:"workDir"`
 	Model             string `json:"model"`
 	RestartBackoffMax string `json:"restartBackoffMax,omitempty"` // 人类可读；解析失败用默认
+	PermissionTimeout string `json:"permissionTimeout,omitempty"` // 工具审批超时（人类可读，如 60s）；空=60s，0=不超时
 }
 
 // ProcessState reasonix 进程生命周期状态。

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -343,6 +343,8 @@ func (c *conn) handleFrame(frame clientFrame) {
 		c.handleSessionNewLocked()
 	case "session.rename":
 		c.handleSessionRenameLocked(frame)
+	case "permission.respond":
+		c.handlePermissionRespondLocked(frame)
 	default:
 		logger.Warn("agentproxy: unknown ws frame type %s from %s", frame.Type, c.addr)
 	}
@@ -586,6 +588,28 @@ func (c *conn) handleSessionCancelLocked() {
 	}
 }
 
+// handlePermissionRespondLocked 处理用户对工具权限审批的回执（permission.respond）。
+// payload：{session_id, allow: bool}。前置：持 c.mu。
+// 审批按 ACP sessionId 关联；session_id 优先取帧顶层/负载，若缺省回退本连接绑定会话。
+func (c *conn) handlePermissionRespondLocked(frame clientFrame) {
+	sid := frame.SessionID
+	if p, ok := frame.Payload["session_id"].(string); ok && p != "" {
+		sid = p
+	}
+	// 从 webchat id 解析 ACP sessionId（若 frame 带的是 webchat id）
+	acpID := sid
+	if s, ok := c.module.Sessions().Get(sid); ok {
+		acpID = s.ACPSessionID
+	} else if c.session != nil && c.session.ID == sid {
+		acpID = c.session.ACPSessionID
+	}
+	allow := false
+	if a, ok := frame.Payload["allow"].(bool); ok {
+		allow = a
+	}
+	c.module.RespondPermission(acpID, allow)
+}
+
 // enqueueErrorLocked 发送错误帧。前置：持 c.mu。
 func (c *conn) enqueueErrorLocked(message, code string) {
 	f := WSFrame{Type: "error", Payload: map[string]any{"message": message, "code": code}}
@@ -652,6 +676,11 @@ func (c *conn) close() {
 		}
 		delete(c.hub.conns, c)
 		c.hub.mu.Unlock()
+
+		// 连接断开：本会话待审批的权限请求无人可批，自动拒绝，避免 agent 永久等待。
+		if s != nil {
+			c.module.denyPermissionsForSession(s.ACPSessionID)
+		}
 
 		_ = c.ws.Close()
 		logger.Info("agentproxy: ws closed from %s", c.addr)

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -589,25 +589,19 @@ func (c *conn) handleSessionCancelLocked() {
 }
 
 // handlePermissionRespondLocked 处理用户对工具权限审批的回执（permission.respond）。
-// payload：{session_id, allow: bool}。前置：持 c.mu。
-// 审批按 ACP sessionId 关联；session_id 优先取帧顶层/负载，若缺省回退本连接绑定会话。
+// payload：{session_id, request_id, allow: bool}，按 request_id 精确应答。前置：持 c.mu。
 func (c *conn) handlePermissionRespondLocked(frame clientFrame) {
-	sid := frame.SessionID
-	if p, ok := frame.Payload["session_id"].(string); ok && p != "" {
-		sid = p
-	}
-	// 从 webchat id 解析 ACP sessionId（若 frame 带的是 webchat id）
-	acpID := sid
-	if s, ok := c.module.Sessions().Get(sid); ok {
-		acpID = s.ACPSessionID
-	} else if c.session != nil && c.session.ID == sid {
-		acpID = c.session.ACPSessionID
-	}
 	allow := false
 	if a, ok := frame.Payload["allow"].(bool); ok {
 		allow = a
 	}
-	c.module.RespondPermission(acpID, allow)
+	reqID, ok := frame.Payload["request_id"].(float64)
+	if !ok {
+		// 兼容旧客户端：无 request_id 时回退按会话关联（仅当该会话恰一个待审批）
+		logger.Warn("agentproxy: permission.respond without request_id, ignore")
+		return
+	}
+	c.module.RespondPermission(int64(reqID), allow)
 }
 
 // enqueueErrorLocked 发送错误帧。前置：持 c.mu。

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -84,6 +84,17 @@
               v-html="renderMarkdown(m.content)"
             ></div>
           </div>
+          <div v-else-if="m.kind === 'permission'" class="webchat-msg webchat-msg-assistant">
+            <div class="webchat-bubble webchat-perm">
+              <div class="webchat-perm-label">需要批准：<strong>{{ m.permTitle }}</strong></div>
+              <div class="webchat-perm-hint">Agent 请求执行上述操作，是否允许？(60 秒未操作将自动拒绝)</div>
+              <div v-if="!m.permDone" class="webchat-perm-actions">
+                <button class="webchat-perm-btn webchat-perm-allow" type="button" @click="respondPermission(m.permReqId, true, m)">允许</button>
+                <button class="webchat-perm-btn webchat-perm-deny" type="button" @click="respondPermission(m.permReqId, false, m)">拒绝</button>
+              </div>
+              <div v-else class="webchat-perm-done">{{ m.permDone === true ? '已允许' : '已拒绝' }}</div>
+            </div>
+          </div>
           <div v-else class="webchat-msg webchat-msg-assistant">
             <span v-if="m.model" class="webchat-msg-model">{{ m.model }}</span>
             <div class="webchat-bubble" v-html="renderMarkdown(m.content)"></div>
@@ -135,6 +146,10 @@
     content: string;
     model?: string;
     open?: boolean;
+    // 权限审批卡片字段
+    permReqId?: number;
+    permTitle?: string;
+    permDone?: boolean | null;
   }
 
   interface Session {
@@ -292,11 +307,62 @@
         // 需求 3：自定义标题后的回执
         applyTitle(msg.session_id, payload.title);
         break;
+      case 'permission.request':
+        handlePermissionRequest(msg.session_id, payload);
+        break;
+      case 'permission.responded':
+        markPermissionDone(payload.request_id, !!payload.allow);
+        break;
       case 'error':
         errorMsg.value = payload.message || '发生错误';
         sending.value = false;
         typing.value = false;
         break;
+    }
+  }
+
+  /** permission.request：Agent 触发需用户批准的工具调用 → 在活跃会话插入审批卡片。 */
+  function handlePermissionRequest(sessionId: string | undefined, payload: any) {
+    const reqId = payload?.request_id;
+    const toolCall = payload?.tool_call || {};
+    if (reqId == null) return;
+    const s = ensureSession();
+    s.messages.push({
+      key: 'perm' + msgSeq++,
+      role: 'assistant',
+      kind: 'permission',
+      content: '',
+      permReqId: reqId,
+      permTitle: (toolCall.title as string) || '工具调用',
+      permDone: null,
+      open: false,
+    });
+    saveSessions();
+    scrollToBottom();
+  }
+
+  /** 用户点击 允许/拒绝 → 回传 permission.respond。 */
+  function respondPermission(reqId: number, allow: boolean, m: ChatMsg) {
+    const sid = activeSess.value?.id;
+    if (ws && ws.ready) {
+      ws.sendFrame({
+        type: 'permission.respond',
+        session_id: sid,
+        payload: { session_id: sid, request_id: reqId, allow },
+      });
+    }
+    m.permDone = allow;
+    saveSessions();
+  }
+
+  /** permission.responded 回执：把对应审批卡片置为已处理（幂等）。 */
+  function markPermissionDone(reqId: number, allow: boolean) {
+    const s = activeSess.value;
+    if (!s) return;
+    const m = s.messages.find((x) => x.permReqId === reqId);
+    if (m) {
+      m.permDone = allow;
+      saveSessions();
     }
   }
 
@@ -835,6 +901,51 @@
   .webchat-msg-error .webchat-bubble {
     background: #fff1f0;
     color: #ff4d4f;
+  }
+
+  /* 权限审批卡片 */
+  .webchat-perm {
+    border: 1px solid #d9d9d9;
+    background: #fafafa;
+  }
+  .webchat-perm-label {
+    font-size: 14px;
+    color: #333;
+  }
+  .webchat-perm-label strong {
+    color: #1a73e8;
+  }
+  .webchat-perm-hint {
+    margin-top: 4px;
+    font-size: 12px;
+    color: #999;
+  }
+  .webchat-perm-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 10px;
+  }
+  .webchat-perm-btn {
+    border: none;
+    border-radius: 4px;
+    padding: 6px 16px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+  .webchat-perm-allow {
+    background: #1a73e8;
+    color: #fff;
+  }
+  .webchat-perm-deny {
+    background: #f0f2f5;
+    color: #333;
+    border: 1px solid #d9d9d9;
+  }
+  .webchat-perm-done {
+    margin-top: 10px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: #666;
   }
 
   .webchat-msg-model {

--- a/web-client/css/style.css
+++ b/web-client/css/style.css
@@ -853,6 +853,34 @@ svg {
   border: 1px solid var(--warning);
 }
 
+/* 工具权限审批卡片 */
+.msg-permission .msg-bubble {
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+.msg-permission-label {
+  font-size: 13.5px;
+  color: var(--fg);
+}
+.msg-permission-label strong {
+  color: var(--accent);
+}
+.msg-permission-hint {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--fg-tertiary);
+}
+.msg-permission-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+.msg-permission-done {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--fg-secondary);
+}
+
 /* 会话项删除按钮 */
 .session-del {
   display: none;

--- a/web-client/js/chat.js
+++ b/web-client/js/chat.js
@@ -648,6 +648,12 @@
       case 'session.history':
         handleSessionHistory(payload);
         break;
+      case 'permission.request':
+        handlePermissionRequest(msg.session_id, payload);
+        break;
+      case 'permission.responded':
+        handlePermissionResponded(payload);
+        break;
       case 'error':
         handleError(payload);
         break;
@@ -671,6 +677,91 @@
     state.sending = false;
     setSendEnabled(true);
     scrollToBottom();
+  }
+
+  // ---------- 工具权限审批（permission.request / permission.responded） ----------
+
+  /** 工具权限审批卡片：Agent 触发需要用户批准的工具调用（如 bash）。
+   *  权限决策在服务器端已配 60s 超时自动拒绝；这里仅纯展示 + 回执。 */
+  function handlePermissionRequest(sessionId, payload) {
+    if (!state.messagesEl || !payload) return;
+    if (payload.request_id == null) return;
+
+    var toolCall = payload.tool_call || {};
+    var title = toolCall.title || '工具调用';
+    var wrap = document.createElement('div');
+    wrap.className = 'msg msg-assistant msg-permission';
+    wrap.setAttribute('data-perm-request', payload.request_id);
+
+    var body = document.createElement('div');
+    body.className = 'msg-bubble msg-permission-body';
+    var label = document.createElement('div');
+    label.className = 'msg-permission-label';
+    label.innerHTML = '需要批准：<strong>' + escapeHtml(title) + '</strong>';
+    body.appendChild(label);
+
+    var hint = document.createElement('div');
+    hint.className = 'msg-permission-hint';
+    hint.textContent = 'Agent 请求执行上述操作，是否允许？(60 秒未操作将自动拒绝)';
+    body.appendChild(hint);
+
+    var actions = document.createElement('div');
+    actions.className = 'msg-permission-actions';
+
+    var allowBtn = document.createElement('button');
+    allowBtn.type = 'button';
+    allowBtn.className = 'btn btn-primary';
+    allowBtn.textContent = '允许';
+    allowBtn.addEventListener('click', function () {
+      respondPermission(sessionId, payload.request_id, true, wrap);
+    });
+    actions.appendChild(allowBtn);
+
+    var denyBtn = document.createElement('button');
+    denyBtn.type = 'button';
+    denyBtn.className = 'btn btn-ghost';
+    denyBtn.textContent = '拒绝';
+    denyBtn.addEventListener('click', function () {
+      respondPermission(sessionId, payload.request_id, false, wrap);
+    });
+    actions.appendChild(denyBtn);
+
+    body.appendChild(actions);
+    wrap.appendChild(body);
+    state.messagesEl.appendChild(wrap);
+    scrollToBottom();
+  }
+
+  /** 审批回执：向前端发送 permission.respond，并把卡片标记为已处理。 */
+  function respondPermission(sessionId, requestId, allow, wrap) {
+    if (state.ws && state.ws.ready) {
+      state.ws.sendFrame({
+        type: 'permission.respond',
+        session_id: sessionId,
+        payload: { session_id: sessionId, request_id: requestId, allow: allow }
+      });
+    }
+    markPermissionDone(wrap, allow ? '已允许' : '已拒绝');
+  }
+
+  /** 服务端回执 permission.responded：更新对应卡片为已处理（幂等）。 */
+  function handlePermissionResponded(payload) {
+    if (!payload || payload.request_id == null) return;
+    var wrap = state.messagesEl.querySelector('[data-perm-request="' + payload.request_id + '"]');
+    if (wrap) {
+      markPermissionDone(wrap, payload.allow ? '已允许' : '已拒绝');
+    }
+  }
+
+  /** 把审批卡片置为已处理（禁用按钮并显示结果）。 */
+  function markPermissionDone(wrap, text) {
+    var actions = wrap.querySelector('.msg-permission-actions');
+    if (!actions) return;
+    actions.innerHTML = '';
+    var done = document.createElement('span');
+    done.className = 'msg-permission-done';
+    done.textContent = text;
+    actions.appendChild(done);
   }
 
   // ---------- 服务端会话回读（跨浏览器/跨设备恢复） ----------


### PR DESCRIPTION
## 背景

chatUI 中一旦出现 tools 调用就会一直阻塞（MYS-182）。根因：Reasonix（bmssm agentproxy 对接的 AI agent）以默认 `permissions mode=ask` 运行，模型触发写工具时发出 ACP `session/request_permission` 审批请求等 host 应答；而 agentproxy 的 `dispatchNotify` 只记日志、从不回应 → reasonix 永久等待 → turn 挂死。

## 方案

把审批决策交回 chatUI 用户：agentproxy 收到 `request_permission` 转发为 WS `permission.request` 帧 → 前端渲染审批卡片（允许/拒绝）→ 用户点击回传 `permission.respond` → agentproxy 按 JSON-RPC id 正确应答 reasonix（selected/allow_once | cancelled）→ 工具继续/中止。

## 改动（4 个提交）

1. **ACP 客户端（acp.go）**：agent 发起的 request 透传 JSON-RPC id；新增 `RespondRequest`/`ResolvePermission`，按 id 回正确 outcome 结构（对齐 reasonix `PermissionRequestResult`）。
2. **模块层（perm.go / module.go / turn.go）**：解析 `request_permission` 记录待审批（**按 reqID 关联**，避免同会话多审批互相覆盖），投递 WS `permission.request` 到绑定会话的连接；`permission.respond` 回执 → resolve；**60s 超时/断线/新一轮/进程重建** 自动拒绝并清理。
3. **SOPHON_REASONIX_HOME 隔离（process.go）**：未显式设置时默认 `/data/sophon/reasonix-home`，定制 reasonix 实例的配置/会话/skill 与系统正常安装的 `~/.reasonix` 彻底隔离。
4. **正确前端（sophliteos WebChat.vue）**：chatUI 实际由 sophliteos :8080 的 `WebChat.vue` 组件承载。本组件新增 `permission.request` 审批卡片 + `permission.respond` 回传 + `permission.responded` 状态更新。
5. **web-client（chat.js/style.css）**：独立 web-chat 客户端同样补上审批卡片（备用界面）。

## 验证

- 单元测试：新增 7 项（请求透传、allow/deny 应答、同会话多待审批按 reqID 独立应答、超时自动拒绝），`go test ./mvc/agentproxy/` 全绿，`go vet` 干净。
- 端到端（测试机，bmssm arm64 + reasonix 重建，Reasonix 以 `SOPHON_REASONIX_HOME=/data/sophon/reasonix-home` 运行并预载 se7 知识库 skill）：
  - **allow**：permission.request 到达 → 用户允许 → 工具 `completed` → 结果流式返回 ✅
  - **deny**：permission.request 到达 → 用户拒绝（cancelled）→ 工具 `failed/blocked` 不执行 ✅
  - 生产日志确认 request/resolve 周期按 reqID 正常工作。
  - sophliteos 前端已重建部署到 :8080（WebChat.52f9bebe.js），含审批卡片逻辑。

> 待办（另行推进，不在本 PR）：sophliteos 登录态下浏览器级截图验证，以及 RAG 用 Go 精简化（numpy/faiss/rank_bm25/jieba 替换）。
