### PR TITLE
feat(se-rag-core): 内置默认硅基流动网关改为自建 Worker，隐藏真 key

### DIFF
--- a/source/se-rag-core/internal/config/config.go
+++ b/source/se-rag-core/internal/config/config.go
@@ -1,14 +1,16 @@
 package config
 
-// 内置 siliconflow 免费 key 不落明文源码，采用 XOR(0x5A) 混淆字节存储，运行时解码。
-// 使用内置 key 时强制限流（并发≤1、单次≤2 段落）；用户自备 key（APIKey 非空）时放开。
+// 默认内置 key 是自建 Cloudflare Worker 网关（se-rag-gateway）分发的 throwaway 网关 key，
+// 不落明文源码，采用 XOR(0x5A) 混淆字节存储，运行时解码。真硅基流动 key 只在网关侧持有，
+// 该内置 key 即使泄露也仅能调用白名单的两个模型、蹭免费额度，不暴露源站 key。
+// 使用内置 key 时强制限流（并发≤1、单次≤2 段落）；用户自备 key（APIKey 非空）时放开并回落官方 SiliconFlow。
 var builtinKeyMask = byte(0x5A)
 
 var builtinKeyEnc = []byte{
-	41, 49, 119, 57, 55, 54, 48, 45, 56, 44, 61, 51, 49, 32, 46, 56, 59, 45, 60, 48, 50, 50, 43, 34, 59, 32, 63, 46, 53, 59, 41, 49, 46, 56, 40, 48, 45, 51, 60, 43, 56, 53, 48, 48, 51, 42, 51, 59, 57, 40, 40,
+	20, 17, 41, 20, 16, 62, 31, 3, 20, 29, 12, 110, 2, 27, 34, 0, 20, 11, 10, 44, 24, 21, 53, 14, 104, 61, 49, 109, 44, 34, 57, 56, 46, 56, 61, 32, 56, 22, 47, 22, 34, 2, 45, 34, 57, 57, 30, 108, 14, 3, 11, 28, 16, 14, 40, 45, 62, 9, 111, 109, 9, 0, 24, 61,
 }
 
-// BuiltinKey 返回内置 siliconflow key（运行时从混淆字节解码）。
+// BuiltinKey 返回默认内置网关 key（运行时从混淆字节解码）。
 func BuiltinKey() string {
 	b := make([]byte, len(builtinKeyEnc))
 	for i, c := range builtinKeyEnc {
@@ -16,6 +18,12 @@ func BuiltinKey() string {
 	}
 	return string(b)
 }
+
+// GatewayBaseURL 是内置默认网关（se-rag-gateway Worker）地址，白名单仅 BAAI/bge-m3、BAAI/bge-reranker-v2-m3。
+const GatewayBaseURL = "https://se-rag-gateway.zetao-zhang.workers.dev/v1"
+
+// 官方 SiliconFlow 地址：用户自备 key 时回落直达，不再经网关中转。
+const officialSiliconflowBaseURL = "https://api.siliconflow.cn/v1"
 
 // Provider 一家 embedding / reranker 供应商。
 // Type ∈ {siliconflow, sophnet}。
@@ -49,11 +57,11 @@ func DefaultConfig() Config {
 			DocsDir: "docs/se7",
 			Embedder: Provider{
 				Type: "siliconflow", Model: "BAAI/bge-m3",
-				BaseURL: "https://api.siliconflow.cn/v1", Dim: 1024,
+				BaseURL: GatewayBaseURL, Dim: 1024,
 			},
 			Reranker: Provider{
 				Type: "siliconflow", Model: "BAAI/bge-reranker-v2-m3",
-				BaseURL: "https://api.siliconflow.cn/v1",
+				BaseURL: GatewayBaseURL,
 			},
 			UseBuiltinKey: true,
 		},
@@ -67,4 +75,13 @@ func (p Provider) EffectiveKey() string {
 		return p.APIKey
 	}
 	return BuiltinKey()
+}
+
+// EffectiveBaseURL 依 key 归属决定上游地址：
+// 内置 key → 默认网关（Worker，白名单两模型）；用户自备 key → 回落官方 SiliconFlow，直达不被网关替换。
+func (p Provider) EffectiveBaseURL() string {
+	if p.APIKey != "" {
+		return officialSiliconflowBaseURL
+	}
+	return p.BaseURL
 }

