### PR TITLE
feat(pSophUI): 适配 CV84X2（cv84x6）芯片

### DIFF
--- a/source/pSophUI/SophUI/deb/DEBIAN/postinst
+++ b/source/pSophUI/SophUI/deb/DEBIAN/postinst
@@ -1,6 +1,14 @@
 #!/bin/bash
 CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
-if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ];then
+# CV84X2（SDK 标识 cv84x6）读 /proc/cpuinfo model name 可能为 null/空/cv186ah；
+# 以 dts 递归含 "cvitek,cv84x6-" compatible 兜底识别（与 get_info 一致），归入 CV 家族启动 SophonHDMI。
+if [ "$CPU_MODEL" != "bm1688" ] && [ "$CPU_MODEL" != "cv186ah" ] && [ "$CPU_MODEL" != "cv84x6" ] \
+   && [ -d /proc/device-tree ]; then
+    if find /proc/device-tree -name compatible -type f -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null | grep -q .; then
+        CPU_MODEL="cv84x6"
+    fi
+fi
+if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ] || [ "$CPU_MODEL" == "cv84x6" ];then
     sudo rm /etc/systemd/system/SophonHDMIStatus.service /etc/systemd/system/multi-user.target.wants/SophonHDMIStatus.service | true
     sudo systemctl daemon-reload > /dev/null | true
     sudo systemctl enable SophonHDMI > /dev/null

--- a/source/pSophUI/SophUI/deb/DEBIAN/prerm
+++ b/source/pSophUI/SophUI/deb/DEBIAN/prerm
@@ -1,6 +1,14 @@
 #!/bin/bash
 CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
-if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ];then
+# CV84X2（SDK 标识 cv84x6）读 /proc/cpuinfo model name 可能为 null/空/cv186ah；
+# 以 dts 递归含 "cvitek,cv84x6-" compatible 兜底识别（与 get_info 一致），归入 CV 家族停止 SophonHDMI。
+if [ "$CPU_MODEL" != "bm1688" ] && [ "$CPU_MODEL" != "cv186ah" ] && [ "$CPU_MODEL" != "cv84x6" ] \
+   && [ -d /proc/device-tree ]; then
+    if find /proc/device-tree -name compatible -type f -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null | grep -q .; then
+        CPU_MODEL="cv84x6"
+    fi
+fi
+if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ] || [ "$CPU_MODEL" == "cv84x6" ];then
         sudo systemctl stop SophonHDMI > /dev/null | true
         exit 0
 fi

