### PR TITLE
feat(psocbak): 适配 CV84X2（cv84x6）芯片

### DIFF
--- a/source/psocbak/readme.md
+++ b/source/psocbak/readme.md
@@ -2,7 +2,7 @@
 
 ## 适用场景
 
-* 芯片：BM1684 BM1684X BM1688 CV186AH
+* 芯片：BM1684 BM1684X BM1688 CV186AH CV84X6
 * SDK版本：
   * 84&X 3.0.0以及之前版本（适配只打包功能）
   * 84&X 3.0.0之后版本（适配只打包功能和打包做包功能）
@@ -75,6 +75,9 @@
    # for bm1688 or cv186ah
    ROOTFS_RW_SIZE_BM1688=$((9291456))
    RECOVERY_SIZE_BM1688=$((131072))
+   # for cv84x6（CV84X2，SDK 标识 cv84x6），与 bm1688/cv186ah 同属 CV 系，默认对齐
+   ROOTFS_RW_SIZE_CV84X6=$((9291456))
+   RECOVERY_SIZE_CV84X6=$((131072))
    TGZ_ALL_SIZE=$((100*1024))
    EMMC_ALL_SIZE=20971520
    EMMC_MAX_SIZE=30000000
@@ -84,10 +87,12 @@
    2. `ROOTFS_RW_SIZE`: 根目录RW分区期望大小
    3. `ROOTFS_RW_SIZE_BM1688`: 对于BM1688/CV186AH平台根目录RW分区期望大小
    4. `TGZ_FILES_SIZE_BM1688`: 对于BM1688/CV186AH平台其余分区的期望大小
+   5. `ROOTFS_RW_SIZE_CV84X6`/`TGZ_FILES_SIZE_CV84X6`/`RECOVERY_SIZE_CV84X6`: 对于CV84X6平台根目录RW、其余分区、recovery 分区的期望大小（默认对齐 BM1688）
 4. 修改方式：
    1. 如果是BM1684/BM1684X平台，修改`TGZ_FILES_SIZE`或者`ROOTFS_RW_SIZE`即可
    2. 如果是BM1688/CV186AH平台，修改`TGZ_FILES_SIZE`、`ROOTFS_RW_SIZE_BM1688`或者`TGZ_FILES_SIZE_BM1688`即可
-   3. 修改后的总大小不得大于emmc大小，工具会自动检测，如果遇到`ERROR: bakpack size(XXX) > emmc size(XXX), please del some file and rework.`的报错，请检查文件是否太多了，或者自定义修改的分区期望大小太大了
+   3. 如果是CV84X6平台，修改`TGZ_FILES_SIZE`、`ROOTFS_RW_SIZE_CV84X6`或者`TGZ_FILES_SIZE_CV84X6`即可
+   4. 修改后的总大小不得大于emmc大小，工具会自动检测，如果遇到`ERROR: bakpack size(XXX) > emmc size(XXX), please del some file and rework.`的报错，请检查文件是否太多了，或者自定义修改的分区期望大小太大了
 5. 保存`socbak.sh`文件，继续执行`bash socbak.sh`命令，开始打包
 
 ### 固定分区大小功能

--- a/source/psocbak/socbak/script/bm1688/bm_make_package.sh
+++ b/source/psocbak/socbak/script/bm1688/bm_make_package.sh
@@ -320,9 +320,17 @@ function create_top_script()
 	script_update "led error off"
 	script_update "setenv light 1"
 	script_update ""
-	script_update "#for SE9BX direct to ubuntu"
+	# cv84x6（CV84X2，SDK 标识 cv84x6）与 cv186ah 同属 CV 系复用本打包脚本，但 dts 名不同。
+	# 打包主机（socbak 所在设备）已通过 SOC_NAME 识别芯片，此处按芯片选择对应的
+	# "direct to ubuntu" dts 兜底名：cv84x6 -> config-cv84x6_wevb_emmc，其余 CV 系维持原配置。
+	local dts_fallback="config-cv186ah_sm9v1_4G" dts_desc="SE9BX"
+	if [[ "$SOC_NAME" == "cv84x6" ]]; then
+		dts_fallback="config-cv84x6_wevb_emmc"
+		dts_desc="cv84x6"
+	fi
+	script_update "#for ${dts_desc} direct to ubuntu"
 	script_update "cmp.b 0x05207f82 0x05207f83 1"
