### PR TITLE
fix(bmssm): /hardware/terminal 增加 admin/superuser 角色检查，修复普通用户越权开 root 终端 (MYS-384)

### DIFF
--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -86,6 +86,9 @@ func setupCompatTest(t *testing.T) *gin.Engine {
 	// 公开 login
 	r.POST("/api/v1/login", userCtrl.Login)
 
+	// 公开 WebSocket 实时终端（对齐 router.go：不走 Auth 中间件，handler 内鉴权）
+	r.GET("/api/v1/hardware/terminal", ctrl.TerminalWS)
+
 	// 受保护组
 	api := r.Group("/api/v1", middleware.Auth())
 	{

--- a/source/pbmssm/mvc/compat/terminal_ws.go
+++ b/source/pbmssm/mvc/compat/terminal_ws.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/websocket"
 
+	"bmssm/database"
 	"bmssm/pkg/auth"
 	"bmssm/pkg/response"
 )
@@ -32,10 +33,38 @@ const wsCtrlResize = 0x01
 // wsIdleTimeout 30 分钟无任何 WebSocket 消息即关闭会话。
 const wsIdleTimeout = 30 * time.Minute
 
+// requireAdminRole 查询 users 表校验 username 具备 superuser/admin 角色。
+// 与 filemanage.authToken / middleware.RequireAdmin 同口径：非管理员 403。
+// DB 不可用或查询失败一律拒绝（fail-closed）——终端以 root 运行，数据库异常时
+// 宁可拒绝也不放开 root shell。
+func requireAdminRole(c *gin.Context, username string) bool {
+	db := database.DB()
+	if db == nil {
+		c.JSON(http.StatusInternalServerError, response.Fail("database unavailable"))
+		return false
+	}
+	// GORM v1 Pluck 目标必须是 slice。
+	var roles []string
+	if err := db.Table("users").Where("username = ?", username).Pluck("role", &roles).Error; err != nil {
+		c.JSON(http.StatusForbidden, response.Fail("admin role required"))
+		return false
+	}
+	role := ""
+	if len(roles) > 0 {
+		role = roles[0]
+	}
+	if role != "superuser" && role != "admin" {
+		c.JSON(http.StatusForbidden, response.Fail("admin role required"))
+		return false
+	}
+	return true
+}
+
 // TerminalWS GET /api/v1/hardware/terminal?token=<jwt>
 // 实时交互终端：WebSocket 升级后启动 shell pty，双向 pump。
 // 鉴权：浏览器无法加 Authorization header，token 从 query ?token= 取，
 // handler 内手动 auth.ParseToken 校验，失败 401。
+// 交互终端以 root 运行，故额外要求 superuser/admin 角色（查 users 表）。
 func (ctrl *Controller) TerminalWS(c *gin.Context) {
 	// 1) JWT 校验（query token，不走 Auth 中间件）
 	// 与 Auth 中间件一致：临时 token（temp=true，默认密码登录态）拒绝，需先改密，
@@ -45,7 +74,7 @@ func (ctrl *Controller) TerminalWS(c *gin.Context) {
 		c.JSON(http.StatusUnauthorized, response.Fail("missing token"))
 		return
 	}
-	_, temp, err := auth.ParseToken(tokenStr, getSecret())
+	username, temp, err := auth.ParseToken(tokenStr, getSecret())
 	if err != nil {
 		c.JSON(http.StatusUnauthorized, response.Fail("invalid token"))
 		return
@@ -55,14 +84,20 @@ func (ctrl *Controller) TerminalWS(c *gin.Context) {
 		return
 	}
 
-	// 2) WebSocket 升级
+	// 2) 角色校验：终端 shell 以 root 运行（bmssm systemd 单元），
+	// 普通 user 角色禁止开交互终端，仅 superuser/admin 可用。
+	if !requireAdminRole(c, username) {
+		return
+	}
+
+	// 3) WebSocket 升级
 	wsConn, err := wsUpgrader.Upgrade(c.Writer, c.Request, nil)
 	if err != nil {
 		return
 	}
 	defer wsConn.Close()
 
-	// 3) 启动 shell pty：优先 bash，没有则 sh；默认账户家目录
+	// 4) 启动 shell pty：优先 bash，没有则 sh；默认账户家目录
 	shell := "sh"
 	if p, lerr := exec.LookPath("bash"); lerr == nil {
 		shell = p
@@ -85,7 +120,7 @@ func (ctrl *Controller) TerminalWS(c *gin.Context) {
 		return
 	}
 
-	// 4) 清理
+	// 5) 清理
 	var once sync.Once
 	cleanup := func() {
 		once.Do(func() {

--- a/source/pbmssm/mvc/compat/terminal_ws_test.go
+++ b/source/pbmssm/mvc/compat/terminal_ws_test.go
@@ -1,0 +1,177 @@
+package compat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"bmssm/database"
+	"bmssm/mvc/user"
+	"bmssm/pkg/auth"
+)
+
+// ---------------------------------------------------------------
+// TerminalWS 越权修复测试（MYS-384）
+//
+// 交互终端以 root 运行，仅 superuser/admin 角色可用。
+// 所有握手走真实 WebSocket Dial（与浏览器攻击路径一致），
+// 失败路径断言 HTTP 状态码，成功路径验证 pty 有输出。
+// ---------------------------------------------------------------
+
+// issueUserToken 直接签发测试 JWT（secret=auth.DefaultSecret，与未加载配置时 getSecret 一致）。
+func issueUserToken(t *testing.T, username, secret string, temp bool) string {
+	t.Helper()
+	tok, _, err := auth.IssueToken(username, secret, temp)
+	if err != nil {
+		t.Fatalf("IssueToken(%s): %v", username, err)
+	}
+	return tok
+}
+
+// wsHandshake 以 token 发起终端 WebSocket 握手，返回 (conn, HTTP 状态码)。
+// 失败时 conn 为 nil；调用方负责关闭 conn。
+func wsHandshake(t *testing.T, srv *httptest.Server, token string) (*websocket.Conn, int) {
+	t.Helper()
+	url := "ws" + strings.TrimPrefix(srv.URL, "http") + "/api/v1/hardware/terminal?token=" + token
+	conn, resp, err := websocket.DefaultDialer.Dial(url, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		if conn != nil {
+			conn.Close()
+		}
+		if resp == nil {
+			t.Fatalf("dial %s: %v (no response)", url, err)
+		}
+		return nil, resp.StatusCode
+	}
+	return conn, resp.StatusCode
+}
+
+// readUntilShellMarker 读 pty 输出直到看到 marker，超时 5s。
+func readUntilShellMarker(t *testing.T, conn *websocket.Conn, marker string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	buf := make([]byte, 0, 256)
+	for time.Now().Before(deadline) {
+		_ = conn.SetReadDeadline(deadline)
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			t.Fatalf("read shell output: %v (got %q, marker %q)", err, string(buf), marker)
+		}
+		buf = append(buf, msg...)
+		if strings.Contains(string(buf), marker) {
+			return
+		}
+	}
+	t.Fatalf("shell marker %q not seen within 5s, got %q", marker, string(buf))
+}
+
+// TestTerminalWSAuthFailures 无 token / 非法 token / 错误 secret → 401。
+func TestTerminalWSAuthFailures(t *testing.T) {
+	r := setupCompatTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"missing token", ""},
+		{"invalid jwt", "not-a-jwt"},
+		{"wrong secret", issueUserToken(t, "admin", "wrong-secret", false)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, code := wsHandshake(t, srv, tc.token); code != http.StatusUnauthorized {
+				t.Errorf("status=%d, want 401", code)
+			}
+		})
+	}
+}
+
+// TestTerminalWSTempTokenRejected 临时 token（默认密码登录态）→ 403。
+func TestTerminalWSTempTokenRejected(t *testing.T) {
+	r := setupCompatTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := issueUserToken(t, "admin", auth.DefaultSecret, true)
+	if _, code := wsHandshake(t, srv, token); code != http.StatusForbidden {
+		t.Errorf("status=%d, want 403", code)
+	}
+}
+
+// TestTerminalWSUserRoleForbidden 普通 user 角色的正式 token → 403（越权回归用例）。
+// 修复前：角色不被检查，普通 user 可升级 WebSocket 开 root shell。
+func TestTerminalWSUserRoleForbidden(t *testing.T) {
+	r := setupCompatTest(t)
+	if err := user.NewService(database.DB()).CreateUser("alice", "realpass", "user"); err != nil {
+		t.Fatalf("create alice: %v", err)
+	}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := issueUserToken(t, "alice", auth.DefaultSecret, false)
+	if _, code := wsHandshake(t, srv, token); code != http.StatusForbidden {
+		t.Errorf("status=%d, want 403 (user role must not open terminal)", code)
+	}
+}
+
+// TestTerminalWSUnknownUserForbidden 用户已被删除（token 仍有效）→ 403（fail-closed）。
+func TestTerminalWSUnknownUserForbidden(t *testing.T) {
+	r := setupCompatTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := issueUserToken(t, "ghost", auth.DefaultSecret, false)
+	if _, code := wsHandshake(t, srv, token); code != http.StatusForbidden {
+		t.Errorf("status=%d, want 403 (deleted user must not open terminal)", code)
+	}
+}
+
+// TestTerminalWSAdminRoleAllowed admin 角色 → 升级成功，pty 输出可见。
+func TestTerminalWSAdminRoleAllowed(t *testing.T) {
+	r := setupCompatTest(t)
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := issueUserToken(t, "admin", auth.DefaultSecret, false) // setupCompatTest 创建 role=admin
+	conn, code := wsHandshake(t, srv, token)
+	if code != http.StatusSwitchingProtocols {
+		t.Fatalf("status=%d, want 101 (admin should get WebSocket)", code)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("echo TWS-ADMIN-OK\nexit\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readUntilShellMarker(t, conn, "TWS-ADMIN-OK")
+}
+
+// TestTerminalWSSuperuserRoleAllowed superuser 角色 → 升级成功，pty 输出可见。
+func TestTerminalWSSuperuserRoleAllowed(t *testing.T) {
+	r := setupCompatTest(t)
+	if err := user.NewService(database.DB()).CreateUser("boss", "realpass", "superuser"); err != nil {
+		t.Fatalf("create boss: %v", err)
+	}
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	token := issueUserToken(t, "boss", auth.DefaultSecret, false)
+	conn, code := wsHandshake(t, srv, token)
+	if code != http.StatusSwitchingProtocols {
+		t.Fatalf("status=%d, want 101 (superuser should get WebSocket)", code)
+	}
+	defer conn.Close()
+
+	if err := conn.WriteMessage(websocket.TextMessage, []byte("echo TWS-SU-OK\nexit\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	readUntilShellMarker(t, conn, "TWS-SU-OK")
+}


### PR DESCRIPTION
## 问题

MYS-377 代码审查发现（P0）：`GET /api/v1/hardware/terminal` 绕过 Auth 中间件，handler 内仅校验 token 有效性与 temp 标志，**无角色检查**。普通 `user` 角色账号即可升级 WebSocket，打开一个以 root 运行的 bash pty（bmssm 以 systemd root 运行）。

## 修复

`source/pbmssm/mvc/compat/terminal_ws.go`：

- handler 内解析 token 拿到 username 后查 users 表，要求 `superuser`/`admin` 角色才允许升级 WebSocket —— 与 `filemanage.authToken` / `middleware.RequireAdmin` 同口径
- temp token（默认密码态）拒绝逻辑保持不变
- 数据库不可用/查询失败/角色不符一律拒绝（fail-closed），避免 DB 异常时放开 root 终端

## 测试

新增 `terminal_ws_test.go`（真实 WebSocket 握手）：

- ✅ 无 token / 非法 token / 错误 secret → 401
- ✅ temp token → 403
- ✅ 普通 user 角色 → 403（越权回归用例：修复前该用例失败，握手返回 101）
- ✅ 用户已删除 → 403
- ✅ admin / superuser → 101 升级成功，pty 输出可见

验证：`go build ./...`、`go vet ./...`、`go test ./...` 全量 32 包全部通过。

Closes MYS-384
