### PR TITLE
fix(pbmssm): agentproxy WS 监听默认改 0.0.0.0（S3 前端可直连 18990）

### DIFF
--- a/source/pbmssm/config/bmssm.yaml
+++ b/source/pbmssm/config/bmssm.yaml
@@ -56,7 +56,7 @@ llm-proxy:
 # enabled 默认 false：reasonix 二进制部署（T5 部署步骤）后置 true 再重启 bmssm。
 agentproxy:
   enabled: false                       # 总开关（reasonix 部署后置 true）
-  listenIP: 127.0.0.1                  # WS 服务绑定（S3 使用）
+  listenIP: 0.0.0.0                    # WS 服务绑定（S3 前端 ws://<host>:18990 直连）
   port: 18990                          # WS 端点端口（已核实空闲）
   binaryPath: ""                       # 空则探测 PATH（reasonix）
   workDir: /home/linaro                # 会话 cwd

--- a/source/pbmssm/config/config.go
+++ b/source/pbmssm/config/config.go
@@ -97,8 +97,11 @@ func LoadFromDir(dir string) bool {
 
 	// Reasonix ACP 适配器（agentproxy）：进程管理 + ACP 客户端 + 会话。
 	// enabled 默认 false：reasonix 二进制未部署时不自动拉进程（T5 部署后再开）。
+	// listenIP 默认 0.0.0.0：前端对话页经 ws://<host>/18990/agent/ws 直连 agentproxy，
+	// 绑定回环（127.0.0.1）会导致浏览器无法连上（"连接未就绪"）；WS 已用
+	// token.<forwardKey> 子协议鉴权兜底，暴露到局域网可接受。
 	v.SetDefault("agentproxy.enabled", false)
-	v.SetDefault("agentproxy.listenIP", "127.0.0.1")
+	v.SetDefault("agentproxy.listenIP", "0.0.0.0")
 	v.SetDefault("agentproxy.port", 18990)
 	v.SetDefault("agentproxy.binaryPath", "")
 	v.SetDefault("agentproxy.workDir", "/home/linaro")


### PR DESCRIPTION
## Summary
修复 S3 AI Agent 前端「连接中/连接未就绪」：agentproxy WS 默认只监听回环导致浏览器连不上。

- `config/config.go`：`agentproxy.listenIP` 默认 `127.0.0.1` → `0.0.0.0`
- `config/bmssm.yaml`：出厂配置文件 agentproxy 段 `listenIP: 0.0.0.0`

前端 `WebChat` 经 `ws://<host>:18990/agent/ws` 直连 agentproxy，原默认绑定回环时浏览器无法连上。改为 `0.0.0.0` 后局域网可达；WS 升级前有 `token.<forwardKey>` 子协议鉴权兜底，暴露到局域网可接受。llm-proxy 的 18080 仍保持 127.0.0.1（本机 reasonix 访问，不开放）。

## 验证
- `go build ./config/...` 通过
- SE7 测试机将 agentproxy listenIP 改 0.0.0.0 后，18990 由 `127.0.0.1` 变 `*:18990`，从非回环地址握手返回 **HTTP/1.1 101 Switching Protocols**

🤖 Generated with Claude Code