### PR TITLE
feat(psophliteos): Agent Proxy「覆盖下游请求」默认开启 (MYS-192)

### DIFF
--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -55,6 +55,9 @@ func TestServiceLLMAndVLMConfig(t *testing.T) {
 	if cfg.VLMModel != "sophnet-vl-flash" {
 		t.Errorf("default vlmModel = %q", cfg.VLMModel)
 	}
+	if !cfg.LLMOverride || !cfg.VLMOverride {
+		t.Errorf("default override should be on, got LLM=%v VLM=%v", cfg.LLMOverride, cfg.VLMOverride)
+	}
 	if cfg.ForwardKey == "" {
 		t.Error("forward key should be auto-generated")
 	}
@@ -202,7 +205,8 @@ func TestForwardModelPrecedence(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-default",
-		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		LLMOverride: boolPtr(false),
+		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
@@ -332,7 +336,8 @@ func TestForwardModelKeptForImage(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
-		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		LLMOverride: boolPtr(false),
+		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
@@ -394,7 +399,8 @@ func TestImageDescribeRouting(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
-		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		LLMOverride: boolPtr(false),
+		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -44,15 +44,18 @@ func (Config) TableName() string { return "llm_proxy_config" }
 
 // DefaultConfig 返回默认配置（sophnet 上游：LLM=deepseek，VLM=vl-flash）。
 // ApiBase 为 OpenAI 兼容 base（转发时直接拼 /chat/completions）。
+// LLMOverride/VLMOverride 默认开启「覆盖下游请求」：新装转发一律用默认模型名。
 func DefaultConfig() Config {
 	return Config{
-		ID:         1,
-		LLMApiBase: "https://www.sophnet.com/api/open-apis/v1",
-		LLMModel:   "sophnet-deepseek",
-		LLMEnabled: true,
-		VLMApiBase: "https://www.sophnet.com/api/open-apis/v1",
-		VLMModel:   "sophnet-vl-flash",
-		VLMEnabled: true,
+		ID:          1,
+		LLMApiBase:  "https://www.sophnet.com/api/open-apis/v1",
+		LLMModel:    "sophnet-deepseek",
+		LLMEnabled:  true,
+		LLMOverride: true,
+		VLMApiBase:  "https://www.sophnet.com/api/open-apis/v1",
+		VLMModel:    "sophnet-vl-flash",
+		VLMEnabled:  true,
+		VLMOverride: true,
 	}
 }
 

--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -186,7 +186,7 @@
     llmApiKey: '',
     llmModel: '',
     llmEnabled: true,
-    llmOverrideModel: false,
+    llmOverrideModel: true,
     llmHasKey: false,
   });
 
@@ -212,7 +212,7 @@
       form.llmApiBaseType = inferApiBaseType(cfg.llmApiBase || '');
       form.llmModel = cfg.llmModel || '';
       form.llmEnabled = cfg.llmEnabled !== false;
-      form.llmOverrideModel = !!cfg.llmOverrideModel;
+      form.llmOverrideModel = cfg.llmOverrideModel !== false;
       form.llmHasKey = !!cfg.llmHasKey;
     }
   }


### PR DESCRIPTION
## 需求
S3 Agent 配置页「Agent Proxy 配置」卡「覆盖下游请求」默认开启。

## 改动
- `types.go` `DefaultConfig()`：LLM/VLM `Override` 默认改为 `true`，保证新装/未保存时默认开启；已存在用户配置保持不变。
- `index.vue`：`form.llmOverrideModel` 初始值 `false` → `true`；`init` 读后端由 `!!cfg.llmOverrideModel` 改为 `cfg.llmOverrideModel !== false`，兼容后端默认 true 与老用户显式 false 两种情况。
- `server_test.go`：model 保留类测试（`TestForwardModelPrecedence`/`TestForwardModelKeptForImage`/`TestImageDescribeRouting`）显式传 `LLMOverride=false` 固定「关闭」意图；新增默认 override 开启断言。

## 验证
- `go test ./mvc/llmproxy/...` 通过
- `go build ./...` 通过
- 前端 `vite build` 通过

MYS-192