### PR TITLE
feat(pmem_aging_test): 适配 CV84X2(cv84x6) 芯片

### DIFF
--- a/source/pmem_aging_test/memtest_a53_gdma/memtest_gdma/build.sh
+++ b/source/pmem_aging_test/memtest_a53_gdma/memtest_gdma/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
-SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah")
+SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah" "cv84x6")
 WORK_MODE="PCIE"
 for element in "${SOC_MODE_CPU_MODEL[@]}"; do
     if [ "$element" == "$CPU_MODEL" ]; then
@@ -15,7 +15,7 @@ make clean
 if [[ "${WORK_MODE}" == "SOC" ]]; then
 	if [[ "${CPU_MODEL}" == "bm1684x" ]] || [[ "${CPU_MODEL}" == "bm1684" ]]; then
 		make USE_GDMA_WITH_CORE=0
-	elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]]; then
+	elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]] || [[ "${CPU_MODEL}" == "cv84x6" ]]; then
 		make USE_GDMA_WITH_CORE=1
 	fi
 else

--- a/source/pmem_aging_test/memtest_a53_gdma/start.sh
+++ b/source/pmem_aging_test/memtest_a53_gdma/start.sh
@@ -89,7 +89,7 @@ function memtest_s() {
 			VPU_MEM_USAGE=$(get_ion_usage "/sys/kernel/debug/ion/bm_vpu_heap_dump")
 			VPP_MEM_USAGE=$(get_ion_usage "/sys/kernel/debug/ion/bm_vpp_heap_dump")
 			t_num=4
-		elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]]; then
+		elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]] || [[ "${CPU_MODEL}" == "cv84x6" ]]; then
 			TPU_MEM_USAGE=$(get_ion_usage "/sys/kernel/debug/ion/cvi_npu_heap_dump")
 			VPP_MEM_USAGE=$(get_ion_usage "/sys/kernel/debug/ion/cvi_vpp_heap_dump")
 			VPU_MEM_USAGE="0"
@@ -130,7 +130,7 @@ function memtest_s() {
 	# CPU NAME
 	CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
 	# WORK MODE
-	SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah")
+	SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah" "cv84x6")
 	# TEST CORE ID (only for PCIE MODE)
 	if [[ "${PCIE_DEV_ID}" != "" ]]; then
 		TEST_DEV_ID=${PCIE_DEV_ID}


### PR DESCRIPTION
## 目标

为 sophon-tools 的 **pmem_aging_test** 工具增加 CV84X2(cv84x6) 芯片支持。

## 改动

最小 diff，2 个文件 4 处增删：

| 文件 | 改动 |
|---|---|
| `source/pmem_aging_test/memtest_a53_gdma/memtest_gdma/build.sh` | `SOC_MODE_CPU_MODEL` 新增 `cv84x6`；`USE_GDMA_WITH_CORE` 分支按 CV 家族处理（`bm1688/cv186ah/cv84x6` → `=1`） |
| `source/pmem_aging_test/memtest_a53_gdma/start.sh` | `SOC_MODE_CPU_MODEL` 新增 `cv84x6`；`gdma_fun` 内存 usage 分支按 CV 家族处理（读 `cvi_npu/cvi_vpp` heap） |

## 适配模式

与已合并兄弟适配一致（get_info #57 / memory_edit #58 / sophliteos #59）：CV84X2 归入 CV/edge 家族（同 bm1688/cv186ah 的 C906 核，走 cvi_* 路径），而非 BM1684 式。

## 验证

- `bash -n` 语法检查通过
- 逻辑模拟：`CPU_MODEL=cv84x6` → `WORK_MODE=SOC`，`USE_GDMA_WITH_CORE=1`（CV 家族）
- 交叉编译验证：CV84X2 官方 `aarch64-none-linux-gnu-gcc` 11.3 + CV84X2 libsophon 0.4.13 bmlib，`USE_GDMA_WITH_CORE=1/0` 两分支均编译通过，产物 aarch64 ELF，正确链接 `libbmlib.so.0`