-	script_update "if test \$? -eq 1; then setenv consoledev ttyS2; setenv DTS_TYPE config-cv186ah_sm9v1_4G; load mmc 0:1 \${scriptaddr} boot.scr.emmc; source \${scriptaddr}; fi;"
+	script_update "if test \$? -eq 1; then setenv consoledev ttyS2; setenv DTS_TYPE ${dts_fallback}; load mmc 0:1 \${scriptaddr} boot.scr.emmc; source \${scriptaddr}; fi;"
 	script_update ""
 	script_update "if test \"\$reset_after\" = \"1\"; then reset; fi;"
 	script_update ""

--- a/source/psocbak/socbak/script/ota_update/ota_update.sh
+++ b/source/psocbak/socbak/script/ota_update/ota_update.sh
@@ -81,8 +81,25 @@ for tool in "${need_tools[@]}"; do
 done
 
 CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
+# CPU_MODEL 兜底：CV84X2（SDK 标识 cv84x6）内核 compat 模式下 /proc/cpuinfo 可能输出
+# null/缺行/或 cv186ah（asm_decode 对 0x27102014 常解出 "cv186ah"）。cv84x6 与 bm1688/cv186ah
+# 同属 CV 系（C906），但 fip 校验/刷写路径相同；为稳妥统一以 dts 为权威信号：
+# 当 CPU_MODEL 落入歧义集（空/null/cv186ah）且内核 dts 含 "cvitek,cv84x6-*" compatible 时，
+# 升级为 cv84x6。已确定的 bm1684x/bm1684/bm1688 model name 不作改写，保持既有行为。
+case "${CPU_MODEL}" in
+    ""|null|cv186ah)
+        if [ -d /proc/device-tree ]; then
+            _cv_match=$(find /proc/device-tree -name compatible -type f \
+                -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null)
+            if [ -n "${_cv_match}" ]; then
+                CPU_MODEL="cv84x6"
+            fi
+            unset _cv_match
+        fi
+        ;;
+esac
 ! [[ "$CPU_MODEL" == "" ]] || panic "cannot get cpu model from /proc/cpuinfo"
-SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah")
+SOC_MODE_CPU_MODEL=("bm1684x" "bm1684" "bm1688" "cv186ah" "cv84x6")
 WORK_MODE="ERROR"
 for element in "${SOC_MODE_CPU_MODEL[@]}"; do
     if [ "$element" == "$CPU_MODEL" ]; then
@@ -346,7 +363,7 @@ if [[ "${CPU_MODEL}" == "bm1684x" ]] || [[ "${CPU_MODEL}" == "bm1684" ]]; then
     if [[ "$(grep -ra ${CPU_MODEL}- ${OTA_FIP_FILE} | wc -l)" == "0" ]]; then
         panic "chip is ${CPU_MODEL}, but fip file not have info about it"
     fi
-elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]]; then
+elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]] || [[ "${CPU_MODEL}" == "cv84x6" ]]; then
     if [[ "$(grep -ra CVBL01 ${OTA_FIP_FILE} | wc -l)" == "0" ]] || \
 [[ "$(grep -ra CVLD02 ${OTA_FIP_FILE} | wc -l)" == "0" ]]; then
         panic "chip is ${CPU_MODEL}, but fip file not have info about it"
@@ -561,7 +578,7 @@ echo skip SPI flash update.
 fi
 echo Program fip.bin done
 " >>$OTA_UPDATE_SCRIPT_FILE
-elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]]; then
+elif [[ "${CPU_MODEL}" == "bm1688" ]] || [[ "${CPU_MODEL}" == "cv186ah" ]] || [[ "${CPU_MODEL}" == "cv84x6" ]]; then
     echo "
 cmp.b 0x05207f82 0x05207f83 1; if test \$? -eq 1; then setenv consoledev ttyS2; fi
 echo Program $OTA_FIP_FILE start

