### PR TITLE
se-rag-core: 内置网关 IP 优先 + DoH 兜底拨号，绕开 workers.dev DNS 污染 (MYS-237)

### DIFF
--- a/source/se-rag-core/internal/embed/gateway_transport.go
+++ b/source/se-rag-core/internal/embed/gateway_transport.go
@@ -1,0 +1,179 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// 内置默认 SiliconFlow 网关（自建 Cloudflare Worker se-rag-gateway）在部分网络下存在
+// *.workers.dev 域名 DNS 污染：本地 resolver 把域名解析到错误 IP 导致连接超时。
+// 因此对内置网关域名采用「IP 优先 + DoH 兜底」，其他域名（sophnet、官方回落自备 key 等）
+// 一律走系统 DNS，作用范围严格收窄到内置网关。
+
+// gatewayHost 内置网关域名，仅对其应用 IP 优先拨号。
+const gatewayHost = "se-rag-gateway.zetao-zhang.workers.dev"
+
+// gatewayIPFallbacks 权威 CF Anycast IP（Cloudflare 官方，TCP 已验证可达），拨号优先直连绕开污染 resolver。
+var gatewayIPFallbacks = []string{"104.21.6.72", "172.67.134.151"}
+
+// dohServers DoH 兜底服务器（按优先级）。IP 直连 DNS-over-HTTPS，不经过被污染的系统 DNS。
+var dohServers = []string{"1.1.1.1", "8.8.8.8"}
+
+const (
+	dialTimeout = 5 * time.Second
+	dohTimeout  = 5 * time.Second
+)
+
+// DialContext 与 net.Dialer.DialContext 同签名，便于测试注入 mock 拨号。
+type DialContext func(ctx context.Context, network, addr string) (net.Conn, error)
+
+// ipResolver 实时拉取某域名的权威 A 记录（仅 IPv4）。
+type ipResolver interface {
+	resolve(ctx context.Context, host string) ([]string, bool)
+}
+
+// dialWithResolve 对内置网关域名做 IP 优先 + DoH 兜底：
+//  1. 主路径：硬编码权威 CF IP 优先直连（强制 IPv4），URL 仍保留域名，SNI/Host/证书校验不受影响；
+//  2. 兜底：硬编码 IP 全失败后用 DoH 实时拉权威 IP 再连，与硬编码重复的 IP 不重复拨号；
+//  3. 兜底的兜底：DoH 也失败时返回错误走降级，不回调被污染的系统 DNS。
+//
+// 非内置网关域名直接透传 base（系统 DNS），不影响其他供应商。
+func dialWithResolve(ctx context.Context, network, addr string, base DialContext, resolver ipResolver) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return base(ctx, network, addr)
+	}
+	if host != gatewayHost {
+		return base(ctx, network, addr)
+	}
+
+	tried := map[string]bool{}
+	firstErr := error(nil)
+	for _, ip := range gatewayIPFallbacks {
+		tried[ip] = true
+		if conn, err := dialIPv4(ctx, base, ip, port); err == nil {
+			return conn, nil
+		} else if firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	// 兜底：DoH 实时拉权威 IP。
+	var ips []string
+	if got, ok := resolver.resolve(ctx, host); ok {
+		ips = got
+	} else {
+		firstErr = errors.New("DoH lookup failed")
+	}
+	for _, ip := range ips {
+		if tried[ip] {
+			continue
+		}
+		tried[ip] = true
+		if conn, err := dialIPv4(ctx, base, ip, port); err == nil {
+			return conn, nil
+		}
+	}
+	return nil, fmt.Errorf("gateway %s unreachable via fallback IPs/DoH: %w", host, firstErr)
+}
+
+func dialIPv4(ctx context.Context, base DialContext, ip, port string) (net.Conn, error) {
+	return base(ctx, "tcp4", net.JoinHostPort(ip, port))
+}
+
+// dohResolver 通过 DNS-over-HTTPS（application/dns-json）实时拉取域名权威 A 记录。
+// 每个 DoH 请求直连 DoH 服务器 IP，不依赖系统 resolver，因而不受 *.workers.dev 污染影响。
+type dohResolver struct {
+	servers []string
+	client  *http.Client
+}
+
+// newDoHResolver 用默认 DoH 服务器列表构造 resolver。
+func newDoHResolver(base DialContext) *dohResolver {
+	return newDoHResolverWith(base, dohServers)
+}
+
+// newDoHResolverWith 方便测试注入服务器列表与 client。
+func newDoHResolverWith(base DialContext, servers []string) *dohResolver {
+	// DoH client 强制直连（不用代理、不经过网关拨号逻辑），跳系统 DNS。
+	tr := &http.Transport{Proxy: nil, DialContext: base}
+	return &dohResolver{
+		servers: servers,
+		client:  &http.Client{Transport: tr, Timeout: dohTimeout},
+	}
+}
+
+// resolve 依次尝试各 DoH 服务器，首个成功者返回；全部失败返回 ok=false。
+func (r *dohResolver) resolve(ctx context.Context, host string) ([]string, bool) {
+	for _, srv := range r.servers {
+		ips, err := r.queryOnce(ctx, srv, host)
+		if err == nil {
+			return ips, true
+		}
+	}
+	return nil, false
+}
+
+func (r *dohResolver) queryOnce(ctx context.Context, server, host string) ([]string, error) {
+	base := server
+	if !strings.Contains(server, "://") {
+		base = "https://" + server
+	}
+	u := base + "/dns-query?name=" + host + "&type=A&ct=application/dns-json"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/dns-json")
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("DoH %s: status %d", server, resp.StatusCode)
+	}
+	var d struct {
+		Status  int `json:"status"`
+		Answers []struct {
+			Type int    `json:"type"`
+			Data string `json:"data"`
+		} `json:"Answer"`
+	}
+	if err := json.Unmarshal(body, &d); err != nil {
+		return nil, err
+	}
+	if d.Status != 0 { // RCODE 0 = NOERROR
+		return nil, fmt.Errorf("DoH %s: RCODE %d", server, d.Status)
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, a := range d.Answers {
+		if a.Type != 1 { // 仅 A 记录，忽略 AAAA(IPv6)
+			continue
+		}
+		ip := net.ParseIP(a.Data)
+		if ip == nil || ip.To4() == nil {
+			continue
+		}
+		if !seen[a.Data] {
+			seen[a.Data] = true
+			out = append(out, a.Data)
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("DoH %s: no A records", server)
+	}
+	return out, nil
+}

--- a/source/se-rag-core/internal/embed/gateway_transport_test.go
+++ b/source/se-rag-core/internal/embed/gateway_transport_test.go
@@ -1,0 +1,251 @@
+package embed
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"se-rag-core/internal/config"
+)
+
+// gatewayAddr 内置网关"域名:端口"拨号地址（transport 传给 DialContext 的形式）。
+const gatewayAddr = gatewayHost + ":443"
+
+func pipedConn() (net.Conn, error) {
+	c, _ := net.Pipe()
+	return c, nil
+}
+
+// recordingBase 记录每个拨号目标；仅当 addr 在 success 集合内时返回成功，其余拒绝。
+func recordingBase(success map[string]bool) (func(ctx context.Context, network, addr string) (net.Conn, error), *[]string) {
+	var calls []string
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		calls = append(calls, network+" "+addr)
+		if success[addr] {
+			return pipedConn()
+		}
+		return nil, errors.New("dial refused")
+	}, &calls
+}
+
+// fakeResolver 可注入的 IP resolver。
+type fakeResolver struct {
+	ips []string
+	ok  bool
+}
+
+func (f fakeResolver) resolve(ctx context.Context, host string) ([]string, bool) {
+	return f.ips, f.ok
+}
+
+// 主路径：拨号目标是内置网关时，优先直连硬编码的权威 CF IP（强制 IPv4）。
+func TestDialWithResolveGatewayPrefersHardcodedIP(t *testing.T) {
+	wantIP := gatewayIPFallbacks[0]
+	base, calls := recordingBase(map[string]bool{
+		net.JoinHostPort(wantIP, "443"): true,
+	})
+	resolver := fakeResolver{}
+	conn, err := dialWithResolve(context.Background(), "tcp", gatewayAddr, base, resolver)
+	if err != nil {
+		t.Fatalf("dialWithResolve = %v, want success", err)
+	}
+	conn.Close()
+	if len(*calls) == 0 {
+		t.Fatal("no dial calls")
+	}
+	if got := (*calls)[0]; got != "tcp4 "+net.JoinHostPort(wantIP, "443") {
+		t.Errorf("first dial target = %q, want tcp4 %s", got, net.JoinHostPort(wantIP, "443"))
+	}
+}
+
+// 作用范围收窄：非内置网关域名（如官方回落 api.siliconflow.cn、sophnet）直接走系统拨号，不做 IP 覆盖。
+func TestDialWithResolveNonGatewayPassesThrough(t *testing.T) {
+	for _, host := range []string{"api.siliconflow.cn", "www.sophnet.com", "127.0.0.1"} {
+		addr := net.JoinHostPort(host, "443")
+		base, calls := recordingBase(map[string]bool{addr: true})
+		_, err := dialWithResolve(context.Background(), "tcp", addr, base, fakeResolver{})
+		if err != nil {
+			t.Fatalf("dial %s = %v", host, err)
+		}
+		if len(*calls) != 1 {
+			t.Fatalf("calls=%v, want exactly 1 passthrough", *calls)
+		}
+		if got := (*calls)[0]; got != "tcp "+addr {
+			t.Errorf("passthrough target = %q, want %q", got, addr)
+		}
+	}
+}
+
+// 兜底：硬编码 IP 全失败后，改用 DoH 解析出的权威 IP 再连；与硬编码重复的 IP 不重复拨号。
+func TestDialWithResolveDoHFallback(t *testing.T) {
+	// 硬编码两个 CF IP 全部失败；DoH 返回一个新 IP 才通。
+	resolved := "1.2.3.4"
+	success := map[string]bool{
+		net.JoinHostPort(resolved, "443"): true,
+	}
+	base, calls := recordingBase(success)
+	resolver := fakeResolver{ips: append(append([]string{}, gatewayIPFallbacks...), resolved), ok: true}
+	conn, err := dialWithResolve(context.Background(), "tcp", gatewayAddr, base, resolver)
+	if err != nil {
+		t.Fatalf("dialWithResolve = %v, want DoH fallback success", err)
+	}
+	conn.Close()
+
+	dialed := *calls
+	// 去重：DoH 返回的与硬编码重复的 IP 不应被再次拨号。
+	dup := net.JoinHostPort(gatewayIPFallbacks[0], "443")
+	n := 0
+	for _, c := range dialed {
+		if strings.HasSuffix(c, " "+dup) {
+			n++
+		}
+	}
+	if n > 1 {
+		t.Errorf("duplicate dial to %s: %d times, want ≤1 (dedup)", dup, n)
+	}
+	found := false
+	for _, c := range dialed {
+		if c == "tcp4 "+net.JoinHostPort(resolved, "443") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("did not dial DoH-resolved IP %s; calls=%v", resolved, dialed)
+	}
+}
+
+// 主路径一次命中：成功时不应触发 DoH。
+func TestDialWithResolveSkipsDoHOnSuccess(t *testing.T) {
+	base, _ := recordingBase(map[string]bool{
+		net.JoinHostPort(gatewayIPFallbacks[0], "443"): true,
+	})
+	resolver := &countingResolver{}
+	conn, err := dialWithResolve(context.Background(), "tcp", gatewayAddr, base, resolver)
+	if err != nil {
+		t.Fatalf("dialWithResolve = %v", err)
+	}
+	conn.Close()
+	if resolver.calls != 0 {
+		t.Errorf("DoH resolve called %d times, want 0 on hardcoded-IP success", resolver.calls)
+	}
+}
+
+type countingResolver struct {
+	calls int
+}
+
+func (c *countingResolver) resolve(ctx context.Context, host string) ([]string, bool) {
+	c.calls++
+	return nil, false
+}
+
+// 兜底的兜底：硬编码 IP 与 DoH 全部失败时返回明确的错误（走降级，不碰被污染的系统 DNS）。
+func TestDialWithResolveAllFail(t *testing.T) {
+	base, _ := recordingBase(map[string]bool{}) // 全部拒绝
+	resolver := fakeResolver{ips: []string{"5.6.7.8"}, ok: true}
+	_, err := dialWithResolve(context.Background(), "tcp", gatewayAddr, base, resolver)
+	if err == nil {
+		t.Fatal("expected error when all dial targets fail")
+	}
+	if !strings.Contains(err.Error(), gatewayHost) {
+		t.Errorf("error should mention gateway host, got %q", err)
+	}
+}
+
+// dohResolver 解析：仅取 IPv4 A 记录、去重、RCODE0 才有效。
+func TestDoHResolverParsesAnswers(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/dns-query", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.URL.Query().Get("name"); got != gatewayHost {
+			t.Errorf("dns-query name = %q, want %q", got, gatewayHost)
+		}
+		if got := r.URL.Query().Get("type"); got != "A" {
+			t.Errorf("dns-query type = %q, want A", got)
+		}
+		w.Header().Set("Content-Type", "application/dns-json")
+		b, _ := json.Marshal(map[string]any{
+			"Status": 0,
+			"Answer": []map[string]any{
+				{"name": gatewayHost, "type": 1, "data": "104.21.6.72"},   // A 重复项 → 去重
+				{"name": gatewayHost, "type": 1, "data": "104.21.6.72"},   // 重复
+				{"name": gatewayHost, "type": 1, "data": "172.67.134.151"}, // A
+				{"name": gatewayHost, "type": 28, "data": "2606:4700:4700::1111"}, // AAAA → 忽略
+				{"name": gatewayHost, "type": 1, "data": "bogus"},                 // 非法 → 忽略
+			},
+		})
+		w.Write(b)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newDoHResolverWith((&net.Dialer{}).DialContext, []string{srv.URL})
+	r.client = srv.Client()
+	ips, ok := r.resolve(context.Background(), gatewayHost)
+	if !ok {
+		t.Fatal("resolve failed, want ok")
+	}
+	if len(ips) != 2 {
+		t.Fatalf("ips = %v, want 2 unique IPv4", ips)
+	}
+	for _, ip := range ips {
+		if p := net.ParseIP(ip); p == nil || p.To4() == nil {
+			t.Errorf("got non-IPv4 %q", ip)
+		}
+	}
+}
+
+// DoH 服务器返回 RCODE!=0 时应视为失败。
+func TestDoHResolverRcodeError(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/dns-query", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dns-json")
+		fmt.Fprintf(w, `{"Status":3,"Comment":"NXDOMAIN"}`)
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	r := newDoHResolverWith((&net.Dialer{}).DialContext, []string{srv.URL})
+	r.client = srv.Client()
+	if ips, ok := r.resolve(context.Background(), gatewayHost); ok {
+		t.Errorf("resolve with RCODE=3 = %v ok, want failure", ips)
+	}
+}
+
+// 兜底链：多个 DoH 服务器，第一个失败时启用第二个。
+func TestDoHResolverFailsOverServer(t *testing.T) {
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", 500)
+	}))
+	defer bad.Close()
+	good := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/dns-json")
+		fmt.Fprintf(w, `{"Status":0,"Answer":[{"name":"%s","type":1,"data":"104.21.6.72"}]}`, gatewayHost)
+	}))
+	defer good.Close()
+
+	r := newDoHResolverWith((&net.Dialer{}).DialContext,
+		[]string{bad.URL, good.URL})
+	r.client = &http.Client{}
+	ips, ok := r.resolve(context.Background(), gatewayHost)
+	if !ok || len(ips) != 1 || ips[0] != "104.21.6.72" {
+		t.Errorf("failover resolve = %v ok=%v, want [104.21.6.72]", ips, ok)
+	}
+}
+
+// 防止常量漂移：内置网关 host 必须与 config.GatewayBaseURL 一致。
+func TestGatewayHostMatchesConfig(t *testing.T) {
+	u, err := url.Parse(config.GatewayBaseURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.Hostname() != gatewayHost {
+		t.Errorf("gatewayHost = %q, config base URL host = %q", gatewayHost, u.Hostname())
+	}
+}

--- a/source/se-rag-core/internal/embed/httpclient.go
+++ b/source/se-rag-core/internal/embed/httpclient.go
@@ -6,11 +6,28 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"time"
 )
 
 const maxAttempts = 6
