### PR TITLE
feat(sophliteos): 前端 go:embed 内嵌改为单文件二进制发布

### DIFF
--- a/source/psophliteos/README.md
+++ b/source/psophliteos/README.md
@@ -37,14 +37,16 @@ bash build/build-deb-sophliteos.sh [VERSION] [soc|pcie]
 
 产物落到 `release/`（`OUTPUT_DIR` 可指定输出目录），如 `release/sophliteos_soc_2.1.0.deb`、`release/sophliteos_pcie_2.1.0.deb`。
 
+> 前端静态资源经 `go:embed` 内嵌进单文件二进制（见 `web_embed.go`），deb 不再单独携带/安装 `dist` 目录。
+
 > `build/build_2_release.sh`、`build/build_test.sh`、`scrip/package.sh`、`build/package-deb-sdk.sh`
 > 是旧 docker-node16 + tgz 流程，已废弃，仅供回溯。
 
 ## 产物
 ```
 release/
-├── sophliteos_soc_2.1.0.deb      # arm64 设备版
-└── sophliteos_pcie_2.1.0.deb     # amd64 开发机版
+├── sophliteos_soc_2.1.0.deb      # arm64 设备版（单文件二进制，前端内嵌）
+└── sophliteos_pcie_2.1.0.deb     # amd64 开发机版（单文件二进制，前端内嵌）
 ```
 
 ## 安装运行
