### PR TITLE
feat: AI Agent/概览/配置 4 项改动（自动审批+停止、sophliteos 版本、跳底、agent/llm 默认关）(MYS-210)

### DIFF
--- a/source/pbmssm/initialization/init.go
+++ b/source/pbmssm/initialization/init.go
@@ -92,10 +92,11 @@ func InitBase() {
 		BoardType: global.ModuleTypeEx,
 	})
 
-	// LLM API 转发 server：迁移旧表结构、读取已存配置启动（或禁用）。
-	// 配置保存接口会热更新。
+	// LLM API 转发 server：迁移旧表结构、读取已存配置。
+	// 需求(MYS-210)：llm 代理默认关闭，bmssm 启动仅加载配置不自动拉起转发 server
+	// （重启后回到默认关闭）；用户保存配置（enabled=true）经 UpdateServer 才启动。
 	llmproxy.Migrate(database.DB())
-	llmproxy.StartServer(llmproxy.NewService(database.DB()).LoadConfig())
+	llmproxy.InitActiveConfig(llmproxy.NewService(database.DB()).LoadConfig())
 
 	// Reasonix ACP 适配器（agentproxy）：进程管理 + ACP 客户端 + 会话管理。
 	// S2 只装配核心链路；WS 端点/协议适配在 S3 接入。

--- a/source/pbmssm/mvc/agentproxy/module.go
+++ b/source/pbmssm/mvc/agentproxy/module.go
@@ -108,11 +108,11 @@ func (m *Module) Start() error {
 			}
 		}()
 	}
-	if !m.cfg.Enabled {
-		logger.Info("agentproxy: disabled, reasonix acp not started")
-		return nil
-	}
-	return m.pm.Start()
+	// 需求(MYS-210)：agent 服务默认关闭，且 bmssm 重启后保持默认关闭。
+	// 这里不据 m.cfg.Enabled 自动拉起 reasonix 进程（即使配置 enabled=true）——
+	// 仅当用户在「Agent 服务管理」手动 start（SetEnabled(true)）才启动；手动启动会
+	// 持久化 enabled 供页面刷新保持显示，但 bmssm 重启后回到默认关闭。
+	return nil
 }
 
 // Shutdown 优雅关闭：关闭 WS 服务与连接、所有活动会话，再停止进程与客户端。

--- a/source/pbmssm/mvc/agentproxy/process_test.go
+++ b/source/pbmssm/mvc/agentproxy/process_test.go
@@ -244,6 +244,12 @@ func TestModuleEndToEnd(t *testing.T) {
 	}
 	defer m.Shutdown()
 
+	// 需求(MYS-210)：module.Start 不再自动拉起 reasonix（默认关闭，需手动启动）。
+	// 测试模拟用户手动启动进程，驱动 initialize → client 就绪链路。
+	if err := m.pm.Start(); err != nil {
+		t.Fatalf("process start: %v", err)
+	}
+
 	// 等 client 就绪（initialize 完成）
 	waitFor(t, 5*time.Second, "client ready", func() bool {
 		return m.Client() != nil

--- a/source/pbmssm/mvc/llmproxy/server.go
+++ b/source/pbmssm/mvc/llmproxy/server.go
@@ -46,6 +46,18 @@ func StartServer(cfg Config) {
 	UpdateServer(cfg)
 }
 
+// InitActiveConfig 在 bmssm 启动时记录当前配置为生效配置，但不启动转发 server。
+// 需求(MYS-210)：llm 代理默认关闭，bmssm 重启后保持默认关闭——即使配置里
+// enabled=true，启动也不自动拉起转发 server；仅用户手动保存配置（SaveConfig →
+// UpdateServer）后才开启。此函数保证启动后转发链路处于关闭态，同时记录配置供
+// 后续 UpdateServer 热更新比较。
+func InitActiveConfig(cfg Config) {
+	mu.Lock()
+	activeCfg = cfg
+	mu.Unlock()
+	logger.Info("llm proxy config loaded (not started): llm=%s vlm=%s", cfg.LLMModel, cfg.VLMModel)
+}
+
 // UpdateServer 更新配置并应用。若 server 未启动则启动（绑定配置的 listenIP:port）。
 // enabled=false 时停止 server（若在运行）。串行化启动避免并发 double-start。
 func UpdateServer(cfg Config) {

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -124,6 +124,7 @@ func TestForwardKeyRelaxed(t *testing.T) {
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "m",
 		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "m",
+		LLMEnabled: boolPtr(true), VLMEnabled: boolPtr(true),
 	})
 	// 强制设一个已知转发 key
 	cfg.ForwardKey = "test-forward-key"
@@ -171,6 +172,7 @@ func TestForwardKeyUnset(t *testing.T) {
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "m",
 		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "m",
+		LLMEnabled: boolPtr(true),
 	})
 	cfg.ForwardKey = ""
 	setActive(cfg)
@@ -205,6 +207,7 @@ func TestForwardModelPrecedence(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-default",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(false),
 		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
 	})