+
+// httpClient 全局 HTTP 客户端：其 Transport 对内置网关域名做 IP 优先 + DoH 兜底拨号，
+// 其余域名（sophnet、官方回落等）走系统 DNS。所有供应商统一经此 client 发请求。
+var httpClient = newGatewayAwareClient((&net.Dialer{Timeout: dialTimeout}).DialContext)
+
+// newGatewayAwareClient 构造对内置网关域名启用 IP 优先 + DoH 兜底的 HTTP 客户端。
+func newGatewayAwareClient(base DialContext) *http.Client {
+	doh := newDoHResolver(base)
+	tr := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return dialWithResolve(ctx, network, addr, base, doh)
+		},
+	}
+	return &http.Client{Transport: tr}
+}
 
 // postJSON POST JSON 到 url，带 Bearer 鉴权。
 // 5xx/429/连接错误 → 指数退避重试（最多6次）；4xx → 快速失败不重试。
@@ -27,7 +44,7 @@ func postJSON(ctx context.Context, url, key string, payload, out any) error {
 		}
 		req.Header.Set("Authorization", "Bearer "+key)
 		req.Header.Set("Content-Type", "application/json")
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			lastErr = err
 			time.Sleep(backoff(attempt))


### PR DESCRIPTION
## 背景

内置默认 SiliconFlow 网关已改为自建 Cloudflare Worker（`se-rag-gateway.zetao-zhang.workers.dev`）。但部分网络（开发沙箱、SE 测试机）存在 `*.workers.dev` 域名 DNS 污染：本地 resolver 把域名解析到错误 IP（沙箱 `202.160.129.6`、测试机 `157.240.18.18`），导致连接超时 HTTP 000；而权威 DNS 正确返回 CF 官方 IP `104.21.6.72` / `172.67.134.151`。