--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -68,9 +68,14 @@ declare -A -g TGZ_FILES_SIZE
 TGZ_FILES_SIZE=(["boot"]=131072 ["recovery"]=3145728 ["rootfs"]=2621440 ["opt"]=2097152 ["system"]=2097152 ["data"]=4194304)
 declare -A -g TGZ_FILES_SIZE_BM1688
 TGZ_FILES_SIZE_BM1688=(["boot"]=131072 ["recovery"]=131072 ["rootfs"]=3145728 ["data"]=4194304)
+# for cv84x6（CV84X2，SDK 标识 cv84x6），与 bm1688/cv186ah 同属 CV 系共用 eMMC 布局，
+# 分区大小默认对齐 bm1688，独立常量便于按 CV84X2 真机实测微调。
+declare -A -g TGZ_FILES_SIZE_CV84X6
+TGZ_FILES_SIZE_CV84X6=(["boot"]=131072 ["recovery"]=131072 ["rootfs"]=3145728 ["data"]=4194304)
 # The increased size of each partition compared to the original partition table
 ROOTFS_RW_SIZE=$((6291456))
 ROOTFS_RW_SIZE_BM1688=$((9291456))
+ROOTFS_RW_SIZE_CV84X6=$((9291456))
 TGZ_ALL_SIZE=$((100*1024))
 EMMC_ALL_SIZE=20971520
 EMMC_MAX_SIZE=30000000
@@ -166,6 +171,15 @@ if [[ "${SOC_NAME}" == "" ]]; then
 		SOC_NAME="bm1688"
 	fi
 fi
+# cv84x6（CV84X2，SDK 标识 cv84x6）兜底：/proc/device-tree/model 根 compatible 可能为通用
+# "linux,dummy-virt"，不能直接判。以内核 dts 递归含 "cvitek,cv84x6-*" compatible 为权威信号
+#（与 get_info 的判法一致），检测到即按 CV 系（bm1688/cv186ah/cv84x6）路径打包。
+if [[ "${SOC_NAME}" == "" ]] && [ -d /proc/device-tree ]; then
+	if [ -n "$(find /proc/device-tree -name compatible -type f \
+		-exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null)" ]; then
+		SOC_NAME="cv84x6"
+	fi
+fi
 if [[ "${SOC_NAME}" == "" ]]; then
 	echo "ERROR: cannot get chip id!"
 	exit -1
@@ -204,13 +218,22 @@ if [[ "$SOC_NAME" == "bm1684x" ]] || [[ "$SOC_NAME" == "bm1684" ]]; then
 		ALL_IN_ONE_SCRIPT="${TGZ_FILES_PATH}/script/bm1684/"
 		echo "INFO: find /opt dir, the version is V22.09.02 or higher"
 	fi
-elif [[ "$SOC_NAME" == "bm1688" ]]; then
+elif [[ "$SOC_NAME" == "bm1688" ]] || [[ "$SOC_NAME" == "cv84x6" ]]; then
 	NEED_BAK_FLASH=1