@@ -272,6 +275,7 @@ func TestForwardModelOverride(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-default",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(true),
 		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
 	})
@@ -444,8 +448,10 @@ func TestForwardModelKeptForImage(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(false),
 		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		VLMEnabled:  boolPtr(true),
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
@@ -507,8 +513,10 @@ func TestImageDescribeRouting(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(false),
 		VLMApiBase:  upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		VLMEnabled:  boolPtr(true),
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
@@ -607,7 +615,9 @@ func TestImageCache(t *testing.T) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		LLMEnabled: boolPtr(true),
 		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		VLMEnabled: boolPtr(true),
 	})
 	cfg.ForwardKey = "fk"
 	_ = svc.db.Model(&Config{}).Where("id = ?", 1).Update("forward_key", "fk").Error
@@ -700,6 +710,7 @@ func TestImagePassthroughLocalLLM(t *testing.T) {
 	off := false
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "local-model",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(false),
 		// VLM 显式未配置（disabled + 空模型）
 		VLMEnabled: &off,
@@ -776,6 +787,7 @@ func TestImageDescribedForSophnetImplicitVLM(t *testing.T) {
 	off := false
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "sophnet-model",
+		LLMEnabled:  boolPtr(true),
 		LLMOverride: boolPtr(false),
 		VLMEnabled:  &off,
 	})

