### PR TITLE
fix(psophliteos): P0 AI-Agent 反向代理加鉴权+目标白名单+探测缓存 (MYS-379)

### DIFF
--- a/source/psophliteos/api/v1/system/sys_ai_agent.go
+++ b/source/psophliteos/api/v1/system/sys_ai_agent.go
@@ -2,62 +2,203 @@ package system
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"time"
 
 	"sophliteos/logger"
 	mvc "sophliteos/mvc/core"
 
 	"github.com/gin-gonic/gin"
+	"github.com/patrickmn/go-cache"
 )
 
 // AiAgentApi AI Agent 功能：picoclaw web 端口探测与转发、本地模型样例。
 // LLM/VLM API 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（sophliteos 不再刷新 picoclaw）。
+//
+// MYS-379 安全加固：路由已叠加 SSO（见 router/system/sys_ai_agent.go）。本层：
+//   - 探测目标身份校验：部署锚定（设备已安装 sophpicoclaw）+ 候选端口白名单 + HTTP 探针；
+//   - 探测结果缓存（ok 30s / miss 5s）：消除每请求 4 次探测的资源消耗、
+//     探测与代理间的 TOCTOU 竞态，以及端口扫描式反馈；
+//   - 代理路径/方法白名单：只放行 picoclaw Web 控制台常规路径，禁止任意路径透传；
+//   - 失败仅回显通用提示，不透露探测细节。
 type AiAgentApi struct{}
 
-const defaultPicoclawPort = 18800 // picoclaw web 默认端口
+const defaultPicoclawPort = 18800 // picoclaw web 默认端口（sophpicoclaw-launcher）
 