-	ROOTFS_RW_SIZE=${ROOTFS_RW_SIZE_BM1688}
-	TGZ_FILES_SIZE["boot"]=${TGZ_FILES_SIZE_BM1688["boot"]}
-	TGZ_FILES_SIZE["recovery"]=${TGZ_FILES_SIZE_BM1688["recovery"]}
-	TGZ_FILES_SIZE["rootfs"]=${TGZ_FILES_SIZE_BM1688["rootfs"]}
-	TGZ_FILES_SIZE["data"]=${TGZ_FILES_SIZE_BM1688["data"]}
+	if [[ "$SOC_NAME" == "cv84x6" ]]; then
+		ROOTFS_RW_SIZE=${ROOTFS_RW_SIZE_CV84X6}
+		TGZ_FILES_SIZE["boot"]=${TGZ_FILES_SIZE_CV84X6["boot"]}
+		TGZ_FILES_SIZE["recovery"]=${TGZ_FILES_SIZE_CV84X6["recovery"]}
+		TGZ_FILES_SIZE["rootfs"]=${TGZ_FILES_SIZE_CV84X6["rootfs"]}
+		TGZ_FILES_SIZE["data"]=${TGZ_FILES_SIZE_CV84X6["data"]}
+	else
+		ROOTFS_RW_SIZE=${ROOTFS_RW_SIZE_BM1688}
+		TGZ_FILES_SIZE["boot"]=${TGZ_FILES_SIZE_BM1688["boot"]}
+		TGZ_FILES_SIZE["recovery"]=${TGZ_FILES_SIZE_BM1688["recovery"]}
+		TGZ_FILES_SIZE["rootfs"]=${TGZ_FILES_SIZE_BM1688["rootfs"]}
+		TGZ_FILES_SIZE["data"]=${TGZ_FILES_SIZE_BM1688["data"]}
+	fi
+	# bm1688/cv186ah/cv84x6 同属 CV 系，共用此打包脚本（含 cvitek raw2cimg 打包路径）
 	ALL_IN_ONE_SCRIPT="${TGZ_FILES_PATH}/script/bm1688/"
 fi
 
@@ -265,7 +288,7 @@ if [ "$NEED_BAK_FLASH" -eq 1 ]; then
 			fi
 			cp spi_flash.bin /boot/spi_flash.bin.socBakNew
 		fi
-	elif [[ "$SOC_NAME" == "bm1688" ]]; then
+	elif [[ "$SOC_NAME" == "bm1688" ]] || [[ "$SOC_NAME" == "cv84x6" ]]; then
 		dd if=/dev/mmcblk0boot0 of=${TGZ_FILES_PATH}/fip.bin bs=512 count=2048
 		if [[ "$?" != "0" ]]; then
 			echo "WARNING: bak fip.bin cannot read data"


### PR DESCRIPTION
## 概述

为 sophon-tools **psocbak** 工具做 CV84X2 (=CV84X6，SDK 标识 `cv84x6`) 芯片兼容，参照已合并兄弟适配 get_info(#57)/memory_edit(#58)。

## 改动

- **socbak.sh**：新增 cv84x6 检测（以内核 dts 含 `cvitek,cv84x6-*` compatible 为权威信号，与 get_info 判法一致）；新增 `TGZ_FILES_SIZE_CV84X6` / `ROOTFS_RW_SIZE_CV84X6` 分区大小常量（默认对齐 bm1688）；cv84x6 走 CV 系 `script/bm1688/` 打包脚本（含 cvitek raw2cimg 打包路径），fip.bin 从 `mmcblk0boot0` 备份。
- **ota_update.sh**：CPU_MODEL 落入歧义集（空/null/cv186ah）时按 dts 升级为 `cv84x6`，加入 `SOC_MODE_CPU_MODEL` 列表，fip 校验与刷写脚本分支并入 CV 系。
- **bm_make_package.sh**：boot 脚本 direct-to-ubuntu 的 DTS_TYPE 兜底名按 SOC_NAME 选择 `config-cv84x6_wevb_emmc`（cv84x6）或 `config-cv186ah_sm9v1_4G`（其余 CV 系）。
- **readme.md**：补充 CV84X6 芯片与其分区常量说明。

## 验证

- 三个脚本 `bash -n` 通过。
- 用模拟 `/proc/cpuinfo` + dts 单元验证：cv84x6 检测、分区常量路由、boot 脚本 DTS_TYPE 选择均正确。
- 本环境无法连通真机（linaro@10.80.40.31 无凭据），未做真机打包验证，已标注待实机复核。

## 风险说明
- dts boot 兜底依赖 `config-cv84x6_wevb_emmc`（已在 84x6 SDK 产物 `boot.itb` 中核实存在）。
- 真机打包验证待 CV84X2 实机复核。

🤖 Generated with [Claude Code](https://claude.com/claude-code)