### PR TITLE
fix(pbmssm): agentproxy 落库合并相邻 text 分片，修复一句话被拆两泡 (MYS-212)

### DIFF
--- a/source/pbmssm/mvc/agentproxy/protocol.go
+++ b/source/pbmssm/mvc/agentproxy/protocol.go
@@ -41,6 +41,7 @@ type StreamState struct {
 	created   map[string]bool            // messageId / toolCallId -> 已发 message.create
 	content   map[string]streamedContent // messageId -> 当前完整内容（含 kind）
 	toolCalls map[string]*ToolCallState  // toolCallId -> 聚合
+	order     []string                   // 本回合 messageId / toolCallId 首次到达顺序（落库合并需保持发言时序）
 	typingOn  bool                       // 当前回合是否仍显示「输入中…」
 }
 
@@ -50,6 +51,7 @@ func NewStreamState() *StreamState {
 		created:   make(map[string]bool),
 		content:   make(map[string]streamedContent),
 		toolCalls: make(map[string]*ToolCallState),
+		order:     []string{},
 		typingOn:  true,
 	}
 }
@@ -150,9 +152,10 @@ func (a *MessageAdapter) messageChunk(ev *ACPSessionUpdate, webchatID, kind stri
 	sc := a.state.content[id]
 	var merged string
 	if sc.Kind == "" {
-		// 首个 chunk：记 kind（text/thought），内容即本段
+		// 首个 chunk：记 kind（text/thought），内容即本段，并记录到达顺序
 		sc.Kind = kind
 		merged = ev.Content
+		a.state.order = appendOrder(a.state.order, id)
 	} else {
 		// 后续 chunk：增量累积
 		merged = sc.Text + ev.Content
@@ -225,6 +228,9 @@ func (a *MessageAdapter) toolCall(ev *ACPSessionUpdate, webchatID string, update
 	a.state.toolCalls[id] = tc
 	already := a.state.created[id]
 	a.state.created[id] = true
+	if !already {
+		a.state.order = appendOrder(a.state.order, id)
+	}
 	typing := a.state.typingOn
 	a.state.typingOn = false
 	a.state.mu.Unlock()
@@ -262,23 +268,47 @@ func (a *MessageAdapter) toolCall(ev *ACPSessionUpdate, webchatID string, update
 
 // RoundAssistants 返回本回合已聚合的 assistant 消息（落库用），并清空聚合状态后重开。
 // text/thought 按 messageId 归并全文，kind 保留；tool_call 按 toolCallId 归并为折叠块摘要。
+//
+// 需求（MYS-212）：reasonix 会把一个连续回答拆成多个不同 messageId 的 text 分片
+// （如同一句被拆成 text-12/text-13）。按 order（到达顺序）遍历，把**相邻的纯 text
+// 分片合并为一条**，遇 thought / tool_calls 才另起，避免落库历史出现「一句话被拆
+// 成两个气泡」。
+//
 // 调用时机：回合结束（prompt stopReason 到达），由连接层追加进会话历史。
 func (a *MessageAdapter) RoundAssistants() []ChatMessage {
 	a.state.mu.Lock()
 	defer a.state.mu.Unlock()
-	out := make([]ChatMessage, 0, len(a.state.content)+len(a.state.toolCalls))
-	for id, sc := range a.state.content {
-		out = append(out, ChatMessage{Role: "assistant", Kind: sc.Kind, Content: sc.Text, ID: id})
-	}
-	for id, tc := range a.state.toolCalls {
-		out = append(out, ChatMessage{Role: "assistant", Kind: "tool_calls", Content: toolCallSummary(tc), ID: id})
+	out := make([]ChatMessage, 0, len(a.state.order))
+	for _, id := range a.state.order {
+		if sc, ok := a.state.content[id]; ok {
+			if sc.Kind == "text" && len(out) > 0 && out[len(out)-1].Kind == "text" {
+				// 相邻纯文本分片：合并进上一条（同一连续回答）
+				out[len(out)-1].Content += sc.Text
+			} else {
+				out = append(out, ChatMessage{Role: "assistant", Kind: sc.Kind, Content: sc.Text, ID: id})
+			}
+		} else if tc, ok := a.state.toolCalls[id]; ok {
+			out = append(out, ChatMessage{Role: "assistant", Kind: "tool_calls", Content: toolCallSummary(tc), ID: id})
+		}
 	}
 	// 清空聚合状态但保留同一把锁（不能整体替换 a.state——会换掉正在持有的 mutex）。
 	a.state.content = make(map[string]streamedContent)
 	a.state.toolCalls = make(map[string]*ToolCallState)
 	a.state.created = make(map[string]bool)
+	a.state.order = []string{}
 	a.state.typingOn = true
 	return out
+}
+
+// appendOrder 把 id 追加到顺序表（幂等：已存在则跳过）。
+// 由于锁内调用，直接用线性查找即可（每条回复 messageId 数量级很小）。
+func appendOrder(order []string, id string) []string {
+	for _, o := range order {
+		if o == id {
+			return order
+		}
+	}
+	return append(order, id)
 }
 
 // modelName 返回 message.create 的 model_name。

--- a/source/pbmssm/mvc/agentproxy/protocol_test.go
+++ b/source/pbmssm/mvc/agentproxy/protocol_test.go
@@ -243,3 +243,45 @@ func TestRoundAssistants(t *testing.T) {
 		}
 	}
 }
+
+// 需求（MYS-212）：reasonix 会把一个连续回答拆成多个不同 messageId 的
+// agent_message_chunk（测试机「为我检查这台设备」会话落库中可见：同一句
+// 「## 当前进展总结」被 reasonix 拆成 text-1='##' 与 text-2=' 当前进展…' 两条
+// 相邻 text 分片）。后端落库时应在回合结束把**相邻的纯 text 分片合并为一条**，
+// 遇 thought / tool_calls 才另起，避免历史里出现「一句话被拆成两个气泡」。
+func TestRoundAssistantsMergesAdjacentTextWithDifferentIDs(t *testing.T) {
+	a := NewMessageAdapter("m")
+	sid := "web-1"
+	// 真实取证：同一句被 reasonix 切成两个不同 messageId 的相邻 text 分片
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "text-1", Content: "##"}, sid)
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "text-2", Content: " 当前进展总结"}, sid)
+	// 一个 thought（应中断 text 合并，独立成条）
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_thought_chunk", MessageID: "thought-1", Content: "思考"}, sid)
+	// thought 后新的相邻 text 分片（不应并入前面的 text-1/text-2）
+	_ = a.OnACPEvent(&ACPSessionUpdate{Discriminator: "agent_message_chunk", MessageID: "text-3", Content: "下一步：升级脚本"}, sid)
+
+	msgs := a.RoundAssistants()
+	var texts []string
+	var thoughts int
+	for _, m := range msgs {
+		switch m.Kind {
+		case "text":
+			texts = append(texts, m.Content)
+		case "thought":
+			thoughts++
+		}
+	}
+	// text-1 与 text-2 相邻纯文本 → 合并为一条；text-3 在 thought 后 → 独立一条
+	if len(texts) != 2 {
+		t.Fatalf("text messages = %d, want 2 (merged ##/当前进展分片 + thought 后的 text-3)", len(texts))
+	}
+	if texts[0] != "## 当前进展总结" {
+		t.Errorf("merged text[0] = %q, want %q", texts[0], "## 当前进展总结")
+	}
+	if texts[1] != "下一步：升级脚本" {
+		t.Errorf("text[1] = %q, want %q", texts[1], "下一步：升级脚本")
+	}
+	if thoughts != 1 {
+		t.Errorf("thought messages = %d, want 1", thoughts)
+	}
+}


