### PR TITLE
feat(bmssm): Agent Proxy VLM 未配置时按 LLM API Base 分流默认模型 (MYS-193)

### DIFF
--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -52,7 +52,7 @@ func TestServiceLLMAndVLMConfig(t *testing.T) {
 	if cfg.LLMModel != "sophnet-deepseek" {
 		t.Errorf("default llmModel = %q", cfg.LLMModel)
 	}
-	if cfg.VLMModel != "sophnet-vl-flash" {
+	if cfg.VLMModel != "qwen3-vl-plus" {
 		t.Errorf("default vlmModel = %q", cfg.VLMModel)
 	}
 	if !cfg.LLMOverride || !cfg.VLMOverride {
@@ -310,6 +310,114 @@ func TestForwardModelOverride(t *testing.T) {
 }
 
 func boolPtr(b bool) *bool { return &b }
+
+// TestVLMUnconfiguredSophnetFallback 验证 MYS-193：VLM 未配置时，LLM API Base 为 Sophnet
+// → 隐式 VLM（ApiBase=Sophnet, ModelName=qwen3-vl-plus, key 复用 LLM 的 key）。
+func TestVLMUnconfiguredSophnetFallback(t *testing.T) {
+	cfg := Config{
+		LLMApiBase: SophnetApiBase,
+		LLMApiKey:  "llm-key",
+		LLMModel:   "sophnet-deepseek",
+		LLMEnabled: true,
+		// VLM 全空 = 未配置
+	}
+	vlm := cfg.VLM()
+	if !vlm.Enabled {
+		t.Error("implicit VLM should be enabled")
+	}
+	if vlm.ApiBase != SophnetApiBase {
+		t.Errorf("implicit VLM ApiBase = %q, want %q", vlm.ApiBase, SophnetApiBase)
+	}
+	if vlm.ModelName != "qwen3-vl-plus" {
+		t.Errorf("implicit VLM ModelName = %q, want qwen3-vl-plus", vlm.ModelName)
+	}
+	if vlm.ApiKey != "llm-key" {
+		t.Errorf("implicit VLM ApiKey = %q, want LLM key", vlm.ApiKey)
+	}
+}
+
+// TestVLMUnconfiguredLocalKeepsUnset 验证 MYS-193：VLM 未配置且 LLM 非 Sophnet（本地 LLM）
+// → 不产生隐式 VLM，保持未配置（转发时跳过描述化直接带 image 透传）。
+func TestVLMUnconfiguredLocalKeepsUnset(t *testing.T) {
+	cfg := Config{
+		LLMApiBase: "http://127.0.0.1:8080/v1",
+		LLMApiKey:  "k",
+		LLMModel:   "local-model",
+		LLMEnabled: true,
+		// VLM 全空 = 未配置
+	}
+	vlm := cfg.VLM()
+	if vlm.Enabled {
+		t.Error("local LLM must NOT get an implicit VLM")
+	}
+	if vlm.ModelName != "" || vlm.ApiBase != "" {
+		t.Errorf("local LLM VLM should stay empty, got %+v", vlm)
+	}
+}
+
+// TestVLMConfiguredKeepsConfigured 验证 VLM 已配置时原样返回（不触发隐式兜底）。
+func TestVLMConfiguredKeepsConfigured(t *testing.T) {
+	cfg := Config{
+		LLMApiBase: SophnetApiBase,
+		LLMModel:   "sophnet-deepseek",
+		LLMEnabled: true,
+		VLMApiBase: "http://vlm.example.com/v1",
+		VLMModel:   "custom-vlm",
+		VLMEnabled: true,
+	}
+	vlm := cfg.VLM()
+	if vlm.ApiBase != "http://vlm.example.com/v1" || vlm.ModelName != "custom-vlm" {
+		t.Errorf("configured VLM should be returned as-is, got %+v", vlm)
+	}
+}
+
+// TestVLMModelDefaultByApiBase 验证 defaultVLMModel：Sophnet → qwen3-vl-plus；本地 → 空。
+func TestVLMModelDefaultByApiBase(t *testing.T) {
+	if m := defaultVLMModel(SophnetApiBase); m != "qwen3-vl-plus" {
+		t.Errorf("sophnet default vlm model = %q, want qwen3-vl-plus", m)
+	}
+	if m := defaultVLMModel("http://127.0.0.1:8080/v1"); m != "" {
+		t.Errorf("local default vlm model = %q, want empty", m)
+	}
+}
+
+// TestSaveConfigVLMDefaultFallback 验证 SaveConfig：请求不带 VLMModel 时，
+// LLM 为 Sophnet → 落库 qwen3-vl-plus；LLM 为本地 → VLMModel 保持空。
+func TestSaveConfigVLMDefaultFallback(t *testing.T) {
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+
+	// Sophnet LLM：不传 VLMModel → 落库默认 qwen3-vl-plus
+	saved, err := svc.SaveConfig(SaveRequest{
+		LLMApiBase: SophnetApiBase,
+		LLMApiKey:  "k",
+		LLMModel:   "sophnet-deepseek",
+	})
+	if err != nil {
+		t.Fatalf("save (sophnet): %v", err)
+	}
+	if saved.VLMModel != "qwen3-vl-plus" {
+		t.Errorf("sophnet save VLMModel = %q, want qwen3-vl-plus", saved.VLMModel)
+	}
+
+	// 本地 LLM：不传 VLMModel → VLMModel 保持空（本地 LLM 直接吃图）
+	saved2, err := svc.SaveConfig(SaveRequest{
+		LLMApiBase: "http://127.0.0.1:8080/v1",
+		LLMApiKey:  "k",
+		LLMModel:   "local-model",
+	})
+	if err != nil {
+		t.Fatalf("save (local): %v", err)
+	}
+	if saved2.VLMModel != "" {
+		t.Errorf("local save VLMModel = %q, want empty", saved2.VLMModel)
+	}
+	// normalizeDefaults 同样按 LLM 分流，不把本地场景的 VLMModel 回填为 qwen3-vl-plus
+	if got := svc.LoadConfig(); got.VLMModel != "" {
+		t.Errorf("local LoadConfig VLMModel = %q, want empty", got.VLMModel)
+	}
+}
 
 // TestForwardModelKeptForImage 验证带图请求：model 保留请求值，图片仍走 VLM 描述化后整体路由 LLM。
 func TestForwardModelKeptForImage(t *testing.T) {
@@ -572,6 +680,158 @@ func TestImageCacheTTL(t *testing.T) {
 func mustJSON(v interface{}) string {
 	b, _ := json.Marshal(v)
 	return string(b)
+}
+
+// TestImagePassthroughLocalLLM 验证 MYS-193：VLM 未配置 + LLM 非 Sophnet（本地 LLM）
+// → 跳过描述化，含 image 的 body 原样转发到本地 LLM API。
+func TestImagePassthroughLocalLLM(t *testing.T) {
+	var gotBody map[string]interface{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	off := false
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "local-model",
+		LLMOverride: boolPtr(false),
+		// VLM 显式未配置（disabled + 空模型）
+		VLMEnabled: &off,
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	setActive(svc.LoadConfig())
+
+	imgData := []byte("fake-png-bytes-local")
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	body, _ := json.Marshal(map[string]interface{}{
+		"model": "devproxy",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{
+				{"type": "text", "text": "what is this"},
+				{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+			}},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	// 上游收到的 body 必须保留 image_url 块（未被描述化替换）
+	msgs := gotBody["messages"].([]interface{})
+	m0 := msgs[0].(map[string]interface{})
+	content := m0["content"].([]interface{})
+	foundImage := false
+	for _, c := range content {
+		block := c.(map[string]interface{})
+		if block["type"] == "image_url" {
+			foundImage = true
+		}
+		if block["type"] == "text" && strings.Contains(block["text"].(string), "这里有一个 image") {
+			t.Error("image should NOT be described when VLM unconfigured (local LLM)")
+		}
+	}
+	if !foundImage {
+		t.Errorf("image_url block should be passed through untouched, got: %s", mustJSON(gotBody))
+	}
+}
+
+// TestImageDescribedForSophnetImplicitVLM 验证 MYS-193：VLM 未配置 + LLM 为 Sophnet
+// → 隐式 VLM（qwen3-vl-plus）仍对图片做描述化，描述请求 model 为 qwen3-vl-plus、
+// Authorization 复用 LLM 的 key。
+func TestImageDescribedForSophnetImplicitVLM(t *testing.T) {
+	var vlmModel string
+	var vlmAuth string
+	var gotLLMBody map[string]interface{}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req map[string]interface{}
+		_ = json.Unmarshal(body, &req)
+		if strings.HasPrefix(r.URL.Path, "/vlm") {
+			vlmModel, _ = req["model"].(string)
+			vlmAuth = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"一只猫在沙发上"}}]}`))
+			return
+		}
+		// 其余请求（本测试场景中仅有 LLM 转发）即 LLM 上游
+		gotLLMBody = req
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"x","object":"chat.completion","choices":[]}`))
+	}))
+	defer upstream.Close()
+
+	db := setupTestDB(t)
+	defer db.Close()
+	svc := NewService(db)
+	off := false
+	cfg, _ := svc.SaveConfig(SaveRequest{
+		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "sophnet-model",
+		LLMOverride: boolPtr(false),
+		VLMEnabled:  &off,
+	})
+	cfg.ForwardKey = "fk"
+	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
+	// 注入 Sophnet LLM API Base + 隐式 VLM 目标（Mock 上游）
+	cfg.LLMApiBase = SophnetApiBase
+	cfg.VLMApiBase = upstream.URL + "/vlm"
+	cfg.VLMApiKey = ""
+	cfg.LLMApiKey = "k"
+	setActive(cfg)
+	globalImageCache = newImageCache(10 << 20)
+
+	imgData := []byte("fake-png-bytes-sophnet")
+	b64 := base64.StdEncoding.EncodeToString(imgData)
+	body, _ := json.Marshal(map[string]interface{}{
+		"model": "devproxy",
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": []map[string]interface{}{
+				{"type": "text", "text": "what is this"},
+				{"type": "image_url", "image_url": map[string]string{"url": "data:image/png;base64," + b64}},
+			}},
+		},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	handleChatCompletions(rec, req)
+	// 注意：LLM 上游为真实 Sophnet（假 key 无法验证），LLM 转发必然 401；
+	// 本测试只验证「VLM 未配置 + LLM=Sophnet 时隐式 VLM 生效」：
+	//   1. 含图请求的图片被隐式 VLM（qwen3-vl-plus）描述化（mock 收到描述请求）
+	//   2. 描述请求 model=qwen3-vl-plus、Authorization=Bearer <LLM key>
+	// 若 mock 未收到描述请求（vlmModel 为空），说明隐式 VLM 未生效 → 测试失败。
+	if vlmModel != "qwen3-vl-plus" {
+		t.Fatalf("implicit VLM not used: vlmModel = %q, want qwen3-vl-plus (mock should receive describe request)", vlmModel)
+	}
+	if vlmAuth != "Bearer k" {
+		t.Errorf("implicit VLM auth = %q, want Bearer k (LLM key reused)", vlmAuth)
+	}
+	// 描述请求已到达 mock 即证明图片被描述化链路处理（LLM 转发发 Sophnet，mock 收不到 LLM body）
+	if gotLLMBody == nil {
+		t.Log("LLM 转发发 Sophnet（预期），mock 仅收到描述请求")
+	} else {
+		msgs := gotLLMBody["messages"].([]interface{})
+		m0 := msgs[0].(map[string]interface{})
+		content := m0["content"].([]interface{})
+		foundDesc := false
+		for _, c := range content {
+			block := c.(map[string]interface{})
+			if block["type"] == "text" && strings.Contains(block["text"].(string), "这里有一个 image") {
+				foundDesc = true
+			}
+		}
+		if !foundDesc {
+			t.Errorf("image should be described via implicit VLM, got: %s", mustJSON(gotLLMBody))
+		}
+	}
 }
 
 // TestModelsEndpoint 验证 /v1/models 返回 LLM/VLM 模型名。