--- a/source/pbmssm/mvc/llmproxy/test_test.go
+++ b/source/pbmssm/mvc/llmproxy/test_test.go
@@ -32,7 +32,9 @@ func setupTestController(t *testing.T) (*Controller, *httptest.Server) {
 	svc := NewService(db)
 	cfg, _ := svc.SaveConfig(SaveRequest{
 		LLMApiBase: upstream.URL + "/llm", LLMApiKey: "k", LLMModel: "llm-target",
+		LLMEnabled: boolPtr(true),
 		VLMApiBase: upstream.URL + "/vlm", VLMApiKey: "k", VLMModel: "vlm-target",
+		VLMEnabled: boolPtr(true),
 	})
 	setActive(cfg)
 	return &Controller{svc: svc}, upstream

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -48,16 +48,18 @@ func (Config) TableName() string { return "llm_proxy_config" }
 // DefaultConfig 返回默认配置（sophnet 上游：LLM=deepseek，VLM=qwen3-vl-plus）。
 // ApiBase 为 OpenAI 兼容 base（转发时直接拼 /chat/completions）。
 // LLMOverride/VLMOverride 默认开启「覆盖下游请求」：新装转发一律用默认模型名。
+// 需求(MYS-210)：LLM/VLM 默认 Enabled=false —— llm 代理默认关闭；用户保存配置
+// （enabled=true）后才开启转发 server，bmssm 重启后回到默认关闭（启动不自动拉起）。
 func DefaultConfig() Config {
 	return Config{
 		ID:          1,
 		LLMApiBase:  "https://www.sophnet.com/api/open-apis/v1",
 		LLMModel:    "sophnet-deepseek",
-		LLMEnabled:  true,
+		LLMEnabled:  false,
 		LLMOverride: true,
 		VLMApiBase:  "https://www.sophnet.com/api/open-apis/v1",
 		VLMModel:    "qwen3-vl-plus",
-		VLMEnabled:  true,
+		VLMEnabled:  false,
 		VLMOverride: true,
 	}
 }

--- a/source/psophliteos/frontend/src/locales/lang/en/overview.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/overview.ts
@@ -18,6 +18,7 @@ export default {
     ctrSN: 'Control board SN',
     system: 'Operating System',
     sdkVersion: 'SDK Version',
+    sophliteosVersion: 'Sophliteos Version',
     runningTime: 'Running Time',
     ip: 'Device IP',
     wanip: 'WAN IP',

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/overview.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/overview.ts
@@ -18,6 +18,7 @@ export default {
     ctrSN: '控制板SN',
     system: '操作系统',
     sdkVersion: 'SDK版本',
+    sophliteosVersion: 'sophliteos版本',
     runningTime: '运行时长',
     ip: '设备IP',
     wanip: 'WAN口IP',

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -57,7 +57,7 @@
         <div class="webchat-header-status" :class="statusClass">{{ statusText }}</div>
       </header>
 
-      <div ref="messagesEl" class="webchat-messages">
+      <div ref="messagesEl" class="webchat-messages" @scroll.passive="onMessagesScroll">
         <template v-for="m in currentMessages" :key="m.key">
           <div v-if="m.role === 'user'" class="webchat-msg webchat-msg-user">
             <div class="webchat-bubble">{{ m.content }}</div>
@@ -100,6 +100,17 @@
         <div v-if="errorMsg" class="webchat-msg webchat-msg-error">
           <div class="webchat-bubble">{{ errorMsg }}</div>
         </div>
+        <!-- 需求(MYS-210)：上翻历史时出现的「跳到最底部」悬浮按钮 -->
+        <Transition name="webchat-fade">
+          <button
+            v-if="showJumpBottom"
+            class="webchat-jump-bottom"
+            type="button"
+            @click="scrollToBottom"
+            aria-label="跳到最底部"
+            >▼</button
+          >
+        </Transition>
       </div>
 
       <footer class="webchat-input-area">
@@ -114,6 +125,25 @@
           </div>
         </div>
         <div class="webchat-input-box">
+          <!-- 需求(MYS-210)：输入框左侧 —— 自动审批开关 + 停止按钮 -->
+          <div class="webchat-input-tools">
+            <label class="webchat-autoapprove" title="开启后，工具权限请求将自动允许（随本会话保存）">
+              <input
+                type="checkbox"
+                v-model="autoApproveOn"
+                @change="onAutoApproveChange"
+              />
+              <span>自动审批</span>
+            </label>
+            <button
+              class="webchat-stop"
+              type="button"
+              :disabled="!activeSess?.busy && !typing"
+              title="停止当前回合"
+              @click="stopAgent"
+              >■</button
+            >
+          </div>
           <textarea
             ref="inputEl"
             v-model="draft"
@@ -163,6 +193,8 @@
     title: string;
     messages: ChatMsg[];
     busy?: boolean;
+    // 需求(MYS-210)：自动审批开关，随会话保存（刷新/换浏览器后恢复）。
+    autoApprove?: boolean;
   }
 
   const SESSIONS_KEY = 'sophon.ai-agent.sessions';
@@ -183,6 +215,10 @@
 
   const messagesEl = ref<HTMLElement | null>(null);
   const inputEl = ref<HTMLTextAreaElement | null>(null);
+  // 需求(MYS-210)：消息区是否可滚动（内容超出视口才显示「跳底」按钮）与是否贴近底部
+  const canScroll = ref(false);
+  const nearBottom = ref(true);
+  const showJumpBottom = computed(() => canScroll.value && !nearBottom.value);
 
   let ws: PicoWs | null = null;
   let forwardKey = '';
@@ -228,6 +264,40 @@
     return msgs.find((m) => m.kind === 'permission' && !m.permDone) || null;
   });
 