@@ -52,7 +54,7 @@ release/
 sudo dpkg -i release/sophliteos_soc_2.1.0.deb     # arm 设备
 sudo dpkg -i release/sophliteos_pcie_2.1.0.deb    # x86 开发机
 ```
-安装后由 systemd 服务 `sophliteos` 拉起，监听 :8080。
+安装后由 systemd 服务 `sophliteos` 拉起，监听 :8080。前端页面由二进制内嵌资源提供，运行时不再需要独立 web 目录。
 
 ---
 
@@ -60,20 +62,11 @@ sudo dpkg -i release/sophliteos_pcie_2.1.0.deb    # x86 开发机
 
 登录页的 LOGO（`class="sophgo_logo"`）保留可替换，其余页面的 sophgo logo（顶部用户下拉 `__header`、菜单 `menu_logo`、应用 `logo.png`、登录表单 `logo.png`）已移除。
 
-替换登录 LOGO 的两种方式：
+> 前端已内嵌进二进制，**运行期替换 `/opt/sophon/sophliteos/dist/` 下文件的方式不再适用**（旧版「方式一：部署后换文件」随 embed 失效）。请走「方式二：构建期注入」，重新构建 deb 后升级即持久生效。
 
-### 方式一：替换部署后的图片文件（无需重新构建）
+### 方式一（已失效，保留说明）
 
-sophliteos 静态资源从 `/opt/sophon/sophliteos/dist/resource/` 提供，登录 LOGO 默认读取 `resource/img/login_logo.png`。
-
-```bash
-# 替换为目标 LOGO（建议 PNG，contain 缩放）
-sudo cp /path/to/your_logo.png /opt/sophon/sophliteos/dist/resource/img/login_logo.png
-```
-
-浏览器强刷（Ctrl+Shift+R）即可生效。
-
-> 注意：sophliteos deb 升级会刷新 `/opt/sophon/sophliteos/dist`，升级后需重新覆盖此文件。
+旧的运行期换文件方式：sophliteos 静态资源原从 `/opt/sophon/sophliteos/dist/resource/` 提供，登录 LOGO 默认读取 `resource/img/login_logo.png`。单文件二进制内嵌后无法直接改盘上 dist，此方式作废，请改用方式二。
 
 ### 方式二：构建期注入自定义路径（持久，随升级保留）
 

--- a/source/psophliteos/build/build-deb-sophliteos.sh
+++ b/source/psophliteos/build/build-deb-sophliteos.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# sophliteos .deb 打包（docker-free）：pnpm 前端 + go 交叉编译 + dpkg-deb。
+# sophliteos .deb 打包（docker-free）：pnpm 前端 + go 交叉编译（前端 go:embed 内嵌）+ dpkg-deb。
 # 用法: bash build/build-deb-sophliteos.sh [VERSION] [soc|pcie]
 #   VERSION 默认 2.1.0
 #   soc=arm64（设备，默认）；pcie=amd64（开发机）
-# 产物: release/sophliteos_<PRODUCT>_<VERSION>.deb
+# 产物: release/sophliteos_<PRODUCT>_<VERSION>.deb（单文件二进制，前端内嵌）
 #
-# 规范化打包：数据树按最终路径布局（/opt/sophon/sophliteos、/etc/systemd），
-# dpkg 直接追踪所有文件；postinst 仅建运行时目录 + systemd enable/restart，不再散布/复制文件。
+# 规范化打包：前端静态资源在 go build 阶段经 //go:embed dist 打进二进制，
+# 数据树只含 二进制 + config + systemd 服务，不再单独安装 dist 目录。
+# dpkg 直接追踪所有文件；postinst 仅建运行时目录 + systemd enable/restart。
 # db 文件由 app 首次启动自动创建（/var/lib/sophliteos/db），属运行时状态，不打包。
 set -e
 
@@ -28,7 +29,8 @@ if [ ! -d node_modules ]; then
 fi
 pnpm run build || yarn build
 cd ..
-cp -r frontend/dist dist
+# 合入内嵌暂存目录 dist/（覆盖占位的 dist/index.html），go:embed 即在下一步编译期把整套前端打进二进制
+cp -r frontend/dist/. dist/
 
 # 3. go 交叉编译（arm64 走 musl 静态；amd64 宿主 gcc 动态）
 if [ "$ARCH" = "arm64" ]; then
@@ -46,17 +48,16 @@ else
 fi
 
 # 4. 组装数据树（最终绝对路径布局，dpkg 直接追踪）
+# 前端已内嵌到二进制，deb 只带 二进制 + 配置 + systemd 服务，不再单独打包 dist 目录。
 STAGE=build/stage
 rm -rf "$STAGE"
 mkdir -p "$STAGE/DEBIAN" \
          "$STAGE/opt/sophon/sophliteos/bin" \
          "$STAGE/opt/sophon/sophliteos/config" \
-         "$STAGE/opt/sophon/sophliteos/dist" \
          "$STAGE/usr/lib/systemd/system"
 install -m 0755 sophliteos "$STAGE/opt/sophon/sophliteos/bin/sophliteos"
 install -m 0644 scrip/sophliteos.service "$STAGE/usr/lib/systemd/system/sophliteos.service"
 install -m 0644 config/sophliteos.yaml "$STAGE/opt/sophon/sophliteos/config/sophliteos.yaml"
-cp -r dist/. "$STAGE/opt/sophon/sophliteos/dist/"
 install -m 0644 release_version.txt "$STAGE/opt/sophon/sophliteos/release_version.txt"
 
 # 5. DEBIAN 控制信息（模板注入 Version + Architecture；@ARCH@ 位于 Description 前，
@@ -78,8 +79,24 @@ mkdir -p release
 OUT="release/sophliteos_${PRODUCT}_${VERSION}.deb"
 dpkg-deb --root-owner-group -b "$STAGE" "$OUT"
 
-# 7. 清理项目根临时构建产物（保留 release/ 与源码）
-rm -rf dist sophliteos release_version.txt build/stage
+# 7. 清理项目根临时构建产物；把内嵌暂存目录 dist/ 重置为只含占位 index.html，
+#    使 git 跟踪的 dist/index.html 保持原样（真实前端产物仅留在 frontend/dist）。
+rm -f sophliteos release_version.txt
+rm -rf build/stage dist
+mkdir -p dist
+# 重写占位内容，与 git 跟踪的 dist/index.html 保持一致，构建后工作区不产生 dirty 差异。
+cat > dist/index.html <<'PLACEHOLDER_EOF'
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>SophLiteOS</title>
+</head>
+<body>
+  <p>SophLiteOS 前端未构建。请通过 sophliteos 统一构建流程生成 dist 后再 go build。</p>
+</body>
+</html>
+PLACEHOLDER_EOF
 
 echo
 echo "✓ built $OUT"

--- a/source/psophliteos/build/sophliteos/DEBIAN/control.bak
+++ b/source/psophliteos/build/sophliteos/DEBIAN/control.bak
@@ -8,4 +8,4 @@ Architecture: @ARCH@
 Description: sophliteos - Sophon Device Web Console
  Sophon 设备运维 Web 控制台（vben-admin 重构）。
  提供设备概览、运维、OTA、网络、告警/审计日志等前端页面，反代 /api/v1/* 到 bmssm。
- 默认监听 :8080，前端 dist 位于 /opt/sophon/sophliteos/dist。
+ 默认监听 :8080，前端静态资源内嵌于单文件二进制。

--- a/source/psophliteos/config/sophliteos.yaml
+++ b/source/psophliteos/config/sophliteos.yaml
@@ -1,6 +1,6 @@
 server:
   port: 8080
-  www: /opt/sophon/sophliteos/dist
+  # 前端静态资源已 go:embed 进单文件二进制，无需 www 磁盘路径。
   # 本地 admin 记录的 MD5 口令（遗留：登录实际走 /api/v1/login 反代到 bmssm 鉴权）。
   # 仅用于初始化本地 sqlite 的 admin 占位记录，无在线登录入口；如需保留请改为强口令。
   admin-password: c3284d0f94606de1fd2af172aba15bf3

--- a/source/psophliteos/dist/index.html
+++ b/source/psophliteos/dist/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="utf-8" />
+  <title>SophLiteOS</title>
+</head>
+<body>
+  <p>SophLiteOS 前端未构建。请通过 sophliteos 统一构建流程生成 dist 后再 go build。</p>
+</body>
+</html>

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -1,21 +1,24 @@
 package initialization
 
 import (
+	"io/fs"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strings"
 	"sophliteos/config"
 	"sophliteos/logger"
 	"sophliteos/middleware"
 	"sophliteos/router"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
 
 // 初始化总路由
+// webFS 为内嵌的前端构建产物（package main 的 go:embed dist），
+// 单文件二进制自带整套静态前端，运行时不再依赖磁盘上的 web 目录。
 
-func Routers() *gin.Engine {
+func Routers(webFS fs.FS) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode) // 设置Gin的模式为release
 	Router := gin.New()
 	Router.Use(gin.Recovery())
@@ -27,7 +30,6 @@ func Routers() *gin.Engine {
 	conf := &config.Conf
 	conf.Lock()
 	v := conf.GetViper()
-	path := v.GetString("server.www")
 	bmssmServer := v.GetString("bmssm.server")
 	conf.Unlock()
 
@@ -35,11 +37,17 @@ func Routers() *gin.Engine {
 		bmssmServer = "127.0.0.1:9779"
 	}
 
-	Router.StaticFile("/_app.config.js", path+"/_app.config.js")
-	Router.StaticFile("/favicon.ico", path+"/favicon.ico")
-	Router.StaticFile("/", path+"/index.html") // 前端网页入口页面
-	Router.Static("/assets", path+"/assets")   // dist里面的静态资源
-	Router.Static("/resource", path+"/resource")
+	// 静态前端全部取自内嵌 FS：以 http.FileServer 挂到 NoRoute 兜底，
+	// 统一提供 index.html/_app.config.js/favicon.ico 及 assets、resource 等子目录资源。
+	// 业务/API 路由显式注册在前，gin 命中优先于 NoRoute，未匹配的 /api/* 与非 GET 则会落此兜底。
+	webFSHandler := http.FileServer(http.FS(webFS))
+	Router.NoRoute(func(c *gin.Context) {
+		if c.Request.Method != http.MethodGet && c.Request.Method != http.MethodHead {
+			c.Status(http.StatusNotFound)
+			return
+		}
+		webFSHandler.ServeHTTP(c.Writer, c.Request)
+	})
 
 	Router.Use(middleware.BlockerMiddleware())
 

--- a/source/psophliteos/initialization/router_embed_test.go
+++ b/source/psophliteos/initialization/router_embed_test.go
@@ -1,0 +1,69 @@
+package initialization
+
+import (
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"sophliteos/config"
+)
+
+// 验证内嵌前端（go:embed dist）经 Routers 的 NoRoute + http.FileServer 正确对外服务，
+// 覆盖入口页、config、favicon 与静态子路径，并确认非 GET 未被兜底误放行。
+func testEmbeddedFS(t *testing.T) fs.FS {
+	t.Helper()
+	return fstest.MapFS{
+		"index.html":     {Data: []byte("<!doctype html><html>sophliteos</html>")},
+		"_app.config.js": {Data: []byte("window.__APP_CONFIG__={}")},
+		"favicon.ico":    {Data: []byte("favicon")},
+		"assets/app.js":  {Data: []byte("console.log(1)")},
+		"resource/a.txt": {Data: []byte("resource")},
+	}
+}
+
+func TestRoutersServesEmbeddedFrontend(t *testing.T) {
+	// 生产路径为 main → InitBase() → config.LoadConfig() 后再 Routers();
+	// 测试先 LoadConfig 拿到有效 viper（读不到配置文件时优雅降级为空配置）。
+	config.LoadConfig()
+	router := Routers(testEmbeddedFS(t))
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		want   int
+	}{
+		{"/ index", "GET", "/", http.StatusOK},
+		{"/assets", "GET", "/assets/app.js", http.StatusOK},
+		{"/resource", "GET", "/resource/a.txt", http.StatusOK},
+		{"/config", "GET", "/_app.config.js", http.StatusOK},
+		{"/favicon", "GET", "/favicon.ico", http.StatusOK},
+		{"/unknown 404", "GET", "/no/such/file.js", http.StatusNotFound},
+		{"/POST not static", "POST", "/", http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		router.ServeHTTP(w, req)
+		if w.Code != tc.want {
+			t.Errorf("%s: status = %d, want %d (body=%q)", tc.name, w.Code, tc.want, w.Body.String())
+		}
+	}
+}
+
+func TestEmbeddedFrontendContent(t *testing.T) {
+	config.LoadConfig()
+	router := Routers(testEmbeddedFS(t))
+
+	for _, p := range []string{"/", "/assets/app.js", "/resource/a.txt"} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK || w.Body.Len() == 0 {
+			t.Errorf("%s: status=%d body=%q", p, w.Code, w.Body.String())
+		}
+	}
+}

--- a/source/psophliteos/main.go
+++ b/source/psophliteos/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	initialization.InitBase()
-	Router := initialization.Routers()
+	Router := initialization.Routers(embeddedWeb)
 	s := initialization.InitServer(Router)
 
 	time.Sleep(10 * time.Microsecond)

--- a/source/psophliteos/middleware/block.go
+++ b/source/psophliteos/middleware/block.go
@@ -13,7 +13,7 @@ func BlockerMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		if global.BlockAllRequests {
 			c.JSON(http.StatusServiceUnavailable, mvc.FailWithMsg(error2.Upgradeing, "服务器升级中，暂不可用"))
-			// c.File("/opt/sophon/sophliteos/dist/updating.html")
+			// 前端已内嵌进二进制；如需升级页可改为从内嵌 FS 读取 updating.html（当前未启用）。
 			c.Abort()
 		}
 	}

--- a/source/psophliteos/release.sh
+++ b/source/psophliteos/release.sh
@@ -4,7 +4,7 @@
 #   ARCH:    arm64(soc) | amd64(pcie) | all（默认 arm64）
 #   VERSION: 显式版本号（默认 2.1.0，与 build/version.sh 一致）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/psophliteos/）
-# 产物: sophliteos_soc_<ver>.deb + sophliteos_pcie_<ver>.deb
+# 产物: sophliteos_soc_<ver>.deb + sophliteos_pcie_<ver>.deb（单文件二进制，前端 go:embed 内嵌）
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"

--- a/source/psophliteos/scrip/install.sh
+++ b/source/psophliteos/scrip/install.sh
@@ -27,9 +27,7 @@ if [[ -f /etc/systemd/system/sophliteos.service ]]; then
   systemctl disable sophliteos.service || true
 fi
 mkdir -p /etc/sophliteos/config /var/log/sophliteos /var/lib/sophliteos/db /data/sophliteos
-rm -rf /var/lib/sophliteos/dist
 
-cp -r dist /var/lib/sophliteos/
 cp "${dir}"sophliteos /bin
 # 配置文件仅在目标不存在时拷入模板，避免升级覆盖用户的 ssm.server/端口/日志等改动
 [ -f /etc/sophliteos/config/sophliteos.yaml ] || cp config/sophliteos.yaml /etc/sophliteos/config

--- a/source/psophliteos/scrip/upgrade.sh
+++ b/source/psophliteos/scrip/upgrade.sh
@@ -1,6 +1,6 @@
 mkdir -p /etc/sophliteos/config /var/log/sophliteos /var/lib/sophliteos/db /data/sophliteos
-rm -rf /var/lib/sophliteos/dist
-cp -r dist /var/lib/sophliteos/
+
+# 前端已内嵌进二进制，无需再部署 dist 目录。
 
 # cp config/sophliteos.yaml /etc/sophliteos/config
 cp release_version.txt /var/lib/sophliteos

--- a/source/psophliteos/web_embed.go
+++ b/source/psophliteos/web_embed.go
@@ -1,0 +1,10 @@
+package main
+
+import "embed"
+
+// embeddedWeb 内嵌前端构建产物（packaged dist/）。
+// 构建流程（build/build-deb-sophliteos.sh）先把 frontend/dist 合入 dist/，再 go build，
+// 使单文件二进制自带整套静态前端。发布物为单文件，无需再随包携带/部署 web 静态目录。
+//
+//go:embed dist
+var embeddedWeb embed.FS


### PR DESCRIPTION
## 背景（MYS-184）

用户要求把 sophliteos 的**发布方式改为二进制单文件**：静态前端文件内嵌进 Go 二进制。此前前端以独立 `dist/` 静态目录随 deb 安装，运行时由 Gin 从磁盘 `server.www` 读取。

## 改动

- **`web_embed.go`（新增）**：`//go:embed dist` 把前端构建产物打进 Go 二进制。
- **`dist/index.html`（新增，git 跟踪的占位）**：保证干净检出下 `go build`/`go test` 可编译（embed 目录需存在）。
- **`initialization/router.go`**：静态前端改由内嵌 FS 提供（`http.FileServer(http.FS(webFS))` 挂 `NoRoute` 兜底），移除磁盘 `server.www` 依赖；`Routers()` 增加 `webFS fs.FS` 入参，`main.go` 传入 `embeddedWeb`。
- **`config/sophliteos.yaml`**：移除 `server.www`。
- **`build/build-deb-sophliteos.sh`**：构建期把 `frontend/dist` 合入 `dist/` 供 `go:embed`；deb 只装 二进制+config+systemd 服务，不再单独打包 dist 目录；构建结束重置 `dist/` 占位，避免工作区 dirty。
- **同步**：README / DEBIAN description / legacy `scrip/install.sh`、`upgrade.sh`。
- **`initialization/router_embed_test.go`（新增）**：覆盖内嵌前端 `/`、`/_app.config.js`、`/favicon.ico`、`/assets/*`、`/resource/*` 各路径服务。

## 验证

- `go build ./...`、`go vet ./...`、`go test ./...` 全部通过。
- amd64 二进制实测：`//go:embed dist` 已把真实前端（index.html/_app.config.js/assets/resource）打进 16MB 单文件；`strings` 确认嵌入内容存在。
- deb 实测：内含组件仅 `bin/sophliteos` + `config/sophliteos.yaml` + `release_version.txt` + systemd 服务，**无独立 dist 目录**。
- 前端源组件（含 agent chatUI）随二进制内嵌，运行时不再依赖独立 web 目录。
- 注：arm64 soc 完整 `release.sh` 需 musl 工具链 + pnpm，本环境未跑全量，改动后的各构建环节已独立验证。

关联 issue：MYS-184