### PR TITLE
style(psophliteos): 减小 AI Agent 页输入区与浏览器底部空隙 (MYS-198)

### DIFF
--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -762,7 +762,7 @@
 <style lang="less" scoped>
   .webchat {
     display: flex;
-    height: calc(100vh - 150px);
+    height: calc(100vh - 110px);
     border: 1px solid #e5e7eb;
     border-radius: 8px;
     overflow: hidden;
@@ -1089,7 +1089,7 @@
 
   .webchat-input-area {
     border-top: 1px solid #eee;
-    padding: 12px 16px;
+    padding: 12px 16px 8px;
   }
   .webchat-input-box {
     display: flex;


### PR DESCRIPTION
## Summary

- 减小 AI Agent 页（`source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue`）输入区与浏览器底部空隙。
- `.webchat` 高度由 `calc(100vh - 150px)` 调整为 `calc(100vh - 110px)`，减小底部预留的空隙。
- `.webchat-input-area` 底部 padding 由 `12px 16px` 调整为 `12px 16px 8px`，输入框进一步贴近可视区底部，保留可读留白。

## Test

- `NODE_ENV=production vite build` 构建通过；产物 `WebChat.*.css` 已包含新样式值 `calc(100vh - 110px)` 与 `padding:12px 16px 8px`。

MYS-198