+  // 需求(MYS-210)：自动审批开关。绑定当前会话的 autoApprove 字段，
+  // 随 Session 一起持久化（saveSessions / loadSessions），刷新或换浏览器后恢复、
+  // 各会话独立。切换会话/无会话时回退 false。
+  const autoApproveOn = computed<boolean>({
+    get: () => !!activeSess.value?.autoApprove,
+    set: (v: boolean) => {
+      const s = activeSess.value;
+      if (s) {
+        s.autoApprove = v;
+        saveSessions();
+      }
+    },
+  });
+
+  // 开关变更触发。
+  function onAutoApproveChange() {
+    // 无需额外处理：面板只是把 autoApproveOn 的状态落到 Session（见 computed setter）。
+  }
+
+  // 需求(MYS-210)：停止当前回合。向服务端发 session.cancel（agentproxy ws.go 已支持
+  // 该帧 → module.CancelTurn 取消在途回合），本地同步清 typing/busy，避免残留转圈。
+  function stopAgent() {
+    const s = activeSess.value;
+    if (ws && ws.ready && s?.id) {
+      ws.sendFrame({ type: 'session.cancel', session_id: s.id });
+    }
+    typing.value = false;
+    sending.value = false;
+    if (s) {
+      s.busy = false;
+      delete busyCalibAt[s.id];
+    }
+  }
+
   // 异步渲染 markdown → 安全 HTML。消息内容流式累积，用版本号避免旧结果的竞态覆盖。
   let renderSeq = 0;
   function renderMsgHtml(m: ChatMsg) {
@@ -272,6 +342,8 @@
           }
         }
       }, 150);
+      // 内容渲染后刷新消息区滚动状态
+      nextTick(refreshScrollState);
     }
   );
 
@@ -426,6 +498,29 @@
     const toolCall = payload?.tool_call || {};
     if (reqId == null) return;
     const s = ensureSession();
+    // 需求(MYS-210)：开启自动审批的会话 → 不渲染人审卡片，直接回「允许」，
+    // 让 agent 流程不间断。仍记录一条已处理（allow）的 permission 消息供历史可见。
+    if (s.autoApprove) {
+      if (ws && ws.ready) {
+        ws.sendFrame({
+          type: 'permission.respond',
+          session_id: s.id,
+          payload: { session_id: s.id, request_id: reqId, allow: true },
+        });
+      }
+      s.messages.push({
+        key: 'perm' + msgSeq++,
+        role: 'assistant',
+        kind: 'permission',
+        content: '',
+        permReqId: reqId,
+        permTitle: (toolCall.title as string) || '工具调用',
+        permDone: true,
+        open: false,
+      });
+      saveSessions();
+      return;
+    }
     s.messages.push({
       key: 'perm' + msgSeq++,
       role: 'assistant',
@@ -785,6 +880,7 @@
         title: ss.title || '新会话',
         messages: existing ? existing.messages : [],
         busy: false,
+        autoApprove: existing ? existing.autoApprove : false, // 需求(MYS-210)：随会话保留
       };
     });
     // 保留本地尚未同步到服务端的会话
@@ -936,8 +1032,28 @@
 
   function scrollToBottom() {
     nextTick(() => {
-      if (messagesEl.value) messagesEl.value.scrollTop = messagesEl.value.scrollHeight;
+      if (messagesEl.value) {
+        messagesEl.value.scrollTop = messagesEl.value.scrollHeight;
+        refreshScrollState();
+      }
     });
+  }
+
+  // 需求(MYS-210)：刷新「可滚动 / 贴近底部」状态（跳底按钮显隐依据）。
+  function refreshScrollState() {
+    const el = messagesEl.value;
+    if (!el) {
+      canScroll.value = false;
+      nearBottom.value = true;
+      return;
+    }
+    const can = el.scrollHeight > el.clientHeight + 1;
+    canScroll.value = can;
+    nearBottom.value = el.scrollHeight - el.scrollTop - el.clientHeight <= 40;
+  }
+
+  function onMessagesScroll() {
+    refreshScrollState();
   }
 
   // ---------- 连接 ----------
@@ -977,6 +1093,7 @@
     if (saved && sessions.value.some((s) => s.id === saved)) activeId.value = saved;
     if (!activeSess.value) newSession();
     connect();