--- a/source/pbmssm/mvc/llmproxy/service.go
+++ b/source/pbmssm/mvc/llmproxy/service.go
@@ -85,7 +85,9 @@ func (s *Service) SaveConfig(req SaveRequest) (Config, error) {
 		LLMOverride: enabled(req.LLMOverride, cur.LLMOverride),
 		VLMApiBase:  nonEmpty(req.VLMApiBase, cur.VLMApiBase, "https://www.sophnet.com/api/open-apis/v1"),
 		VLMApiKey:   nonEmpty(req.VLMApiKey, cur.VLMApiKey, ""),
-		VLMModel:    nonEmpty(req.VLMModel, cur.VLMModel, "sophnet-vl-flash"),
+		// VLMModel 为空（未配置）时按 LLM API Base 分流默认模型（MYS-193）：
+		// Sophnet → qwen3-vl-plus；本地 LLM → 保持空（不经过描述化，直接带 image 透传）。
+		VLMModel: nonEmpty(req.VLMModel, defaultVLMModel(nonEmpty(req.LLMApiBase, cur.LLMApiBase))),
 		VLMEnabled:  enabled(req.VLMEnabled, cur.VLMEnabled),
 		VLMOverride: enabled(req.VLMOverride, cur.VLMOverride),
 		ForwardKey:  cur.ForwardKey,
@@ -149,6 +151,7 @@ func (c Config) ToResponse(written bool) ConfigResponse {
 }
 
 // normalizeDefaults 补齐默认值（兼容旧表结构缺字段）。
+// VLMModel 为空时按 LLM API Base 分流（MYS-193）：Sophnet → qwen3-vl-plus；本地 LLM → 保持空。
 func (c *Config) normalizeDefaults() {
 	def := DefaultConfig()
 	if strings.TrimSpace(c.LLMApiBase) == "" {
@@ -161,7 +164,7 @@ func (c *Config) normalizeDefaults() {
 		c.VLMApiBase = def.VLMApiBase
 	}
 	if strings.TrimSpace(c.VLMModel) == "" {
-		c.VLMModel = def.VLMModel
+		c.VLMModel = defaultVLMModel(c.LLMApiBase)
 	}
 }
 

--- a/source/pbmssm/mvc/llmproxy/test.go
+++ b/source/pbmssm/mvc/llmproxy/test.go
@@ -56,8 +56,17 @@ func testImageDispatch(ctx context.Context, cfg Config) TestResult {
 	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
 		return TestResult{Name: name, OK: false, Message: "LLM 上游未配置或未启用"}
 	}
-
-	// 构造含图请求（内嵌一张 1x1 PNG 测试图）。
+	// VLM 未配置（非 Sophnet 本地 LLM 场景）：跳过描述化，直接带 image 转发给本地 LLM。
+	if !vlm.Enabled || vlm.ApiBase == "" || vlm.ModelName == "" {
+		body, statusCode, err := forwardLLM(ctx, buildImageDispatchReq(), llm, vlm)
+		if err != nil {
+			return TestResult{Name: name, OK: false, Message: "转发失败: " + err.Error()}
+		}
+		if statusCode != http.StatusOK {
+			return TestResult{Name: name, OK: false, Message: fmt.Sprintf("上游返回 %d: %s", statusCode, truncate(string(body), 200))}
+		}
+		return TestResult{Name: name, OK: true, Message: "VLM 未配置，图片直接透传本地 LLM 成功: " + truncate(string(body), 200)}
+	}
 	// 注意：messages 必须用 []interface{} 构造（与 JSON 反序列化后类型一致），
 	// 否则 describeImagesInRequest 的 []interface{} 类型断言会失败，图片不会被描述化。
 	png := testPNG()
@@ -82,6 +91,24 @@ func testImageDispatch(ctx context.Context, cfg Config) TestResult {
 		return TestResult{Name: name, OK: false, Message: fmt.Sprintf("上游返回 %d: %s", statusCode, truncate(string(body), 200))}
 	}
 	return TestResult{Name: name, OK: true, Message: "图片描述化 + LLM 转发成功: " + truncate(string(body), 200)}
+}
+
+// buildImageDispatchReq 构造带图请求（内嵌一张 1x1 PNG 测试图）。
+func buildImageDispatchReq() map[string]interface{} {
+	png := testPNG()
+	b64 := base64.StdEncoding.EncodeToString(png)
+	return map[string]interface{}{
+		"model": "devproxy",
+		"messages": []interface{}{
+			map[string]interface{}{
+				"role": "user",
+				"content": []interface{}{
+					map[string]interface{}{"type": "text", "text": "请用一句话描述这张图片"},
+					map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "data:image/png;base64," + b64}},
+				},
+			},
+		},
+	}
 }
 
 // testLLMInference 测试纯文本 LLM 推理。
