### PR TITLE
fix(psophliteos): go:embed 前端根路径挂载 + markdown 内容样式 :deep 修复 (MYS-189)

### DIFF
--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -1210,72 +1210,72 @@
     overscroll-behavior: contain;
   }
   /* 列表点位与编号 */
-  .webchat-bubble ul,
-  .webchat-collapse-body ul {
+  .webchat-bubble :deep(ul),
+  .webchat-collapse-body :deep(ul) {
     list-style: disc;
     padding-left: 1.5em;
     margin: 0.5em 0;
   }
-  .webchat-bubble ol,
-  .webchat-collapse-body ol {
+  .webchat-bubble :deep(ol),
+  .webchat-collapse-body :deep(ol) {
     list-style: decimal;
     padding-left: 1.5em;
     margin: 0.5em 0;
   }
-  .webchat-bubble li,
-  .webchat-collapse-body li {
+  .webchat-bubble :deep(li),
+  .webchat-collapse-body :deep(li) {
     margin: 0.15em 0;
   }
   /* 表格格子线 */
-  .webchat-bubble table,
-  .webchat-collapse-body table {
+  .webchat-bubble :deep(table),
+  .webchat-collapse-body :deep(table) {
     border-collapse: collapse;
     margin: 0.5em 0;
     width: 100%;
     display: block;
     overflow-x: auto;
   }
-  .webchat-bubble th,
-  .webchat-bubble td,
-  .webchat-collapse-body th,
-  .webchat-collapse-body td {
+  .webchat-bubble :deep(th),
+  .webchat-bubble :deep(td),
+  .webchat-collapse-body :deep(th),
+  .webchat-collapse-body :deep(td) {
     border: 1px solid #d9d9d9;
     padding: 6px 10px;
     text-align: left;
   }
-  .webchat-bubble th,
-  .webchat-collapse-body th {
+  .webchat-bubble :deep(th),
+  .webchat-collapse-body :deep(th) {
     background: #f0f0f0;
     font-weight: 600;
   }
   /* 标题 */
-  .webchat-bubble h1,
-  .webchat-collapse-body h1 {
+  .webchat-bubble :deep(h1),
+  .webchat-collapse-body :deep(h1) {
     font-size: 1.5em;
     margin: 0.6em 0 0.4em;
   }
-  .webchat-bubble h2,
-  .webchat-collapse-body h2 {
+  .webchat-bubble :deep(h2),
+  .webchat-collapse-body :deep(h2) {
     font-size: 1.3em;
     margin: 0.6em 0 0.4em;
   }
-  .webchat-bubble h3,
-  .webchat-collapse-body h3 {
+  .webchat-bubble :deep(h3),
+  .webchat-collapse-body :deep(h3) {
     font-size: 1.15em;
     margin: 0.5em 0 0.35em;
   }
-  .webchat-bubble h4,
-  .webchat-bubble h5,
-  .webchat-bubble h6,
-  .webchat-collapse-body h4,
-  .webchat-collapse-body h5,
-  .webchat-collapse-body h6 {
+  .webchat-bubble :deep(h4),
+  .webchat-bubble :deep(h5),
+  .webchat-bubble :deep(h6),
+  .webchat-collapse-body :deep(h4),
+  .webchat-collapse-body :deep(h5),
+  .webchat-collapse-body :deep(h6) {
     font-size: 1em;
     margin: 0.5em 0 0.3em;
   }
   /* 段落 */
-  .webchat-bubble p,
-  .webchat-collapse-body p {
+  .webchat-bubble :deep(p),
+  .webchat-collapse-body :deep(p) {
     margin: 0.4em 0;
   }
   /* 代码块（代码高亮 / mermaid 回退共用）。
@@ -1283,8 +1283,8 @@
      与 hljs 的 github（浅色）高亮主题 token 颜色（深色系）搭配，保证在浅色气泡内可读。
      暗色模式（html.dark）下气泡为深色，为避免浅色 token 撞深底，代码块保持浅色卡片
      （github 浅色主题的 token 恒为深色），随页面暗色切换不冲突。 */
-  .webchat-bubble .webchat-codeblock,
-  .webchat-collapse-body .webchat-codeblock {
+  .webchat-bubble :deep(.webchat-codeblock),
+  .webchat-collapse-body :deep(.webchat-codeblock) {
     margin: 0.5em 0;
     padding: 10px 12px;
     background: #f6f8fa;
@@ -1294,8 +1294,8 @@
     line-height: 1.5;
     overflow-x: auto;
   }
-  .webchat-bubble .webchat-codeblock code,
-  .webchat-collapse-body .webchat-codeblock code {
+  .webchat-bubble :deep(.webchat-codeblock code),
+  .webchat-collapse-body :deep(.webchat-codeblock code) {
     font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
     white-space: pre;
     word-break: normal;
@@ -1303,14 +1303,14 @@
   }
   /* 暗色页面下代码块保持浅色卡片：hljs 用的是 github(浅色)主题，token 恒为深色，
      深色页面上若让代码块随背景变深会致 token 撞底不可读，故恒保浅底。 */
-  .dark .webchat-bubble .webchat-codeblock,
-  .dark .webchat-collapse-body .webchat-codeblock {
+  .dark .webchat-bubble :deep(.webchat-codeblock),
+  .dark .webchat-collapse-body :deep(.webchat-codeblock) {
     background: #f6f8fa;
     color: #24292e;
   }
   /* 行内代码 */
-  .webchat-bubble code:not(.webchat-codeblock code),
-  .webchat-collapse-body code:not(.webchat-codeblock code) {
+  .webchat-bubble :deep(code:not(.webchat-codeblock code)),
+  .webchat-collapse-body :deep(code:not(.webchat-codeblock code)) {
     background: rgba(27, 31, 35, 0.08);
     padding: 0.15em 0.35em;
     border-radius: 4px;
@@ -1318,8 +1318,8 @@
     font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
   }
   /* 引用 */
-  .webchat-bubble blockquote,
-  .webchat-collapse-body blockquote {
+  .webchat-bubble :deep(blockquote),
+  .webchat-collapse-body :deep(blockquote) {
     margin: 0.5em 0;
     padding: 4px 12px;
     border-left: 3px solid #d9d9d9;
@@ -1327,8 +1327,8 @@
     background: rgba(0, 0, 0, 0.03);
   }
   /* mermaid 图表容器 */
-  .webchat-bubble .webchat-mermaid,
-  .webchat-collapse-body .webchat-mermaid {
+  .webchat-bubble :deep(.webchat-mermaid),
+  .webchat-collapse-body :deep(.webchat-mermaid) {
     margin: 0.5em 0;
     overflow-x: auto;
     background: #fff;

--- a/source/psophliteos/main.go
+++ b/source/psophliteos/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/fs"
 	"time"
 
 	"sophliteos/initialization"
@@ -9,12 +10,19 @@ import (
 
 func main() {
 	initialization.InitBase()
-	Router := initialization.Routers(embeddedWeb)
+	// 内嵌 FS 根为 dist/（//go:embed dist），取子目录使其暴露在前端期望的服务器根路径
+	// （index.html/assets/_app.config.js 均以根路径 / 引用，见 vite base=/）。
+	webFS, err := fs.Sub(embeddedWeb, "dist")
+	if err != nil {
+		logger.Error("fs.Sub(embeddedWeb,\"dist\") failed: %v", err)
+		webFS = embeddedWeb
+	}
+	Router := initialization.Routers(webFS)
 	s := initialization.InitServer(Router)
 
 	time.Sleep(10 * time.Microsecond)
 
-	err := s.ListenAndServe()
+	err = s.ListenAndServe()
 	if err != nil {
 		logger.Error("An error occurred starting HTTP listener %v", err)
 	}

--- a/source/psophliteos/web_embed.go
+++ b/source/psophliteos/web_embed.go
@@ -6,5 +6,5 @@ import "embed"
 // 构建流程（build/build-deb-sophliteos.sh）先把 frontend/dist 合入 dist/，再 go build，
 // 使单文件二进制自带整套静态前端。发布物为单文件，无需再随包携带/部署 web 静态目录。
 //
-//go:embed dist
+//go:embed all:dist
 var embeddedWeb embed.FS


### PR DESCRIPTION
## Summary

修复哲学：部署最新 main 到设备时，psophliteos 单文件二进制的内嵌 web 端无法正常访问、以及 markdown 内容样式（列表/表格/代码块）不生效。两处都是最小且必要的修复。

## Root cause
1. **go:embed 内嵌前端挂载路径错误**：`web_embed.go` 用 `//go:embed dist` 内嵌，`Routers(embeddedWeb)` 把内嵌 FS（根为 `dist/`）直接挂到 server 上，导致页面在 `/dist/` 下、但其 `index.html` 以根路径 `/` 引用 `/assets/*`、`/_app.config.js`，全部 404 → 白屏。
   - 修复：`main.go` 用 `fs.Sub(embeddedWeb,"dist")` 把内嵌前端暴露到服务器根路径；`web_embed.go` 改 `//go:embed all:dist` 使下划线前缀的 `_app.config.js` 也能打进二进制（Go 默认 embed 忽略 `_`/`.` 开头文件）。
2. **scoped CSS 匹配不到 `v-html` 内容**：`WebChat.vue` 的 `<style scoped>` 中 markdown 内容样式（`.webchat-bubble ul/.table/.webchat-codeblock` 等）被 Vue 编译成 `[data-v-x]` 后代选择器，但 markdown 是由 `renderMarkdownToHtml` 生成后经 `v-html` 注入的嵌套 HTML，不含 `data-v` 属性 → 规则不生效（列表无圆点、表格无格子线、代码块样式不应用）。
   - 修复：把这些 markdown 内容选择器改用 `:deep()`（编译为 `.webchat-bubble[data-v-x] ul`，只要求父元素带 data-v，子元素无需），使其作用于 v-html 内容。

## Changes
- `source/psophliteos/main.go`：`fs.Sub(embeddedWeb,"dist")` 挂载到根路径（含 error 兜底）
- `source/psophliteos/web_embed.go`：`//go:embed all:dist`
- `WebChat.vue`：markdown 内容样式（ul/ol/li、table/th/td、h1-6、p、.webchat-codeblock、行内 code、blockquote、.webchat-mermaid、以及 `.dark` 变体）改用 `:deep()`

## Test
- 已构建 arm64 `soc` deb 部署到测试机（172.26.166.185），sophliteos V2.1.20
- web 根路径 `/`、`/_app.config.js`、`/assets/*` 均 200；页面无 console 报错
- markdown 实测：无序列表 `list-style:disc`、表格 `td border:1px solid`、代码块浅灰底深字（`#f6f8fa/#24292e`）+ hljs 高亮均生效

Closes MYS-189 的部署收口（修复已在测试机验证）。