+    nextTick(refreshScrollState);
     // 兜底2/4：启动忙状态扫描（防回合永不结束致 busy 卡死 + 恢复型 busy 一次性校准）
     busyStallTimer = setInterval(() => {
       clearStalledBusy();
@@ -1170,6 +1287,39 @@
     flex: 1;
     overflow-y: auto;
     padding: 16px;
+    position: relative; /* 供「跳到最底部」悬浮按钮定位 */
+  }
+
+  /* 需求(MYS-210)：上翻历史时出现的「跳到最底部」悬浮按钮 */
+  .webchat-jump-bottom {
+    position: sticky;
+    bottom: 12px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 5;
+    border: 1px solid #d9d9d9;
+    background: rgba(255, 255, 255, 0.92);
+    color: #1a73e8;
+    border-radius: 50%;
+    width: 34px;
+    height: 34px;
+    font-size: 14px;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  }
+  .webchat-jump-bottom:hover {
+    color: #fff;
+    background: #1a73e8;
+    border-color: #1a73e8;
+  }
+  .webchat-fade-enter-active,
+  .webchat-fade-leave-active {
+    transition: opacity 0.2s ease;
+  }
+  .webchat-fade-enter-from,
+  .webchat-fade-leave-to {
+    opacity: 0;
   }
 
   .webchat-msg {
@@ -1462,6 +1612,49 @@
     display: flex;
     align-items: flex-end;
     gap: 8px;
+  }
+  /* 需求(MYS-210)：输入框左侧工具区（自动审批开关 + 停止按钮） */
+  .webchat-input-tools {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
+    flex-shrink: 0;
+    padding-bottom: 2px;
+  }
+  .webchat-autoapprove {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+    color: #666;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+  }
+  .webchat-autoapprove input {
+    accent-color: #1a73e8;
+    cursor: pointer;
+  }
+  .webchat-stop {
+    border: 1px solid #d9d9d9;
+    background: #fff;
+    color: #666;
+    border-radius: 6px;
+    font-size: 12px;
+    line-height: 1;
+    padding: 6px 10px;
+    cursor: pointer;
+    text-align: center;
+  }
+  .webchat-stop:hover:not(:disabled) {
+    border-color: #ff4d4f;
+    color: #ff4d4f;
+  }
+  .webchat-stop:disabled {
+    color: #ccc;
+    cursor: not-allowed;
+    background: #fafafa;
   }
   .webchat-input-box textarea {
     flex: 1;

--- a/source/psophliteos/frontend/src/views/overview/detail-se5.vue
+++ b/source/psophliteos/frontend/src/views/overview/detail-se5.vue
@@ -69,6 +69,10 @@
           <a-descriptions-item :label="t('overview.buildTime')">{{
             originData.bmssmVersion
           }}</a-descriptions-item>
+          <!-- 需求(MYS-210)：显示 sophliteos 版本号（本地 /api/device/version 的 buildname） -->
+          <a-descriptions-item :label="t('overview.device.sophliteosVersion')">{{
+            sophliteosVersion || '-'
+          }}</a-descriptions-item>
           <a-descriptions-item :label="t('overview.device.runningTime')">
             <a-badge status="processing" :text="dynTime" />
           </a-descriptions-item>
@@ -116,9 +120,11 @@
   import DiskLayout from './components/DiskLayout.vue';
   import { getFormatTime } from '/@/utils/dateUtil';
   import { EditOutlined } from '@ant-design/icons-vue';
-  import { setDeviceInfoApi } from '/@/api/overview/index';
+  import { setDeviceInfoApi, getSoftwareInfoApi } from '/@/api/overview/index';
 
   const { t } = useI18n();
+  // 需求(MYS-210)：sophliteos 版本号（本地 /api/device/version → result.buildname）
+  const sophliteosVersion = ref('');
 
   const ADescriptions = Descriptions;
   const ATooltip = Tooltip;
@@ -137,6 +143,17 @@
       loading.value = false;
     });
   }