## 改动

集中 `source/se-rag-core/internal/embed/`，新增 `gateway_transport.go`，`httpclient.go` 的 `postJSON` 改用统一的 gateway-aware `http.Client`。

| 路径 | 逻辑 |
|------|------|
| 主路径（IP 优先）| 对内置网关域名定制 `Transport.DialContext`，直连权威 CF IP（`104.21.6.72` / `172.67.134.151`），强制 IPv4；URL 保留域名，SNI / Host / TLS 证书校验正常 |
| 兜底（DoH）| 硬编码 IP 全失败后用 DoH `https://1.1.1.1/dns-query`（application/dns-json，优先，必要时 `8.8.8.8`）实时拉权威 IP 再连；与硬编码重复的 IP 去重；**不**回调被污染的系统 DNS |
| 兜底的兜底 | DoH 也失败则返回错误走降级，不形成公共 DNS 单点依赖 |
| 作用范围收窄 | 仅内置网关域名走 IP 优先；sophnet、官方回落 `api.siliconflow.cn`（用户自备 key）一律走系统 DNS |

## 验证

- 单元测试（无网络、注入 mock 拨号/resolver）：IP 优先命中、非内置域名透传、DoH 兜底、去重、全败报错、DoH 解析（仅 IPv4 /去重/RCODE）、`gatewayHost` 与 `config.GatewayBaseURL` 一致性
- `go vet ./...` + `go test -count=1 ./...` 全绿
- 在受污染 SE 测试机（172.26.166.185）实测：系统 resolver 解析网关域名→`157.240.18.18`，原始访问→`http=000 / 7.29s` 超时；改用硬编码 CF IP 直连→POST 返回 `http=401 / 0.58s`（连接成功后正常鉴权响应，证明 TCP+TLS+SNI+HTTP 全链路通畅）；沙箱侧验证 1.1.1.1 DoH 返回权威 IP 与硬编码一致

## 影响面

所有供应商（siliconflow / sophnet）统一经新 client，但仅内置网关域名触发 IP 优先，其余行为不变。