--- a/source/se-rag-core/internal/config/config_test.go
+++ b/source/se-rag-core/internal/config/config_test.go
@@ -1,24 +1,57 @@
 package config
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
-// 内置 key 的有效明文（仅测试用；生产代码以混淆字节保存，不落明文源码）。
-const builtinPlaintext = "sk-cmljwbvgikztbawfjhhqxazetoasktbrjwifqbojjipiacrr"
+// 内置 key 是 gateway throwaway 网关钥匙，不落明文到测试文件（避免 git 里铺密钥指纹）。
+// 这里只校验解码结果的形态与自洽性，不校验明文值本身。
+
+// builtinKeyLen 为内置网关 key 的固定长度，用于捕获混淆字节被误改/截断。
+const builtinKeyLen = 64
 
 func TestBuiltinKeyDecodes(t *testing.T) {
-	if BuiltinKey() != builtinPlaintext {
-		t.Errorf("BuiltinKey() decode mismatch")
+	k := BuiltinKey()
+	if k == "" {
+		t.Fatal("BuiltinKey() returned empty")
+	}
+	if len(k) != builtinKeyLen {
+		t.Errorf("BuiltinKey() length = %d, want %d", len(k), builtinKeyLen)
+	}
+	// 往返自洽：同一 key 再次混淆解码应得到相同结果
+	re := make([]byte, len(builtinKeyEnc))
+	for i, c := range builtinKeyEnc {
+		re[i] = c ^ builtinKeyMask
+	}
+	if string(re) != k {
+		t.Errorf("XOR roundtrip mismatch")
 	}
 }
 
-func TestEffectiveKey(t *testing.T) {
+func TestEffectiveKeyUsesBuiltinWhenEmpty(t *testing.T) {
 	d := DefaultConfig()
 	p := d.Products[0].Embedder
 	if !p.IsBuiltinKey() {
 		t.Error("default embedder should use builtin key")
 	}
-	if p.EffectiveKey() != builtinPlaintext {
-		t.Errorf("effective key mismatch")
+	if p.EffectiveKey() != BuiltinKey() {
+		t.Errorf("effective key mismatch: want builtin, got %q", p.EffectiveKey())
+	}
+}
+
+func TestEffectiveBaseURL(t *testing.T) {
+	d := DefaultConfig()
+	p := d.Products[0].Embedder
+	// 内置 → 默认网关
+	if p.EffectiveBaseURL() != GatewayBaseURL {
+		t.Errorf("builtin effective base url = %q, want gateway %q", p.EffectiveBaseURL(), GatewayBaseURL)
+	}
+	// 自备 key → 回落官方 SiliconFlow，直达不被网关替换
+	u := p
+	u.APIKey = "user-key"
+	if u.EffectiveBaseURL() != officialSiliconflowBaseURL {
+		t.Errorf("user-key effective base url = %q, want official %q", u.EffectiveBaseURL(), officialSiliconflowBaseURL)
 	}
 }
 
@@ -29,6 +62,12 @@ func TestUserKeyOverrides(t *testing.T) {
 	}
 	if p.EffectiveKey() != "user-key" {
 		t.Errorf("want user-key, got %q", p.EffectiveKey())
+	}
+}
+
+func TestGatewayBaseURLShape(t *testing.T) {
+	if !strings.Contains(GatewayBaseURL, "workers.dev") {
+		t.Errorf("GatewayBaseURL %q should be the gateway worker host", GatewayBaseURL)
 	}
 }
 

--- a/source/se-rag-core/internal/embed/provider.go
+++ b/source/se-rag-core/internal/embed/provider.go
@@ -24,7 +24,7 @@ type Reranker interface {
 func NewEmbedder(cfg config.Provider) (Embedder, error) {
 	switch cfg.Type {
 	case "siliconflow":
-		return newSiliconflowEmbedder(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model, cfg.Dim, cfg.IsBuiltinKey())
+		return newSiliconflowEmbedder(cfg.EffectiveBaseURL(), cfg.EffectiveKey(), cfg.Model, cfg.Dim, cfg.IsBuiltinKey())
 	case "sophnet":
 		return newSophnetEmbedder(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model, cfg.Dim)
 	default:
@@ -36,7 +36,7 @@ func NewEmbedder(cfg config.Provider) (Embedder, error) {
 func NewReranker(cfg config.Provider) (Reranker, error) {
 	switch cfg.Type {
 	case "siliconflow":
-		return newSiliconflowReranker(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model, cfg.IsBuiltinKey())
+		return newSiliconflowReranker(cfg.EffectiveBaseURL(), cfg.EffectiveKey(), cfg.Model, cfg.IsBuiltinKey())
 	case "sophnet":
 		return newSophnetReranker(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model)
 	default:


### PR DESCRIPTION
## Summary
将 se-rag-core 的内置默认 embedding/rerank 供应商从"真 SiliconFlow key"改为"自建 Cloudflare Worker 网关 + throwaway 网关 key"，隐藏真实源站 key。

- 删除内置真 SiliconFlow key 的 XOR 混淆字节与测试明文常量
- 新增 `GatewayBaseURL`（se-rag-gateway.workers.dev），`DefaultConfig` 默认指向它
- 新增 `EffectiveBaseURL()`：内置 key → 走网关；用户自备 `SE_RAG_EMBED_KEY` → 回落官方 SiliconFlow
- 默认 key 强制限流（并发≤1、单次≤2 段落）保持

## 测试
- `go vet ./...` 通过
- `go test -count=1 ./...` 全绿（8 包）
- 离线端到端 build+query（SE_RAG_FAKE_EMBED=1）通过

## 说明
- 内置 key 为 Worker 网关分发的 throwaway key（白名单仅 bge-m3 / bge-reranker-v2-m3），泄露仅蹭免费额度、不暴露源站 key
- ⚠️ `*.workers.dev` 在部分网络（本沙箱/测试机）不可达，SE 设备实机连通性待验证