### PR TITLE
feat(psophliteos): Agent 服务管理删除「会话 xx」展示 (MYS-194)

### DIFF
--- a/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue
@@ -87,7 +87,6 @@
             <a-tag :color="serviceEnabled ? 'green' : 'red'">
               {{ serviceEnabled ? '运行中' : '已停止' }}
             </a-tag>
-            <span v-if="svc && svc.sessionCount" class="ml-2"> 会话 {{ svc.sessionCount }} </span>
           </div>
         </div>
         <p class="mt-3 text-xs text-gray-400">


### PR DESCRIPTION
## 需求
S5 Agent 配置页删除「Agent 服务管理」卡状态区的「会话 xx」展示。

## 改动
`source/psophliteos/frontend/src/views/ai-agent/apiConfig/index.vue`：删除 `会话 {{ svc.sessionCount }}` 展示元素（约 L90）。

## 说明
- 仅删 UI 展示，`ServiceStatus` 接口及 `sessionCount` 字段保留（服务端 pbmssm 完整链路一部分，conservative 起见不破坏 `getServiceStatus` 接口）。
- `svc` 变量仍被 `serviceEnabled` computed 使用，未清理。

## 测试
前端改动为单行删除展示元素，不影响其他逻辑。

关联 issue: MYS-194