### PR TITLE
feat(psophliteos): 删除默认模型名称的「选择」按钮（MYS-191）

### DIFF
--- a/source/psophliteos/frontend/src/api/aiAgent/index.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/index.ts
@@ -6,7 +6,6 @@ import { defHttp } from '/@/utils/http/axios';
 // defHttp 自动加 /api 前缀。
 enum Api {
   LlmProxyConfig = '/v1/llm-proxy/config',
-  LlmProxyModels = '/v1/llm-proxy/models',
   LlmProxyTest = '/v1/llm-proxy/test',
   ServiceStatus = '/v1/llm-proxy/service/status',
   ServiceAction = '/v1/llm-proxy/service/action',
@@ -67,21 +66,6 @@ export async function saveAgentConfig(cfg: {
     return { ok: false, message: (res as any)?.error_message || (res as any)?.msg || '保存失败' };
   } catch (e: any) {
     return { ok: false, message: e?.message || '保存失败' };
-  }
-}
-
-// 从供应商拉取模型列表（LLM）。
-export async function getProviderModels(): Promise<string[]> {
-  try {
-    const res = await defHttp.get<{ models: { id: string }[] }>(
-      { url: Api.LlmProxyModels, params: { kind: 'llm' } },
-      { isTransformResponse: false },
-    );
-    const data = (res as any)?.result ?? res;
-    const list = data?.models;
-    return Array.isArray(list) ? list.map((m: any) => m?.id ?? m).filter(Boolean) : [];
-  } catch {
-    return [];
   }
 }
 

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -32,14 +32,11 @@
           />
         </a-form-item>
         <a-form-item label="默认模型名称">
-          <a-input-group compact>
-            <a-input
-              v-model:value="form.llmModel"
-              style="width: 60%"
-              placeholder="sophnet-deepseek"
-            />
-            <a-button style="width: 20%" @click="openModelPicker">选择</a-button>
-          </a-input-group>
+          <a-input
+            v-model:value="form.llmModel"
+            style="width: 100%"
+            placeholder="sophnet-deepseek"
+          />
         </a-form-item>
         <a-form-item
           label="覆盖下游请求"
@@ -98,32 +95,6 @@
         </p>
       </div>
     </a-card>
-
-    <!-- 模型选择弹窗 -->
-    <a-modal
-      v-model:open="picker.visible"
-      title="选择模型"
-      @ok="applyPickedModel"
-      :ok-button-props="{ disabled: !picker.selected }"
-    >
-      <div class="mb-3">
-        <a-input-search
-          v-model:value="picker.custom"
-          placeholder="或手动输入模型名，回车确认"
-          enter-button="使用"
-          @search="applyCustomModel"
-        />
-      </div>
-      <a-select
-        v-model:value="picker.selected"
-        style="width: 100%"
-        placeholder="从供应商拉取模型列表"
-        :loading="picker.loading"
-        :options="picker.options"
-        @dropdown-visible-change="loadModels"
-        allow-clear
-      />
-    </a-modal>
   </div>
 </template>
 
@@ -137,15 +108,12 @@
     Button,
     Switch,
     Alert,
-    Modal,
-    Select,
     Tag,
     message,
   } from 'ant-design-vue';
   import {
     getAgentConfig,
     saveAgentConfig,
-    getProviderModels,
     testAgentConfig,
     getServiceStatus,
     serviceAction,
@@ -158,13 +126,9 @@
   const AFormItem = Form.Item;
   const AInput = Input;
   const AInputPassword = Input.Password;
-  const AInputGroup = Input.Group;
-  const AInputSearch = Input.Search;
   const AButton = Button;
   const ASwitch = Switch;
   const AAlert = Alert;
-  const AModal = Modal;
-  const ASelect = Select;
   const ATag = Tag;
 
   const saving = ref(false);
@@ -241,14 +205,6 @@
     form.llmApiBase = apiBaseByType[type] || SOPHNET_API_BASE;
   }
 
-  const picker = reactive({
-    visible: false,
-    options: [] as { label: string; value: string }[],
-    selected: undefined as string | undefined,
-    custom: '',
-    loading: false,
-  });
-
   async function init() {
     const cfg = await getAgentConfig();
     if (cfg) {
@@ -296,40 +252,6 @@
       testAllOK.value = false;
       testResults.value = [{ name: '测试', ok: false, message: res.message || '测试请求失败' }];
     }
-  }
-
-  // --- 模型选择弹窗 ---
-  function openModelPicker() {
-    picker.selected = undefined;
-    picker.custom = '';
-    picker.options = [];
-    picker.visible = true;
-  }
-
-  async function loadModels(open: boolean) {
-    if (!open || picker.options.length) return;
-    picker.loading = true;
-    const ids = await getProviderModels();
-    picker.options = ids.map((id) => ({ label: id, value: id }));
-    picker.loading = false;
-  }
-
-  function applyCustomModel() {
-    const v = picker.custom.trim();
-    if (!v) return;
-    applyModel(v);
-  }
-
-  function applyPickedModel() {
-    if (picker.selected) {
-      applyModel(picker.selected);
-    }
-  }
-
-  function applyModel(name: string) {
-    form.llmModel = name;
-    picker.visible = false;
-    message.success(`已选择模型 ${name}`);
   }
 
   onMounted(() => {


### PR DESCRIPTION
## 需求
MYS-191：删除 Agent 配置页「默认模型名称」行的「选择」按钮，仅保留模型名输入框。

## 改动
- `source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue`
  - 删除「选择」按钮及 a-input-group 组合，默认模型名称改为全宽输入框
  - 删除模型选择弹窗（a-modal）模板
  - 清理不再使用的 `picker` 状态、`openModelPicker`/`loadModels`/`applyPickedModel`/`applyCustomModel`/`applyModel` 函数
  - 清理不再使用的 import（`Modal`/`Select`/`getProviderModels`）及局部组件别名（`AInputGroup`/`AInputSearch`/`AModal`/`ASelect`）
- `source/psophliteos/frontend/src/api/aiAgent/index.ts`
  - 删除无人引用的 `getProviderModels` API 及 `LlmProxyModels` 枚举

## 验证
- 改动前已确认代码为 main 最新（分支基于 main 新建）
- `vite build` 构建通过
- 页面仍使用的 `<a-select>`（API Base URL 下拉）由全局组件注册提供，不受影响