### PR TITLE
fix(se-rag-core): chunker extractProtected 切片越界崩溃（大型文档 build）

### DIFF
--- a/source/se-rag-core/internal/chunker/chunker.go
+++ b/source/se-rag-core/internal/chunker/chunker.go
@@ -262,15 +262,33 @@ func extractProtected(text string) (string, []region) {
 	segs = scanTables(text, segs)
 	sort.SliceStable(segs, func(i, j int) bool { return segs[i].s < segs[j].s })
 
+	clamp := func(lo, hi, n int) (int, int) {
+		if lo < 0 {
+			lo = 0
+		}
+		if lo > n {
+			lo = n
+		}
+		if hi < lo {
+			hi = lo
+		}
+		if hi > n {
+			hi = n
+		}
+		return lo, hi
+	}
+
 	var regions []region
 	var sb strings.Builder
 	last := 0
 	for i, s := range segs {
-		if s.s >= last {
-			sb.WriteString(text[last:s.s])
+		lo, hi := clamp(s.s, s.e, len(text))
+		// 仅保留非空、且不重叠在已处理区域之后的片段（防御越界于 len(text)）。
+		if hi > lo && lo >= last {
+			sb.WriteString(text[last:lo])
 			sb.WriteString(fmt.Sprintf("__PROTECTED_%d__", i))
-			regions = append(regions, region{s.s, s.e, text[s.s:s.e], s.kind})
-			last = s.e
+			regions = append(regions, region{lo, hi, text[lo:hi], s.kind})
+			last = hi
 		}
 	}
 	sb.WriteString(text[last:])
@@ -299,6 +317,7 @@ func scanCodeBlock(text string, in []seg) []seg {
 func scanTables(text string, in []seg) []seg {
 	out := in
 	lines := strings.Split(text, "\n")
+	n := len(text)
 	off := 0
 	i := 0
 	for i < len(lines) {
@@ -307,7 +326,11 @@ func scanTables(text string, in []seg) []seg {
 			st := off
 			j := i
 			for j < len(lines) && tableRow(lines[j]) {
+				// +1 对应换行符；最后一行无换行时 off 不应超过 len(text)
 				off += len(lines[j]) + 1
+				if off > n {
+					off = n
+				}
 				j++
 			}
 			out = append(out, seg{st, off, "table"})
@@ -315,6 +338,9 @@ func scanTables(text string, in []seg) []seg {
 			continue
 		}
 		off += len(line) + 1
+		if off > n {
+			off = n
+		}
 		i++
 	}
 	return out

--- a/source/se-rag-core/internal/chunker/chunker_test.go
+++ b/source/se-rag-core/internal/chunker/chunker_test.go
@@ -1,6 +1,7 @@
 package chunker
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -46,5 +47,22 @@ func TestChunksSizedBelowMax(t *testing.T) {
 		if len([]rune(c.Text)) > 6000 {
 			t.Errorf("chunk too large: %d runes > 6000", len([]rune(c.Text)))
 		}
+	}
+}
+
+func TestExtractProtectedNoTrailingNewlineTable(t *testing.T) {
+	// 回归：以表格结尾且文件末尾无换行时，旧 scanTables 的 off 会溢出到 len(text)+1，
+	// extractProtected 对 text[s.s:s.e] / text[last:s.s] 切片越界 panic。
+	text := "前文\n\n| a | b |\n| c | d |\n\n最后的表格：\n| x | y |\n| p | q |"
+	txt, regions := extractProtected(text)
+	if txt == "" {
+		t.Fatalf("unexpected empty result")
+	}
+	// 每张表格都应作为保护区域被还原，且原文内容不被破坏
+	for i, r := range regions {
+		if !strings.Contains(txt, fmt.Sprintf("__PROTECTED_%d__", i)) {
+			t.Fatalf("missing protected placeholder %d", i)
+		}
+		_ = r
 	}
 }


### PR DESCRIPTION
## 背景

在把 SE7 知识库 skill 的检索核心**切换到 Go se-rag** 时，用真实 se7 文档（`sophon-testhub_clear.md`，约 144KB）`build` 索引会崩溃：

```
panic: slice bounds out of range [:144755] with length 144754
  at internal/chunker/chunker.go:272 extractProtected
```

根因：`scanTables` 对「文件以表格结尾且末尾无换行」时，`off` 计数溢出到 `len(text)+1`，随后 `extractProtected` 对 `text[s.s:s.e]` / `text[last:s.s]` 切片越界。示例/小文档不触发，真实产品文档必现 → **Go 检索核心无法用于默认部署**。

## 改动（source/se-rag-core）

1. **chunker.go `extractProtected`**：对每个保护片段的起止做 `[0, len(text)]` 收敛，并仅保留非空、不重叠片段 —— 防御任意文档边界的越界。
2. **chunker.go `scanTables`**：`off` 计数封顶 `len(text)`，修正文件末尾无换行时多计的幻影换行。
3. **chunker_test.go**：新增回归测试 `TestExtractProtectedNoTrailingNewlineTable`（以表格结尾无换行）——旧码必 panic，新码通过。

## 验证

- `go test ./...`（se-rag-core 全量）通过
- 真实 se7 文档（144KB）`se-rag build` 索引成功：1183 chunks / 1024d / siliconflow.BAAI/bge-m3
- 测试机端到端：agent 用 Go se-rag 检索 SE7 并正确回答（来源可溯）

## 备注

本 PR 仅修 chunker 崩溃；skill 切换（se7-knowledge-base 调用 Go se-rag）为设备端部署，另行说明。
