### PR TITLE
feat(psophliteos): 删除 Agent Proxy 配置卡独立「启用」开关 (MYS-190)

### DIFF
--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -47,17 +47,6 @@
         >
           <a-switch v-model:checked="form.llmOverrideModel" />
         </a-form-item>
-        <a-form-item
-          label="启用"
-          tooltip="控制 Agent（Reasonix 服务）是否运行。开启后 Agent Proxy 服务启动，可对话；关闭后服务停止。"
-        >
-          <a-switch
-            :checked="serviceEnabled"
-            :loading="svcActing"
-            :disabled="svcLoading"
-            @change="toggleAgentService"
-          />
-        </a-form-item>
       </a-form>
 
       <!-- 保存 + 测试 -->


### PR DESCRIPTION
## Summary

删除 agent 配置页（`source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue`）中「Agent Proxy 配置」卡的独立「启用」开关。

下发代理与 agent 服务的启停统一由下方「Agent 服务管理」的服务开关控制，避免重复入口语义混淆。

## Changes

- 移除「Agent Proxy 配置」内 `label="启用"` 的 `a-form-item`（含 tooltip 与 `a-switch`）
- 保留下方「Agent 服务管理」的服务开关（`serviceEnabled` / `toggleAgentService`）
- 删除后 `serviceEnabled`、`svcActing`、`svcLoading`、`toggleAgentService` 等变量仍被服务管理卡使用，无未用变量

## Test

- `vite build` 通过（模板编译正常）
- 无需后端改动

关联 issue：MYS-190