+
+  // 需求(MYS-210)：拉取本地 sophliteos 版本号（buildname）并入基础信息展示。
+  // 失败静默（版本号非关键信息，保持向后兼容）。
+  getSoftwareInfoApi()
+    .then((res: any) => {
+      const result = res?.result ?? res;
+      sophliteosVersion.value = result?.buildname || '';
+    })
+    .catch(() => {
+      /* ignore */
+    });
 
   const cpuCard = computed(() => {
     const cpu = originData.value.cpu || {};

--- a/source/psophliteos/frontend/src/views/overview/detail.vue
+++ b/source/psophliteos/frontend/src/views/overview/detail.vue
@@ -26,6 +26,10 @@
         <a-descriptions-item :label="t('overview.buildTime')">{{
           originData.bmssmVersion
         }}</a-descriptions-item>
+        <!-- 需求(MYS-210)：显示 sophliteos 版本号（本地 /api/device/version 的 buildname） -->
+        <a-descriptions-item :label="t('overview.device.sophliteosVersion')">{{
+          sophlitesVersion || '-'
+        }}</a-descriptions-item>
         <a-descriptions-item :label="t('overview.device.ip')">{{
           originData.deviceIp
         }}</a-descriptions-item>
@@ -118,9 +122,12 @@
   import CircleGrid from './components/CircleGrid.vue';
   import GaugeChart from './components/Gauge.vue';
   import { useWindowSize } from '@vueuse/core';
+  import { getSoftwareInfoApi } from '/@/api/overview';
 
   const { t } = useI18n();
   const { currentRoute } = useRouter();
+  // 需求(MYS-210)：sophliteos 版本号（本地 /api/device/version → result.buildname）
+  const sophlitesVersion = ref('');
 
   const ADescriptions = Descriptions;
   const ADescriptionsItem = Descriptions.Item;
@@ -137,6 +144,17 @@
       loading.value = false;
     });
   }
+
+  // 需求(MYS-210)：拉取本地 sophliteos 版本号（buildname）并入基础信息展示。
+  // 失败静默（版本号非关键信息，保持向后兼容）。
+  getSoftwareInfoApi()
+    .then((res: any) => {
+      const result = res?.result ?? res;
+      sophlitesVersion.value = result?.buildname || '';
+    })
+    .catch(() => {
+      /* ignore */
+    });
 
   const activeKey = ref('control');
   const chipStatus = {


### PR DESCRIPTION
## 概述
针对 MYS-210 的 4 项改动，涉及 AI Agent 对话框（前端）、设备概览（前端）、后端 bmssm agentproxy / llmproxy。

### 1. 自动审批开关 + 停止按钮（WebChat.vue）
- 输入框左侧新增「自动审批开关」与「停止按钮」。
- 自动审批开关随会话保存（`Session.autoApprove` 进 localStorage），刷新/换浏览器后恢复，各会话独立。
- 开启后 `permission.request` 直接自动 `permission.respond allow`，不渲染人审卡片（仍记录一条已处理记录）。
- 停止按钮发 `session.cancel` 帧（后端 agentproxy ws.go 已支持 → `CancelTurn` 取消在途回合），本地同步清 typing/busy。

### 2. 设备概览基础信息新增 sophliteos 版本（detail.vue + i18n）
- 新增一行「sophliteos 版本」，数据来自本地 `/api/device/version`（`result.buildname`）。
- 补 zh/en i18n key。

### 3. 对话页「跳到最底部」按钮（WebChat.vue）
- 消息区上翻历史时出现右下角悬浮「▼」按钮，点击回底并自动隐藏；贴近底部时隐藏。

### 4. agent 服务与 llm 代理默认关闭（pbmssm）
- `agentproxy.Module.Start` 不再据 `cfg.Enabled` 自动拉起 reasonix（默认关；用户「Agent 服务管理」手动 start 才拉起，重启 bmssm 后回默认关）。WS hub 仍始终启动以保持页面可达。
- `llmproxy.DefaultConfig` 的 LLM/VLM `Enabled` 默认改为 `false`；bmssm 启动改调 `InitActiveConfig` 仅加载配置不自动拉起转发 server（保存配置 enabled=true 经 `UpdateServer` 才启动）。

## 测试
- Go：`go build ./...`、`go test ./...` 全绿（pbmssm）。
- 前端：因本地无 node_modules，交由测试机验证（待部署后实测自动审批/停止、跳底、概览版本、agent/llm 默认关与重启重置）。

## 关联
- Issue: MYS-210