@@ -109,13 +136,17 @@ func testLLMInference(ctx context.Context, cfg Config) TestResult {
 
 // forwardLLM 核心转发：图片描述化（可选）+ model 请求优先/默认兜底 + 调 LLM 上游，返回响应体与状态码。
 // 供 handleChatCompletions 与测试接口共用。
+// VLM 未配置时（!vlm.Enabled || ApiBase=="" || ModelName==""）跳过描述化：
+// 本地 LLM 场景（LLM API Base 非 Sophnet）直接透传含 image 的 body 给本地 API。
 func forwardLLM(ctx context.Context, req map[string]interface{}, llm, vlm ProviderConfig) ([]byte, int, error) {
 	if !llm.Enabled || llm.ApiBase == "" || llm.ModelName == "" {
 		return nil, 0, fmt.Errorf("llm upstream not configured")
 	}
-	// 图片描述化（若含图）
-	if err := describeImagesInRequest(req, vlm); err != nil {
-		return nil, 0, fmt.Errorf("image describe failed: %w", err)
+	// 图片描述化（若含图）：VLM 已配置才描述；未配置则原样透传（本地 LLM 直接吃图）
+	if vlm.Enabled && vlm.ApiBase != "" && vlm.ModelName != "" {
+		if err := describeImagesInRequest(req, vlm); err != nil {
+			return nil, 0, fmt.Errorf("image describe failed: %w", err)
+		}
 	}
 	// 覆盖下游请求（OverrideModel）控制转发的 model 取值：
 	//   - true：无论下游请求里 model 是什么，转发时一律强制替换为配置的默认模型名；

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -9,7 +9,10 @@
 // 未配置 / 未携带 / 不匹配均放行，不强制拦截。转发时用 bmssm 内部存储的上游 key。
 package llmproxy
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // ProviderConfig 单套上游模型配置（LLM / VLM 各一份）。
 type ProviderConfig struct {
@@ -42,7 +45,7 @@ type Config struct {
 // TableName 指定表名。
 func (Config) TableName() string { return "llm_proxy_config" }
 
-// DefaultConfig 返回默认配置（sophnet 上游：LLM=deepseek，VLM=vl-flash）。
+// DefaultConfig 返回默认配置（sophnet 上游：LLM=deepseek，VLM=qwen3-vl-plus）。
 // ApiBase 为 OpenAI 兼容 base（转发时直接拼 /chat/completions）。
 // LLMOverride/VLMOverride 默认开启「覆盖下游请求」：新装转发一律用默认模型名。
 func DefaultConfig() Config {
@@ -53,7 +56,7 @@ func DefaultConfig() Config {
 		LLMEnabled:  true,
 		LLMOverride: true,
 		VLMApiBase:  "https://www.sophnet.com/api/open-apis/v1",
-		VLMModel:    "sophnet-vl-flash",
+		VLMModel:    "qwen3-vl-plus",
 		VLMEnabled:  true,
 		VLMOverride: true,
 	}
@@ -67,14 +70,58 @@ const (
 	ProviderVLM Provider = "vlm"
 )
 
+// SophnetApiBase 是 sophnet 官方 API 的 OpenAI 兼容 base 地址。
+// 判断 LLM 上游是否为 Sophnet 的判定源：LLM API Base URL 等于它时，视为 Sophnet 云端 LLM。
+const SophnetApiBase = "https://www.sophnet.com/api/open-apis/v1"
+
+// SophnetVLMModel 是 Sophnet 场景下 VLM 未配置时的默认视觉模型。
+const SophnetVLMModel = "qwen3-vl-plus"
+
+// defaultVLMModel 返回 VLM 默认模型：LLM 上游为 Sophnet 时用 qwen3-vl-plus，
+// 否则（本地 LLM）保持空（VLM 未配置 → 不经过描述化，直接带 image 向本地 API 请求）。
+func defaultVLMModel(llmApiBase string) string {
+	if strings.TrimSpace(llmApiBase) == SophnetApiBase {
+		return SophnetVLMModel
+	}
+	return ""
+}
+
 // LLM 返回 LLM 上游配置。
 func (c Config) LLM() ProviderConfig {
 	return ProviderConfig{ApiBase: c.LLMApiBase, ApiKey: c.LLMApiKey, ModelName: c.LLMModel, Enabled: c.LLMEnabled, OverrideModel: c.LLMOverride}
 }
 
 // VLM 返回 VLM 上游配置。
+// VLM 未配置时按 LLM API Base URL 分流默认模型（MYS-193）：
+//   - LLM 为 Sophnet（apiBase == SophnetApiBase）→ 隐式 Sophnet VLM（qwen3-vl-plus），
+//     图片仍走描述化链路，key 复用 LLM 的 ApiKey；
+//   - 否则（本地 LLM）→ 保持未配置，forwardLLM 将跳过描述化、直接带 image 转发给本地 LLM。
 func (c Config) VLM() ProviderConfig {
-	return ProviderConfig{ApiBase: c.VLMApiBase, ApiKey: c.VLMApiKey, ModelName: c.VLMModel, Enabled: c.VLMEnabled, OverrideModel: c.VLMOverride}
+	vlm := ProviderConfig{ApiBase: c.VLMApiBase, ApiKey: c.VLMApiKey, ModelName: c.VLMModel, Enabled: c.VLMEnabled, OverrideModel: c.VLMOverride}
+	if vlm.Enabled && vlm.ApiBase != "" && vlm.ModelName != "" {
+		return vlm
+	}
+	if strings.TrimSpace(c.LLMApiBase) == SophnetApiBase {
+		return ProviderConfig{
+			// 隐式 VLM 默认打到 Sophnet；已有 VLMApiBase 配置（如测试注入）则优先复用
+			ApiBase:       nonEmptyVLMBase(c.VLMApiBase, SophnetApiBase),
+			ApiKey:        c.LLMApiKey,
+			ModelName:     SophnetVLMModel,
+			Enabled:       true,
+			OverrideModel: true,
+		}
+	}
+	return vlm
+}
+
+// nonEmptyVLMBase 取第一个非空值；全部为空时回退 fallback。
+func nonEmptyVLMBase(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return strings.TrimSpace(v)
+		}
+	}
+	return ""
 }
 
 // Provider 按类型取上游配置。


### PR DESCRIPTION
## 需求

Agent Proxy 代理功能针对 **VLM 未配置** 场景做默认化分流（MYS-193）。判定源是 **LLM 的 API Base URL**：

1. **LLM API Base == Sophnet**（`https://www.sophnet.com/api/open-apis/v1`）→ 隐式 VLM 默认模型 `qwen3-vl-plus`，图片仍走描述化链路
2. **LLM API Base 非 Sophnet**（本地 LLM）→ 跳过描述化，直接带 image 向本地 API 请求

## 改动

### source/pbmssm/mvc/llmproxy/types.go
- 新增常量 `SophnetApiBase` / `SophnetVLMModel`（qwen3-vl-plus）
- `VLM()`：VLM 未配置（!Enabled || ApiBase=="" || ModelName==""）且 LLM 为 Sophnet 时，构造隐式 VLM ProviderConfig（ApiBase 复用已配置 VLMApiBase 或默认 Sophnet，ModelName=qwen3-vl-plus，ApiKey 复用 LLM 的 key）；否则保持原样
- `DefaultConfig`：VLMModel 默认 `sophnet-vl-flash` → `qwen3-vl-plus`

### source/pbmssm/mvc/llmproxy/service.go
- `SaveConfig`：VLMModel 为空时按 LLM API Base 分流（Sophnet → qwen3-vl-plus；本地 → 空）
- `normalizeDefaults`：同样按 LLM API Base 分流，本地场景不回填默认模型

### source/pbmssm/mvc/llmproxy/test.go
- `forwardLLM`：仅当 VLM 已配置时才做图片描述化；未配置直接透传含 image 的 body
- `testImageDispatch`：适配本地 LLM 直接透传场景（不要求 VLM 描述）

### source/pbmssm/mvc/llmproxy/server_test.go
- 补单测：隐式 VLM 兜底（Sophnet→qwen3-vl-plus / 本地→保持未配置）、SaveConfig 分流兜底、本地 LLM 图片透传、Sophnet 隐式 VLM 描述化

## 测试

- `go test ./mvc/llmproxy/` 全部通过（27 个用例）
- `go vet ./mvc/llmproxy/` 无告警