--- a/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
+++ b/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
@@ -42,7 +42,16 @@ function SOPHON_QT_4() {
 export -f SOPHON_QT_4
 
 CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
-if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ];then
+# CV84X2（SDK 标识 cv84x6）读 /proc/cpuinfo model name 可能为 null/空/cv186ah；
+# 以 dts 递归含 "cvitek,cv84x6-" compatible 兜底识别（与 get_info 一致）。
+# cv84x6 与 bm1688/cv186ah 同属 CV 家族，HDMI 走原生 DRM(card0) 通路，与 fl2000/USB 方案区分。
+if [ "$CPU_MODEL" != "bm1688" ] && [ "$CPU_MODEL" != "cv186ah" ] && [ "$CPU_MODEL" != "cv84x6" ] \
+   && [ -d /proc/device-tree ]; then
+    if find /proc/device-tree -name compatible -type f -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null | grep -q .; then
+        CPU_MODEL="cv84x6"
+    fi
+fi
+if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ] || [ "$CPU_MODEL" == "cv84x6" ];then
         function SOPHON_QT_1() {
                 if [[ "$SOPHON_QT_EN_ENABLE" == "1" ]]; then
                         echo "Device Info:"

--- a/source/pSophUI/SophUI/main.cpp
+++ b/source/pSophUI/SophUI/main.cpp
@@ -72,10 +72,19 @@ int main(int argc, char *argv[])
 
     MainWindow w;
     QString device_name = MainWindow::executeLinuxCmd("awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo").trimmed();
+    // CV84X2（SDK 标识 cv84x6）内核 compat 模式下 model name 可能为 null/空/cv186ah；
+    // 以 dts 递归含 "cvitek,cv84x6-" compatible 权威识别（与 get_info 一致），归一化后与 bm1688/cv186ah
+    // 同走 CV 家族的原生 DRM(card0) HDMI 通路与全屏尺寸逻辑。
+    if (device_name != "bm1688" && device_name != "cv186ah" && device_name != "cv84x6") {
+        QString dtsMatch = MainWindow::executeLinuxCmd(
+            "find /proc/device-tree -name compatible -type f -exec grep -laE 'cvitek,cv84x6-' {} + 2>/dev/null | grep -c .").trimmed();
+        if (dtsMatch.toInt() > 0)
+            device_name = "cv84x6";
+    }
     qDebug() << device_name;
     w.fontId = fontId;
     w.app = &a;
-    if (device_name == "bm1688" || device_name == "cv186ah"){
+    if (device_name == "bm1688" || device_name == "cv186ah" || device_name == "cv84x6"){
         QScreen *primaryScreen = QGuiApplication::primaryScreen();
         int screenWidth = primaryScreen->size().width();; // 屏幕分辨率
         int screenHeight= primaryScreen->size().height(); // 屏幕分辨率高度


### PR DESCRIPTION
## Summary
pSophUI（HDMI 显示 UI 框架）适配 CV84X2（SDK 标识 `cv84x6`）芯片，与 bm1688/cv186ah 同归 CV 家族的原生 DRM(card0) HDMI 通路。参照已合并的兄弟适配 get_info(#57) / memory_edit(#58)。

## 背景
CV84X2（=CV84X6）的 dts 含完整 DRM/HDMI 节点（`drm_subsystem` + `dw_hdmi`），HDMI 走 `/dev/dri/card0` 原生通路，与 bm1688/cv186ah 一致，而非 bm1684x/bm1684 的 fl2000/USB 方案。但 CV84X2 内核 compat 模式下 `/proc/cpuinfo` 的 `model name` 可能输出 `null`/空/`cv186ah`，无法直接据此归属 CV 家族。

## 改动点（4 处 CV 家族判断，全部最小 diff）
1. **SophUI/deb/DEBIAN/postinst**：CV 家族条件加 `cv84x6`，使 CV84X2 正确 `enable`/`restart` **SophonHDMI**（避免误走 `SophonHDMIStatus`）
2. **SophUI/deb/DEBIAN/prerm**：CV 家族条件加 `cv84x6`，卸载时正确 `stop SophonHDMI`
3. **SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh**：CV 家族条件加 `cv84x6`，使 CV84X2 走原生 `card0` DRM 通路（而非 fl2000/`devmem chip_reg` 分支）
4. **SophUI/main.cpp**：`device_name` 判断加 `cv84x6`，CV84X2 走全屏/屏幕 DPI 自适应尺寸逻辑（而非固定分辨率路径）

**芯片识别兜底**：因 CV84X2 的 `/proc/cpuinfo model name` 可能为 `null`/空/`cv186ah`，以上各脚本/程序在 model name 落入歧义时不直接判非 CV，而以 **dts 递归含 `cvitek,cv84x6-` compatible** 为权威信号（与 get_info #57 一致），将 `cpu_model` 归一化为 `cv84x6` 后再归入 CV 家族。已确定的 bm1688/bm1684x 等 model name 不作改写，保持既有行为。

## 验证
- 三个 shell 脚本 `bash -n` 语法检查通过
- 交叉编译（arm64，容器 `sophon-tools-build:unified-v1.1.0` + aarch64 Qt 5.12.8）：`release.sh arm64` 全量通过 → `SophUI` ELF aarch64 静态可执行
- 编译产物 `main.o` 含 `cvitek,cv84x6-` 识别串（确认改动已编入）
- 打出的 `sophgo-hdmi_1.6.8_arm64.deb` 内 `run_hdmi_show.sh` 含 cv84x6 逻辑（确认脚本入包）
- bm1688/cv186ah 回归：仅扩展判断多一个 `|| cv84x6` 与歧义兜底；其既有分支逻辑逐字保留，无行为变化

## Test plan
- [ ] CV84X2 真机安装 deb 后 HDMI 直出 SophUI（需硬件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