### PR DESCRIPTION
## 背景（MYS-212）
用户验证 V2.1.21 后反馈：AI Agent 对话框里「单条消息被拆分到两个气泡」，如一句话「复制到/data2并先做6秒单路冒烟测试」被拆成「复制」+「到 /data2…」两个气泡。MYS-209 只修了前端历史加载合并，实时/落库多条仍存在。

## 根因（后端源码 + 测试机取证）
bmssm agentproxy 是"一条 ACP messageId → 一条会话记录"的忠实记录器（`source/pbmssm/mvc/agentproxy/`）：
- reasonix（ACP `agent_message_chunk`）会把一个**连续回答**拆成多个**不同 messageId** 的 text 分片。
- `MessageAdapter.RoundAssistants` 原先用 **Go map 无序迭代**、按 messageId **逐条** append 落库（`protocol.go`）。
- 测试机「为我检查这台设备」会话落库实锤：同一句「## 当前进展总结」被 reasonix 拆成 `text-1='##'` 与 `text-2=' 当前进展…'` 两条**相邻** text 分片，旧逻辑各自成条 → 刷新后一个气泡拆成两个。

## 修复
`protocol.go` `MessageAdapter`：
- `StreamState` 增加 `order []string`，记录本回合每个 messageId / toolCallId 的**到达顺序**（`messageChunk` 首个 chunk、`toolCall` 首次出现时记录）。
- `RoundAssistants` 改为**按 order 顺序遍历**，把**相邻的纯 text 分片合并为一条**（`out[len-1].Content += sc.Text`），遇 **thought / tool_calls** 才另起新气泡（不跨逻辑段误合并）。

这样新的落库历史里，reasonix 拆出的相邻 text 分片（text-1/text-2）会合并成一条，不再两泡。实时 WS 帧语义保持不变（`messageChunk` 不调整；前端对相邻 text 已有 MYS-209 合并兜底）。

## 验证
- 新增 `TestRoundAssistantsMergesAdjacentTextWithDifferentIDs`：用真实取证分片序列（text-1='##'、text-2=' 当前进展总结'、一个 thought、thought 后 text-3）断言相邻 text 合并为一条、thought 后新段落另起。
- `go build ./...`、`go test ./mvc/agentproxy/ -count=1` 全通过。
- 已在测试机（172.26.166.185）替换 bmssm 并重启，reasonix 已重新拉起 healthy。

## 测试说明（如实）
端到端「新回合落库合并」的实时 UI 对比因 reasonix 单次回复生成慢（DeepSeek、多会话恢复）尚未取到截图；根因实锤（旧数据 text-1/text-2 相邻两条）与合并逻辑（单测）均已确证。可在发版窗口按需再验证界面效果。

🤖 生成自 sophon-tools 开发 agent