### PR TITLE
feat(psophliteos): AI Agent 页删除 agent 身份标签，用户消息气泡左对齐 (MYS-195)

### DIFF
--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -96,7 +96,6 @@
             </div>
           </div>
           <div v-else class="webchat-msg webchat-msg-assistant">
-            <span v-if="m.model" class="webchat-msg-model">{{ m.model }}</span>
             <div class="webchat-bubble" v-html="renderMarkdown(m.content)"></div>
           </div>
         </template>
@@ -144,7 +143,6 @@
     role: 'user' | 'assistant';
     kind?: string;
     content: string;
-    model?: string;
     open?: boolean;
     // 权限审批卡片字段
     permReqId?: number;
@@ -394,7 +392,6 @@
     const messageId = payload.message_id || '';
     const kind = payload.kind || 'text';
     const content = payload.content || '';
-    const model = payload.model_name || '';
 
     if (kind === 'text') {
       // 连续 text 合并到最近一条 assistant 文本（修复拆泡）
@@ -407,14 +404,12 @@
         !s.messages.some((m) => m.key === messageId)
       ) {
         last.content += content;
-        last.model = last.model || model;
         return;
       }
       s.messages.push({
         key: messageId || 'msg' + msgSeq++,
         role: 'assistant',
         content,
-        model,
         open: false,
       });
     } else if (kind === 'thought') {
@@ -542,7 +537,6 @@
       role: m.role === 'user' ? 'user' : 'assistant',
       kind: m.kind || (m.role === 'user' ? '' : 'text'),
       content: m.content || '',
-      model: m.model || '',
       open: false,
     }));
     if (payload.title && s.title !== payload.title) s.title = payload.title;
@@ -876,7 +870,7 @@
     display: flex;
   }
   .webchat-msg-user {
-    justify-content: flex-end;
+    justify-content: flex-start;
   }
   .webchat-msg-assistant {
     justify-content: flex-start;
@@ -946,14 +940,6 @@
     font-size: 12.5px;
     font-weight: 600;
     color: #666;
-  }
-
-  .webchat-msg-model {
-    font-size: 11px;
-    color: #999;
-    margin-right: 8px;
-    align-self: flex-start;
-    margin-top: 8px;
   }
 
   .webchat-collapse {


### PR DESCRIPTION
## Summary
- 删除 AI Agent/Agent 页 assistant 消息的身份标签 `.webchat-msg-model`（model 名展示），及其在 `ChatMsg` 接口、`handleCreate`、`handleSessionHistory` 中的 `model` 字段处理
- 前端仅在 Api 连接函数 `defaultReasonixWsUrl` 出现 Reasonix 字样，无独立头像/logo UI，无其他需删除内容（已全局 grep 核查）
- `.webchat-msg-user` 由 `justify-content: flex-end` 改为 `flex-start`，用户与 agent 消息统一左对齐；用户气泡保持蓝色、agent 灰白，色差可读

## 验证
- 前端完整 `npm run build` 通过（`✨ build successfully!`）
- 编译产物确认：`.webchat-msg-user` 与 `.webchat-msg-assistant` 均 `justify-content:flex-start`，无 `.webchat-msg-model` 残留

## 关联
- 处理 MYS-195

🤖 Generated with [Claude Code](https://claude.com/Claude)