-// detectPicoclawPort 探测 picoclaw web 端口：默认 18800，若不可用则探测候选端口。
-func detectPicoclawPort() int {
-	candidates := []int{defaultPicoclawPort}
-	for _, p := range []int{18790, 8081, 18801} {
-		if p != defaultPicoclawPort {
-			candidates = append(candidates, p)
+// picoclawCandidates 允许探测与代理的目标端口白名单（出厂部署口径）：
+// 18800 sophpicoclaw-launcher Web 控制台；18790 sophpicoclaw gateway；
+// 8081/18801 历史手工部署遗留端口。代理目标只允许来自本列表。
+// 包级变量便于测试注入。
+var picoclawCandidates = []int{defaultPicoclawPort, 18790, 8081, 18801}
+
+// 探测结果缓存：命中端口后 okTTL 内复用；未命中负缓存 missTTL（防探测风暴与
+// 端口扫描反馈面）。TTL 为变量便于测试缩短。
+var (
+	probeOKTTL  = 30 * time.Second
+	probeMissTTL = 5 * time.Second
+	probeCache   = cache.New(30*time.Second, time.Minute)
+)
+
+// probeMu 串行化真实探测，避免并发请求同时触发多个探测。
+var probeMu sync.Mutex
+
+// picoclawInstalled 部署锚定：设备是否已安装 sophpicoclaw（仅检查配置目录存在）。
+// 口径与 pbmssm devproxyKeyPath 一致：SOPHON_PICOCLAW_HOME → /opt/sophon/picoclaw
+// （出厂路径）→ 当前部署用户 ~/.picoclaw（手工部署）。包级变量便于测试注入。
+var picoclawInstalled = func() bool {
+	dirs := []string{}
+	if home := os.Getenv("SOPHON_PICOCLAW_HOME"); home != "" {
+		dirs = append(dirs, filepath.Join(home, ".picoclaw"))
+	}
+	dirs = append(dirs,
+		"/opt/sophon/picoclaw/.picoclaw",
+		filepath.Join(os.Getenv("HOME"), ".picoclaw"),
+	)
+	for _, d := range dirs {
+		if st, err := os.Stat(d); err == nil && st.IsDir() {
+			return true
 		}
 	}
-	for _, p := range candidates {
-		if picoclawWebUp(p) {
-			return p
-		}
-	}
-	return defaultPicoclawPort
+	return false
 }
 
-// picoclawWebUp 探测端口上是否为 picoclaw web（GET / 返回 2xx/3xx 即视为 up）。
-func picoclawWebUp(port int) bool {
-	client := &http.Client{Timeout: 3 * time.Second}
+// picoclawWebUp 探测 127.0.0.1:port 上是否为 picoclaw web（GET / 返回 2xx/3xx）。
+// 不跟随重定向：picoclaw Web 控制台 GET / 即 302（README 验证口径），
+// 避免探测被 Location 带到本机其他服务。包级变量便于测试注入。
+var picoclawWebUp = func(port int) bool {
+	client := &http.Client{
+		Timeout:       3 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
 	resp, err := client.Get(url)
 	if err != nil {
 		return false
 	}
 	defer resp.Body.Close()
+	// 仅消费少量响应体，防大响应占用
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
 	return resp.StatusCode >= 200 && resp.StatusCode < 400
 }
 
-// Port GET 返回探测到的 picoclaw web 端口。
+// detectPicoclawPort 返回确认可用的 picoclaw web 端口；up=false 表示未确认可用
+// （此时返回默认端口以兼容旧行为，调用方应结合 up 判定）。
+// 先查缓存（ok 30s / miss 5s），未命中才加锁探测；同一缓存结果被 port 端点与
+// proxy 共享，消除「探测目标与代理目标不一致」的 TOCTOU。
+func detectPicoclawPort() (port int, up bool) {
+	if v, ok := probeCache.Get("port"); ok {
+		return probeCached(v), v.(int) >= 0
+	}
+	probeMu.Lock()
+	defer probeMu.Unlock()
+	// 双重检查：锁内其他请求可能已完成探测
+	if v, ok := probeCache.Get("port"); ok {
+		return probeCached(v), v.(int) >= 0
+	}
+	if !picoclawInstalled() {
+		probeCache.Set("port", -1, probeMissTTL) // 无安装锚定：负缓存，不探测
+		return defaultPicoclawPort, false
+	}
+	for _, p := range picoclawCandidates {
+		if picoclawWebUp(p) {
+			probeCache.Set("port", p, probeOKTTL)
+			return p, true
+		}
+	}
+	probeCache.Set("port", -1, probeMissTTL)
+	return defaultPicoclawPort, false
+}
+
+// probeCached 把缓存值还原为对外端口：负缓存（-1，未确认可用）统一回退默认端口，
+// 保持 port 字段始终是合法端口值，仅 up 区分确认状态。
+func probeCached(v interface{}) int {
+	if p := v.(int); p >= 0 {
+		return p
+	}
+	return defaultPicoclawPort
+}
+
+// resetPicoclawProbeCache 清空探测缓存（测试用）。
+func resetPicoclawProbeCache() {
+	probeCache.Flush()
+}
+
+// Port GET 返回探测到的 picoclaw web 端口；up 标识服务是否确认可用。
+// 探测失败仅回传 up=false，不回显任何端口探测细节。
 func (a *AiAgentApi) Port(c *gin.Context) {
-	c.JSON(http.StatusOK, mvc.Success(gin.H{"port": detectPicoclawPort()}))
+	port, up := detectPicoclawPort()
+	c.JSON(http.StatusOK, mvc.Success(gin.H{"port": port, "up": up}))
+}
+
+// picoclawProxyPathAllowed 代理路径白名单：只放行 picoclaw Web 控制台常规路径
+// （入口页/静态资源/控制台 API/聊天 WebSocket），禁止任意路径透传。
+// 对路径穿越（..、反斜杠、编码穿越）一律拒绝。
+func picoclawProxyPathAllowed(p string) bool {
+	if p == "" || strings.Contains(p, "..") || strings.Contains(p, "\\") {
+		return false
+	}
+	clean := p
+	if i := strings.IndexByte(clean, '?'); i >= 0 {
+		clean = clean[:i]
+	}
+	switch {
+	case clean == "/" || clean == "/index.html" || clean == "/favicon.ico" || clean == "/robots.txt":
+		return true
+	case strings.HasPrefix(clean, "/api/"):
+		return true
+	case clean == "/ws" || strings.HasPrefix(clean, "/ws/"):
+		return true
+	}
+	if i := strings.LastIndexByte(clean, '.'); i > 0 {
+		switch strings.ToLower(clean[i:]) {
+		case ".js", ".css", ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico",
+			".woff", ".woff2", ".webp", ".map", ".txt":
+			return true
+		}
+	}
+	return false
+}
+
+// picoclawProxyMethodAllowed 代理方法白名单：禁 CONNECT/TRACE 等隧道/反射原语。
+func picoclawProxyMethodAllowed(m string) bool {
+	switch m {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodDelete, http.MethodPatch, http.MethodOptions:
+		return true
+	}
+	return false
 }
 
 // Proxy 反向代理 picoclaw web（保留路径与查询串；供 iframe 同源访问使用）。
+// 仅代理「已确认的 AI 助手服务」：安装锚定 + 候选端口白名单 + HTTP 探针
+// （探测结果缓存复用，无 TOCTOU）；路径/方法经白名单校验；
+// 任何失败只回显通用提示，不泄露探测与目标细节。
 func (a *AiAgentApi) Proxy(c *gin.Context) {
-	port := detectPicoclawPort()
+	port, up := detectPicoclawPort()
+	if !up {
+		c.JSON(http.StatusBadGateway, mvc.Fail(-1, "AI 助手服务未就绪"))
+		return
+	}
+	// 路径取自通配参数（gin proxy/*any），归一化斜杠后走白名单；
+	// 不能直接用 URL.Path——其含 /api/device/ai-agent/proxy 前缀。
+	targetPath := c.Param("any")
+	if !strings.HasPrefix(targetPath, "/") {
+		targetPath = "/" + targetPath
+	}
+	if !picoclawProxyMethodAllowed(c.Request.Method) || !picoclawProxyPathAllowed(targetPath) {
+		c.JSON(http.StatusForbidden, mvc.Fail(-1, "forbidden"))
+		return
+	}
 	target, err := url.Parse(fmt.Sprintf("http://127.0.0.1:%d", port))
 	if err != nil {
-		c.JSON(http.StatusOK, mvc.Fail(-1, "proxy target error"))
+		c.JSON(http.StatusBadGateway, mvc.Fail(-1, "AI 助手服务未就绪"))
 		return
 	}
 	proxy := httputil.NewSingleHostReverseProxy(target)
@@ -68,7 +209,7 @@ func (a *AiAgentApi) Proxy(c *gin.Context) {
 	}
 	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, e error) {
 		logger.Error("picoclaw 代理错误 %s %s: %v", r.Method, r.URL.Path, e)
-		w.WriteHeader(http.StatusBadGateway)
+		w.WriteHeader(http.StatusBadGateway) // 只给状态码，不回显内部错误
 	}
 	proxy.ServeHTTP(c.Writer, c.Request)
 }

--- a/source/psophliteos/api/v1/system/sys_ai_agent_test.go
+++ b/source/psophliteos/api/v1/system/sys_ai_agent_test.go
@@ -1,0 +1,335 @@
+package system
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// --- 测试工具 ---------------------------------------------------------------
+
+// fakePicoclaw 起一个假 picoclaw web（GET / 200），返回其端口。
+func fakePicoclaw(t *testing.T) int {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, "<html>fake picoclaw %s</html>", r.URL.Path)
+	}))
+	t.Cleanup(srv.Close)
+	return srv.Listener.Addr().(*net.TCPAddr).Port
+}
+
+// fakeProbe 返回注入用的 picoclawWebUp 实现（带探测次数计数）。
+func fakeProbe(upPorts map[int]bool) (probe func(int) bool, count *int32) {
+	var n int32
+	return func(port int) bool {
+		atomic.AddInt32(&n, 1)
+		return upPorts[port]
+	}, &n
+}
+
+// newTestEngine 组装最小路由（与生产路由同构：port + proxy/*any）。
+func newTestEngine(t *testing.T) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+	api := &AiAgentApi{}
+	g := r.Group("api/device/ai-agent")
+	g.GET("port", api.Port)
+	g.Any("proxy/*any", api.Proxy)
+	return r
+}
+
+// doReq 通过真实 HTTP server 发起请求（gin 的 responseWriter.CloseNotify 需要
+// 真实连接对象，httptest.NewRecorder 不实现 http.CloseNotifier，会 panic）。
+func doReq(r *gin.Engine, method, rawPath string) *httptest.ResponseRecorder {
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+	req, err := http.NewRequest(method, srv.URL+rawPath, nil)
+	if err != nil {
+		panic(err)
+	}
+	cli := &http.Client{Timeout: 5 * time.Second,
+		// 不跟随重定向：与探测探针口径一致，直接拿到 302 本身
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	resp, err := cli.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	return &httptest.ResponseRecorder{Code: resp.StatusCode, Body: bytesBufferOf(body)}
+}
+
+// bytesBufferOf 包装 []byte 为 *bytes.Buffer，供 ResponseRecorder.Body 断言用。
+func bytesBufferOf(b []byte) *bytes.Buffer {
+	return bytes.NewBuffer(b)
+}
+
+// --- 探测缓存 ---------------------------------------------------------------
+
+func TestDetectPicoclawPortUsesCache(t *testing.T) {
+	port := fakePicoclaw(t)
+	oldCands, oldUp, oldInst := picoclawCandidates, picoclawWebUp, picoclawInstalled
+	picoclawCandidates = []int{port}
+	probeUp, count := fakeProbe(map[int]bool{port: true})
+	picoclawWebUp = probeUp
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawWebUp, picoclawInstalled = oldCands, oldUp, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	p1, up1 := detectPicoclawPort()
+	p2, up2 := detectPicoclawPort()
+	p3, up3 := detectPicoclawPort()
+	if !up1 || !up2 || !up3 {
+		t.Fatalf("all should be up: %v %v %v", up1, up2, up3)
+	}
+	if p1 != port || p2 != port || p3 != port {
+		t.Fatalf("port mismatch: %d/%d/%d want %d", p1, p2, p3, port)
+	}
+	if got := atomic.LoadInt32(count); got != 1 {
+		t.Fatalf("probe called %d times, want 1 (cache must absorb repeats)", got)
+	}
+}
+
+func TestDetectPicoclawPortNegativeCache(t *testing.T) {
+	oldCands, oldUp, oldInst := picoclawCandidates, picoclawWebUp, picoclawInstalled
+	picoclawCandidates = []int{18800}
+	probeUp, count := fakeProbe(map[int]bool{})
+	picoclawWebUp = probeUp
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawWebUp, picoclawInstalled = oldCands, oldUp, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	p1, up1 := detectPicoclawPort()
+	p2, up2 := detectPicoclawPort()
+	if up1 || up2 {
+		t.Fatalf("should be down: %v %v", up1, up2)
+	}
+	if p1 != defaultPicoclawPort || p2 != defaultPicoclawPort {
+		t.Fatalf("down probe should fall back to default port: %d/%d", p1, p2)
+	}
+	if got := atomic.LoadInt32(count); got != 1 {
+		t.Fatalf("negative probe called %d times, want 1 (negative cache)", got)
+	}
+}
+
+func TestDetectPicoclawPortRequiresInstallAnchor(t *testing.T) {
+	oldCands, oldUp, oldInst := picoclawCandidates, picoclawWebUp, picoclawInstalled
+	picoclawCandidates = []int{18800}
+	probeUp, count := fakeProbe(map[int]bool{18800: true})
+	picoclawWebUp = probeUp
+	picoclawInstalled = func() bool { return false } // 未安装 → 不探测、不代理
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawWebUp, picoclawInstalled = oldCands, oldUp, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	p, up := detectPicoclawPort()
+	if up {
+		t.Fatalf("uninstalled device must not report up")
+	}
+	if p != defaultPicoclawPort {
+		t.Fatalf("uninstalled port fallback mismatch: %d", p)
+	}
+	if got := atomic.LoadInt32(count); got != 0 {
+		t.Fatalf("probe must not run when picoclaw not installed, called %d times", got)
+	}
+}
+
+func TestDetectPicoclawPortRefreshesAfterTTL(t *testing.T) {
+	port := fakePicoclaw(t)
+	oldCands, oldUp, oldInst, oldOK := picoclawCandidates, picoclawWebUp, picoclawInstalled, probeOKTTL
+	picoclawCandidates = []int{port}
+	probeUp, count := fakeProbe(map[int]bool{port: true})
+	picoclawWebUp = probeUp
+	picoclawInstalled = func() bool { return true }
+	probeOKTTL = 50 * time.Millisecond // 缩短 TTL 验证过期重探
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawWebUp, picoclawInstalled, probeOKTTL = oldCands, oldUp, oldInst, oldOK
+		resetPicoclawProbeCache()
+	})
+
+	detectPicoclawPort()
+	detectPicoclawPort()
+	time.Sleep(120 * time.Millisecond)
+	detectPicoclawPort()
+	if got := atomic.LoadInt32(count); got != 2 {
+		t.Fatalf("probe called %d times, want 2 (expired cache must re-probe)", got)
+	}
+}
+
+// --- 路径/方法白名单 ----------------------------------------------------------
+
+func TestPicoclawProxyPathAllowed(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/", true},
+		{"/index.html", true},
+		{"/favicon.ico", true},
+		{"/robots.txt", true},
+		{"/assets/app.js", true},
+		{"/static/css/style.css", true},
+		{"/static/img/logo.png", true},
+		{"/api/sessions", true},
+		{"/api/chat", true},
+		{"/ws", true},
+		{"/ws/chat", true},
+		{"/index.html?token=abc", true},
+
+		{"/etc/passwd", false},
+		{"/etc/shadow", false},
+		{"/api/../etc/passwd", false},
+		{"./etc/passwd", false},
+		{"/api/..%2f..%2fetc", false}, // 含 ..（未解码判定）→ 拒绝
+		{"/proc/self/environ", false},
+		{"/cmd", false},
+		{"/admin/exec", false},
+		{"/data/ota", false},
+		{"", false},
+		{`/api/\etc`, false}, // 反斜杠 → 拒绝
+	}
+	for _, tc := range cases {
+		if got := picoclawProxyPathAllowed(tc.path); got != tc.want {
+			t.Errorf("path %q = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestPicoclawProxyMethodAllowed(t *testing.T) {
+	ok := []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodDelete, http.MethodPatch, http.MethodOptions}
+	for _, m := range ok {
+		if !picoclawProxyMethodAllowed(m) {
+			t.Errorf("method %s should be allowed", m)
+		}
+	}
+	bad := []string{http.MethodConnect, http.MethodTrace, "TRACK", "BREW"}
+	for _, m := range bad {
+		if picoclawProxyMethodAllowed(m) {
+			t.Errorf("method %s should be rejected", m)
+		}
+	}
+}
+
+// --- Proxy handler ----------------------------------------------------------
+
+func TestProxyRejectsForbiddenPath(t *testing.T) {
+	port := fakePicoclaw(t)
+	oldCands, oldInst := picoclawCandidates, picoclawInstalled
+	picoclawCandidates = []int{port}
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawInstalled = oldCands, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	r := newTestEngine(t)
+	w := doReq(r, http.MethodGet, "/api/device/ai-agent/proxy/etc/passwd")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+	if strings.Contains(w.Body.String(), "127.0.0.1") || strings.Contains(w.Body.String(), fmt.Sprintf("%d", port)) {
+		t.Fatalf("response must not leak target, body=%q", w.Body.String())
+	}
+}
+
+func TestProxyRejectsUnallowedMethod(t *testing.T) {
+	port := fakePicoclaw(t)
+	oldCands, oldInst := picoclawCandidates, picoclawInstalled
+	picoclawCandidates = []int{port}
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawInstalled = oldCands, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	r := newTestEngine(t)
+	w := doReq(r, http.MethodConnect, "/api/device/ai-agent/proxy/")
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", w.Code)
+	}
+}
+
+func TestProxyProxiesAllowedPath(t *testing.T) {
+	port := fakePicoclaw(t)
+	oldCands, oldInst := picoclawCandidates, picoclawInstalled
+	picoclawCandidates = []int{port}
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawInstalled = oldCands, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	r := newTestEngine(t)
+	w := doReq(r, http.MethodGet, "/api/device/ai-agent/proxy/index.html")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "fake picoclaw") {
+		t.Fatalf("body should come from upstream, got %q", w.Body.String())
+	}
+}
+
+func TestProxyGenericErrorWhenNotUp(t *testing.T) {
+	oldCands, oldInst := picoclawCandidates, picoclawInstalled
+	picoclawCandidates = []int{18800}
+	picoclawInstalled = func() bool { return false } // 无安装锚定 → 未就绪
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawInstalled = oldCands, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	r := newTestEngine(t)
+	w := doReq(r, http.MethodGet, "/api/device/ai-agent/proxy/index.html")
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	// 不回显探测失败细节（端口、网络错误、扫描线索）
+	body := w.Body.String()
+	for _, leak := range []string{"18800", "18790", "8081", "探测", "proxy target error", "connection", "bad gateway"} {
+		if strings.Contains(strings.ToLower(body), leak) {
+			t.Fatalf("response leaks probe detail %q: %q", leak, body)
+		}
+	}
+}
+
+// --- Port 端点 ---------------------------------------------------------------
+
+func TestPortEndpointShape(t *testing.T) {
+	oldCands, oldUp, oldInst := picoclawCandidates, picoclawWebUp, picoclawInstalled
+	picoclawCandidates = []int{18800}
+	probeUp, _ := fakeProbe(map[int]bool{18800: true})
+	picoclawWebUp = probeUp
+	picoclawInstalled = func() bool { return true }
+	t.Cleanup(func() {
+		picoclawCandidates, picoclawWebUp, picoclawInstalled = oldCands, oldUp, oldInst
+		resetPicoclawProbeCache()
+	})
+
+	r := newTestEngine(t)
+	w := doReq(r, http.MethodGet, "/api/device/ai-agent/port")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"port":18800`) || !strings.Contains(body, `"up":true`) {
+		t.Fatalf("port response shape mismatch: %q", body)
+	}
+}

--- a/source/psophliteos/initialization/sys_ai_agent_router_test.go
+++ b/source/psophliteos/initialization/sys_ai_agent_router_test.go
@@ -1,0 +1,84 @@
+package initialization
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"testing/fstest"
+
+	"sophliteos/config"
+	"sophliteos/middleware"
+)
+
+// MYS-379：/api/device/ai-agent/* 必须与 OTA 一致挂 SSO —— 有活跃会话时，
+// 无/错误 token 的请求一律 401 SESSION_OFFLINE；携带活跃 token 才放行到 handler。
+func TestAiAgentRouterRequiresSSO(t *testing.T) {
+	config.LoadConfig()
+	router := Routers(fstest.MapFS{ // 无真实前端 dist 也可建路由
+		"index.html": {Data: []byte("<html></html>")},
+	})
+
+	// 模拟 ssm 登录注入活跃会话
+	middleware.SSORegister("tester", "session-token-abc")
+	defer middleware.SSOLogout("session-token-abc")
+
+	cases := []struct {
+		name   string
+		method string
+		path   string
+		auth   string // Authorization 头；空表示不带
+		want   int
+	}{
+		{"port no token → 401", http.MethodGet, "/api/device/ai-agent/port", "", http.StatusUnauthorized},
+		{"port wrong token → 401", http.MethodGet, "/api/device/ai-agent/port", "Bearer wrong-token", http.StatusUnauthorized},
+		{"proxy no token → 401", http.MethodGet, "/api/device/ai-agent/proxy/index.html", "", http.StatusUnauthorized},
+		{"proxy wrong token → 401", http.MethodPost, "/api/device/ai-agent/proxy/api/chat", "Bearer wrong-token", http.StatusUnauthorized},
+		{"port query token mismatch → 401", http.MethodGet, "/api/device/ai-agent/port?token=wrong", "", http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		if tc.auth != "" {
+			req.Header.Set("Authorization", tc.auth)
+		}
+		router.ServeHTTP(w, req)
+		if w.Code != tc.want {
+			t.Errorf("%s: status = %d, want %d (body=%q)", tc.name, w.Code, tc.want, w.Body.String())
+		}
+	}
+
+	// 携带活跃 token → 放行到 handler（测试机无 picoclaw 时仍是业务响应而非 401）
+	for _, tc := range []struct {
+		name   string
+		method string
+		path   string
+	}{
+		{"port valid token → pass SSO", http.MethodGet, "/api/device/ai-agent/port"},
+		{"proxy valid token → pass SSO", http.MethodGet, "/api/device/ai-agent/proxy/index.html"},
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		req.Header.Set("Authorization", "Bearer session-token-abc")
+		router.ServeHTTP(w, req)
+		if w.Code == http.StatusUnauthorized {
+			t.Errorf("%s: valid session token must pass SSO, got 401", tc.name)
+		}
+	}
+}
+
+// 与 OTA 对齐：OTA 路由挂 SSO 后本地无会话时仍放行（sophliteos 重启后 SSO 暂不生效）。
+// 不做断言，仅确保本测试不污染其他测试的会话状态。
+func TestAiAgentRouterSSONoSessionPassthrough(t *testing.T) {
+	config.LoadConfig()
+	router := Routers(fstest.MapFS{
+		"index.html": {Data: []byte("<html></html>")},
+	})
+
+	// 无活跃会话：SSO 放行（与 OTA 同一中间件语义），此处只验证不 401
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/device/ai-agent/port", nil)
+	router.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("no active session must pass SSO (same semantics as OTA), got 401")
+	}
+}

--- a/source/psophliteos/router/system/sys_ai_agent.go
+++ b/source/psophliteos/router/system/sys_ai_agent.go
@@ -13,8 +13,10 @@ type AiAgentRouter struct{}
 // InitAiAgentRouter 注册 AI Agent 本地端点（不经 bmssm 反代）。
 // LLM/VLM 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（经 /api/v1/* 反代），
 // 此处仅保留 picoclaw 端口探测、本地模型样例与页面转发。
+// MYS-379：AI Agent 本地端点是 AI 助手页面/内部 API（聊天记录、Agent 控制）的
+// 直达入口，此前无任何鉴权；与 OTA 一致叠加 SSO 单会话校验。
 func (s *AiAgentRouter) InitAiAgentRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
-	agentRouter := Router.Group("api/device/ai-agent", middleware.TimeoutMiddleware(global.TimeOut))
+	agentRouter := Router.Group("api/device/ai-agent", middleware.SSO(), middleware.TimeoutMiddleware(global.TimeOut))
 	api := v1.ApiGroupApp.SystemApiGroup.AiAgentApi
 	{
 		agentRouter.GET("port", api.Port)


### PR DESCRIPTION
## 背景

MYS-379（P0，MYS-377 审查发现）：sophliteos AI-Agent 反向代理完全无鉴权。
`/api/device/ai-agent/port` 与 `/api/device/ai-agent/proxy/*` 是本地端点（不经 bmssm 反代），
此前仅挂 `TimeoutMiddleware`——未认证者可直达 AI 助手页面与内部 API（聊天记录、Agent 控制），
proxy 任意路径透传可作为端口扫描与代理原语，且探测结果存在 TOCTOU 竞态与每请求 4 次探测。

## 修复内容（3 个 commit）

### 1. 路由挂 SSO 鉴权（与 OTA 一致）

`router/system/sys_ai_agent.go`：`api/device/ai-agent` 路由组叠加 `middleware.SSO()`。
有活跃会话时无/错 token 一律 401 SESSION_OFFLINE。

### 2. 代理目标身份校验 + 路径白名单 + 探测缓存

`api/v1/system/sys_ai_agent.go`：

- **目标身份校验**：代理目标必须同时满足——
  - 部署锚定：设备已安装 sophpicoclaw（`SOPHON_PICOCLAW_HOME` → `/opt/sophon/picoclaw` → `~/.picoclaw`，口径与 pbmssm `devproxyKeyPath()` 一致，仅查目录存在）
  - 端口白名单：仅 {18800, 18790, 8081, 18801}（sophpicoclaw-launcher / gateway 及历史遗留端口）
  - HTTP 探针：GET / 2xx/3xx，且不跟随重定向（picoclaw Web 控制台 GET / 即 302，防探测被带到本机其他服务）
- **探测结果缓存**：ok 30s / miss 5s 负缓存，锁内双重检查合并并发探测——消除每请求 4 次探测、TOCTOU 竞态与端口扫描式反馈；代理与 port 端点共享同一缓存结果
- **路径白名单**：仅放行入口页/常见静态资源（js/css/图片/字体等）/ `/api/*`（控制台 API）/ `/ws*`（聊天 WebSocket）；`..`/反斜杠/编码穿越一律拒绝
- **方法白名单**：GET/HEAD/POST/PUT/DELETE/PATCH/OPTIONS；CONNECT/TRACE 隧道与反射原语拒绝
- **不回显探测失败信息**：代理失败与探测未就绪仅返回通用文案「AI 助手服务未就绪」；port 端点探测失败仅回传 `up:false`，响应结构与旧版兼容（`port` 字段保持默认 18800，追加 `up` 字段标记确认状态，前端已不依赖该端点）

### 3. 测试

- `api/v1/system/sys_ai_agent_test.go`：11 个用例——缓存命中/负缓存/无锚定不探测/TTL 过期重探、路径与方法白名单、代理 403（非法路径/非法方法）、合法路径真实转发、未就绪 502 且响应不含端口/探测字样、port 响应结构
- `initialization/sys_ai_agent_router_test.go`：SSO 行为——注册会话后无/错 token 401，合法 token 放行，覆盖 port 与 proxy 两端点

## 验证

- `go test ./...` 全绿（含既有测试）；`go vet ./...` 通过
- 官方口径 musl 静态交叉编译 arm64 通过
- 测试机（172.26.166.185）集成验证：
  - SSO：无 token / 错 token → 401；正确 token → 200；proxy 未就绪 → 502 通用文案（无探测细节）
  - 端到端（预设锚定 + 18800 假服务）：port → `{"port":18800,"up":true}`；/index.html、/assets/*、/api/* 正常转发 200；/etc/passwd、路径穿越、CONNECT → 403
  - 验证后已还原测试机原二进制与现场

## 兼容性

- port 端点响应追加 `up` 字段（老字段 `port` 语义不变）
- 前端（MYS-179 起）已改用 `/api/v1/llm-proxy/*` + 原生 WebChat，不再调用本组端点，本次只加固不删除
- 无 picoclaw 安装的设备上 proxy 返回 502（此前为代理失败/探测直落默认端口后 502，语义一致但不再掩盖细节）