### PR TITLE
fix(psophliteos): 升级两段式确认+互斥与BlockAllRequests回滚；修复timeout中间件goroutine泄漏 (MYS-381)

### DIFF
--- a/source/psophliteos/api/v1/system/sys_upgrade.go
+++ b/source/psophliteos/api/v1/system/sys_upgrade.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sophliteos/global"
 	"sophliteos/logger"
 	mvc "sophliteos/mvc/core"
 	"sophliteos/mvc/i18n"
 	services "sophliteos/mvc/services/opt"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -25,8 +27,37 @@ func init() {
 	i18n.SetString(i18n.En, "upgrade", "sophliteos upgrade")
 }
 
+// 升级采用两段式流程（上传暂存 → 确认执行），并做并发互斥：
+//   - pendingUpgrade/pendingFileName：升级包先暂存，由用户再次确认后才真正执行升级/重启，
+//     持令牌一次请求无法直接触发"上传+重启"；
+//   - upgradeInFlight：升级/重启进行中，拒绝并发的上传/确认，避免双浏览器/重复请求误触，
+//     保证升级只执行一次（幂等）。
+//
+// 上述状态均受 upgradeMu 保护；与 OTA 上传（otaMu）相互独立。
+var (
+	upgradeMu       sync.Mutex
+	pendingUpgrade  bool   // 已暂存待确认的升级包
+	pendingFileName string // 暂存的升级包文件名
+	upgradeInFlight bool   // 升级/重启进行中
+)
+
+// 重启流程的注入点：生产环境 sleep 5 秒后以 syscall.Exec 替换进程映像；
+// 测试中注入短延迟/安全函数，避免真实 sleep 与进程替换。
+var (
+	restartDelay = 5 * time.Second
+	execSelf     = func() error { return syscall.Exec(os.Args[0], os.Args, os.Environ()) }
+)
+
+// Upgrade 升级流程第一步：上传并暂存升级包（不执行升级）。
+// 幂等：重复上传会覆盖暂存包；升级进行中时拒绝上传。
 func (b *UpgradeApi) Upgrade(c *gin.Context) {
-	var err error
+	upgradeMu.Lock()
+	defer upgradeMu.Unlock()
+
+	if upgradeInFlight {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "升级正在进行中，请等待升级完成后重试"))
+		return
+	}
 
 	// filename 保存为局部变量：全局变量在并发请求下会被覆盖，导致校验/清理错乱。
 	savedName, err := saveFile(c.Request, "/data/sophliteos/")
@@ -42,8 +73,35 @@ func (b *UpgradeApi) Upgrade(c *gin.Context) {
 		return
 	}
 
-	err = upgradeLiteOs()
+	pendingUpgrade = true
+	pendingFileName = savedName
+	services.SaveOptLog(c.Request, "升级包上传")
+	c.JSON(http.StatusOK, mvc.OkWithMsg("升级包已暂存，请点击「确认升级」执行升级"))
+}
+
+// UpgradeConfirm 升级流程第二步：确认执行已暂存的升级包。
+// 无暂存包或升级进行中时返回明确错误，避免误操作。
+func (b *UpgradeApi) UpgradeConfirm(c *gin.Context) {
+	upgradeMu.Lock()
+	defer upgradeMu.Unlock()
+
+	if upgradeInFlight {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "升级正在进行中，请等待升级完成后重试"))
+		return
+	}
+	if !pendingUpgrade {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "没有待升级的升级包，请先上传升级包"))
+		return
+	}
+
+	// 先复位暂存并置为进行中：后续并发请求（上传/确认）都会被拒绝，升级只会执行一次。
+	name := pendingFileName
+	pendingUpgrade = false
+	upgradeInFlight = true
+
+	err := upgradeLiteOs()
 	if err != nil {
+		upgradeInFlight = false
 		logger.Error("upgrade failed", err)
 		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "操作失败"))
 		return
@@ -51,8 +109,8 @@ func (b *UpgradeApi) Upgrade(c *gin.Context) {
 	global.BlockAllRequests = true
 	services.SaveOptLog(c.Request, i18n.GetString(mvc.GetLang(c.Request), "upgrade"))
 
-	// 重新执行更新后的程序
-	go restartUpgradedProgram(savedName)
+	// 重新执行更新后的程序；Exec 失败时会回滚 BlockAllRequests（见 restartUpgradedProgram）
+	go restartUpgradedProgram(name)
 	c.JSON(http.StatusOK, mvc.OkWithMsg("升级成功，LiteOS正在重启，请一分钟后刷新页面重新进入"))
 }
 
@@ -106,23 +164,34 @@ func upgradeLiteOs() error {
 }
 
 func restartUpgradedProgram(savedName string) {
-	time.Sleep(5 * time.Second)
-	// 启动新进程
-	if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
-		logger.Error("Failed to restart: %v", err)
+	time.Sleep(restartDelay)
+	// 启动新进程；Exec 成功时进程映像即被新程序替换，此后的代码不再执行。
+	if err := execSelf(); err != nil {
+		// Exec 失败（二进制被替换/删除、无权限等）：进程并未重启。必须回滚阻塞标记，
+		// 否则整个平台将一直 503；同时记录告警日志，并复位 in-flight 允许重新升级。
+		logger.Error("升级重启失败: %v，回滚 BlockAllRequests，平台继续提供服务", err)
+		upgradeMu.Lock()
+		global.BlockAllRequests = false
+		upgradeInFlight = false
+		upgradeMu.Unlock()
 	}
 
-	cmd := exec.Command("rm", "-f", savedName)
+	// 清理上传的升级包（Exec 成功时进程已替换，此段不可达）
+	removeUpgradePackage(savedName)
+}
+
+// removeUpgradePackage 删除暂存的升级包；用完整路径清理，避免相对路径（进程 CWD）删错文件。
+func removeUpgradePackage(savedName string) {
+	if savedName == "" {
+		return
+	}
+	cmd := exec.Command("rm", "-f", filepath.Join("/data/sophliteos", savedName))
 	cmd.Dir = "/data/sophliteos"
 
 	// 执行命令
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		logger.Error("tar rm failed", err)
 	}
-
-	// 退出当前进程
-	os.Exit(0)
 }
 
 // 文件上传控制
@@ -153,13 +222,17 @@ func saveFile(request *http.Request, dir string) (string, error) {
 	_, err = io.Copy(f, file)
 	if err != nil {
 		_ = f.Close()
+		// 写入失败：清理半成品文件后返回
+		_ = os.Remove(dstPath)
 		return "", err
 	}
-	defer func() {
-		_ = f.Close()
-		// 清理上传文件：用实际保存路径，而非 handler.Filename（相对 CWD 可能删到别的文件）。
+	if err := f.Close(); err != nil {
 		_ = os.Remove(dstPath)
-		_ = request.MultipartForm.RemoveAll()
-	}()
+		return "", err
+	}
+
+	// 注意：上传文件保留在磁盘（升级暂存/OtaFile 后续 MD5 校验都需要），
+	// 由调用方负责清理；不再在返回时无条件删除。
+	_ = request.MultipartForm.RemoveAll()
 	return handler.Filename, nil
 }

--- a/source/psophliteos/api/v1/system/sys_upgrade_test.go
+++ b/source/psophliteos/api/v1/system/sys_upgrade_test.go
@@ -1,0 +1,295 @@
+package system
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"sophliteos/database"
+	"sophliteos/global"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+)
+
+// 升级接口对外返回的结构（与 mvc.Result 对应）
+type upgradeResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+// newUpgradeUploadRequest 构造携带升级包的 multipart 上传请求。
+func newUpgradeUploadRequest(t *testing.T, filename string) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write([]byte("fake upgrade package")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/upgrade", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func doUpgrade(t *testing.T, api *UpgradeApi, req *http.Request) upgradeResp {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/api/upgrade", api.Upgrade)
+	router.POST("/api/upgrade/confirm", api.UpgradeConfirm)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	var resp upgradeResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json %q: %v", w.Body.String(), err)
+	}
+	return resp
+}
+
+// setupDatabase 用 in-memory sqlite 初始化 database.DB，保证 SaveOptLog 等
+// 数据库查询路径不因 DB 为 nil 而 panic（生产环境由 InitDB 初始化）。
+func setupDatabase(t *testing.T) {
+	t.Helper()
+	sqlDb, err := sql.Open("sqlite3_with_go_func", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDB := database.DB
+	db, err := gorm.Open("sqlite3", sqlDb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.DB = db
+	t.Cleanup(func() {
+		_ = db.Close()
+		database.DB = oldDB
+	})
+}
+
+// waitUpgradeDone 阻塞直到后台重启流程完成：注入的 execSelf 必然失败，
+// 失败回滚会复位 upgradeInFlight，此函数等待其复位，保证测试结束时无遗留
+// goroutine 读写注入点（否则会与后续测试的 setup 竞争）。
+func waitUpgradeDone(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		upgradeMu.Lock()
+		done := !upgradeInFlight
+		upgradeMu.Unlock()
+		if done {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("等待升级流程完成超时")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// setupUpgradeTest 备份/恢复升级流程的全局状态与注入点，避免测试相互污染。
+// 默认把重启延迟拉到极大并注入安全的 execSelf，防止测试进程真的被 syscall.Exec 替换。
+// 启动重启 goroutine 的测试需自行覆盖注入点并在结束前 waitUpgradeDone。
+func setupUpgradeTest(t *testing.T) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	setupDatabase(t)
+
+	upgradeMu.Lock()
+	oldPending, oldInFlight := pendingUpgrade, upgradeInFlight
+	pendingUpgrade, upgradeInFlight = false, false
+	upgradeMu.Unlock()
+
+	// 注入点（restartDelay/execSelf）由各测试自行设置且不做恢复：
+	// confirm 启动的后台重启 goroutine 可能晚于本测试的 Cleanup 才访问它们，
+	// 恢复写入会与之竞争；测试进程独立，注入值不会泄漏到其他测试。
+	oldBlock := global.BlockAllRequests
+	restartDelay = 24 * time.Hour
+	execSelf = func() error { return errors.New("execSelf disabled in test") }
+
+	t.Cleanup(func() {
+		upgradeMu.Lock()
+		pendingUpgrade, upgradeInFlight = oldPending, oldInFlight
+		upgradeMu.Unlock()
+		global.BlockAllRequests = oldBlock
+	})
+}
+
+// TestUpgradeTwoPhaseFlow 验证两段式流程：
+// 上传只暂存不执行，确认后才置 BlockAllRequests 并进入升级中状态；期间并发请求被拒绝。
+func TestUpgradeTwoPhaseFlow(t *testing.T) {
+	setupUpgradeTest(t)
+	// 确认后会启动重启 goroutine：注入短延迟 + 必然失败的 execSelf，
+	// 断言窗口（毫秒级）内 goroutine 尚未执行，测试结束时等待其完成。
+	restartDelay = time.Second
+	execSelf = func() error { return errors.New("exec disabled in test") }
+	api := &UpgradeApi{}
+
+	// 第一次上传：仅暂存，不应触发阻塞
+	resp := doUpgrade(t, api, newUpgradeUploadRequest(t, "sophliteos-linux_arm64.tgz"))
+	if resp.Code != 0 {
+		t.Fatalf("upload resp code = %d, msg=%q; want 0", resp.Code, resp.Msg)
+	}
+	if global.BlockAllRequests {
+		t.Fatal("暂存阶段不应设置 BlockAllRequests")
+	}
+	upgradeMu.Lock()
+	pending := pendingUpgrade
+	upgradeMu.Unlock()
+	if !pending {
+		t.Fatal("上传后应处于待确认（pending）状态")
+	}
+
+	// 确认执行：置 BlockAllRequests，进入升级中
+	req := httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil)
+	resp = doUpgrade(t, api, req)
+	if resp.Code != 0 {
+		t.Fatalf("confirm resp code = %d, msg=%q; want 0", resp.Code, resp.Msg)
+	}
+	if !global.BlockAllRequests {
+		t.Fatal("确认执行后应设置 BlockAllRequests")
+	}
+	upgradeMu.Lock()
+	inflight, pending := upgradeInFlight, pendingUpgrade
+	upgradeMu.Unlock()
+	if !inflight || pending {
+		t.Fatalf("确认后状态: inflight=%v pending=%v; want inflight=true pending=false", inflight, pending)
+	}
+
+	// 升级中：再次上传与再次确认都应被拒绝
+	resp = doUpgrade(t, api, newUpgradeUploadRequest(t, "sophliteos-linux_arm64.tgz"))
+	if resp.Code == 0 {
+		t.Fatalf("升级中上传应被拒绝, msg=%q", resp.Msg)
+	}
+	resp = doUpgrade(t, api, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+	if resp.Code == 0 {
+		t.Fatalf("升级中二次确认应被拒绝, msg=%q", resp.Msg)
+	}
+
+	// 等待后台重启流程完成（exec 失败回滚），避免遗留 goroutine 影响后续测试
+	waitUpgradeDone(t)
+}
+
+// TestUpgradeConfirmWithoutPending 验证无暂存包时确认被拒绝。
+func TestUpgradeConfirmWithoutPending(t *testing.T) {
+	setupUpgradeTest(t)
+	api := &UpgradeApi{}
+
+	resp := doUpgrade(t, api, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+	if resp.Code == 0 {
+		t.Fatalf("无暂存包时确认应被拒绝, msg=%q", resp.Msg)
+	}
+	if global.BlockAllRequests {
+		t.Fatal("确认失败不应设置 BlockAllRequests")
+	}
+}
+
+// TestUpgradeConcurrentConfirm 验证并发 confirm：恰好一个成功，其余返回明确错误（幂等）。
+func TestUpgradeConcurrentConfirm(t *testing.T) {
+	setupUpgradeTest(t)
+	// 与 TestUpgradeTwoPhaseFlow 相同：短延迟 + 失败 execSelf，断言后等待完成
+	restartDelay = time.Second
+	execSelf = func() error { return errors.New("exec disabled in test") }
+	api := &UpgradeApi{}
+
+	upgradeMu.Lock()
+	pendingUpgrade = true
+	upgradeMu.Unlock()
+
+	const n = 10
+	router := gin.New()
+	router.POST("/api/upgrade/confirm", api.UpgradeConfirm)
+
+	var wg sync.WaitGroup
+	codes := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+			var resp upgradeResp
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Errorf("invalid json %q: %v", w.Body.String(), err)
+				return
+			}
+			codes[i] = resp.Code
+		}(i)
+	}
+	wg.Wait()
+
+	success := 0
+	for _, code := range codes {
+		if code == 0 {
+			success++
+		}
+	}
+	if success != 1 {
+		t.Fatalf("并发确认成功次数 = %d, want 1 (codes=%v)", success, codes)
+	}
+	if !global.BlockAllRequests {
+		t.Fatal("并发确认后应有一个请求成功设置 BlockAllRequests")
+	}
+	// 等待后台重启流程完成（exec 失败回滚），避免遗留 goroutine 影响后续测试
+	waitUpgradeDone(t)
+}
+
+// TestUpgradeRejectsBadFilename 验证非法升级包名在暂存阶段就被拒绝。
+func TestUpgradeRejectsBadFilename(t *testing.T) {
+	setupUpgradeTest(t)
+	api := &UpgradeApi{}
+
+	resp := doUpgrade(t, api, newUpgradeUploadRequest(t, "evil.sh"))
+	if resp.Code == 0 {
+		t.Fatalf("非法文件名上传应被拒绝, msg=%q", resp.Msg)
+	}
+	upgradeMu.Lock()
+	pending := pendingUpgrade
+	upgradeMu.Unlock()
+	if pending {
+		t.Fatal("非法文件名不应进入 pending 状态")
+	}
+}
+
+// TestRestartExecFailureRollback 验证 syscall.Exec 失败时回滚 BlockAllRequests 与 in-flight 状态，
+// 平台继续提供服务而非永久 503。
+func TestRestartExecFailureRollback(t *testing.T) {
+	setupUpgradeTest(t)
+
+	upgradeMu.Lock()
+	upgradeInFlight = true
+	upgradeMu.Unlock()
+	global.BlockAllRequests = true
+
+	restartDelay = 0
+	execSelf = func() error { return errors.New("binary replaced or missing") }
+
+	// 同步调用重启流程（生产环境经 go 调用；注入的 execSelf 必然失败）
+	restartUpgradedProgram("sophliteos-linux_arm64.tgz")
+
+	if global.BlockAllRequests {
+		t.Fatal("Exec 失败后应回滚 BlockAllRequests，避免平台永久 503")
+	}
+	upgradeMu.Lock()
+	inflight := upgradeInFlight
+	upgradeMu.Unlock()
+	if inflight {
+		t.Fatal("Exec 失败后应复位 upgradeInFlight，允许后续重新升级")
+	}
+}

--- a/source/psophliteos/middleware/timeout.go
+++ b/source/psophliteos/middleware/timeout.go
@@ -2,37 +2,144 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"sophliteos/logger"
 	mvc "sophliteos/mvc/core"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
+// timeoutWriter 包装 gin.ResponseWriter：超时被标记后，handler 的后续写入
+// （WriteHeader/Write/WriteString/WriteHeaderNow/Flush）全部丢弃，避免超时响应
+// 发出后 handler 仍在后台写 ResponseWriter，产生 "superfluous WriteHeader" 与
+// 响应字节交错。检查+写入在 mu 内原子完成，与 writeTimeoutResponse 的标记+写严格串行。
+type timeoutWriter struct {
+	gin.ResponseWriter
+	mu        sync.Mutex // 保护 timedOut 标记，并串行化写入与标记
+	timedOut  bool
+	discarded http.Header // 超时标记后的占位 header：写入丢弃，不指向真实响应 header map
+}
+
+// writeTimeoutResponse 在锁内标记超时并写出超时响应：
+// handler 侧的写入需等待本锁，看到 timedOut 后即被丢弃，因此对底层
+// ResponseWriter 的写不会与 handler 写入交错。
+// Content-Type 在此显式设置：Go 仅在 handler 未显式 WriteHeader 时才嗅探 body，
+// 显式 WriteHeader(200) 会锁定默认 text/plain；锁内设置避免与 handler 侧的
+// header map 写竞争（handler 在超时后经 Header() 拿到的是丢弃 map）。
+// 最后 Flush：chunked 响应体默认缓冲 4KB，不 Flush 客户端要等 handler 结束后
+// 才实际收到超时响应。
+func (w *timeoutWriter) writeTimeoutResponse(status int, body []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.timedOut = true
+	w.ResponseWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.ResponseWriter.WriteHeader(status)
+	_, _ = w.ResponseWriter.Write(body)
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Header 在超时标记后返回丢弃用 header：gin render 在写 body 前会先
+// Header().Set("Content-Type", ...)，若不隔离，handler 在超时后仍会在真实
+// 响应 header map 上写，与超时响应的写（Clone/遍历 map）竞争。
+func (w *timeoutWriter) Header() http.Header {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return w.discarded
+	}
+	return w.ResponseWriter.Header()
+}
+
+func (w *timeoutWriter) WriteHeader(code int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *timeoutWriter) WriteHeaderNow() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.WriteHeaderNow()
+}
+
+func (w *timeoutWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		// 超时后丢弃 handler 写入，防止与超时响应并发写
+		return len(data), nil
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *timeoutWriter) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return len(s), nil
+	}
+	return w.ResponseWriter.WriteString(s)
+}
+
+func (w *timeoutWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.Flush()
+}
+
 func TimeoutMiddleware(timeOut time.Duration) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		originWriter := c.Writer
+		w := &timeoutWriter{ResponseWriter: originWriter, discarded: http.Header{}}
+		c.Writer = w
+
 		ctx, cancel := context.WithTimeout(c.Request.Context(), timeOut)
 		defer cancel()
 
 		c.Request = c.Request.WithContext(ctx)
 
-		done := make(chan bool)
+		// handler 链继续在主 goroutine 上执行（c 单线程访问，无并发写 gin.Context）；
+		// 辅助 goroutine 只做超时定时：超时后经 timeoutWriter 的锁标记丢弃并写超时
+		// 响应。协程退出经 timerDone 通知，主 goroutine 收尾 join，为后续对响应的
+		// 读取（含测试断言）建立 happens-before，避免响应读写竞争。
+		done := make(chan struct{})
+		timerDone := make(chan struct{})
 		go func() {
-			defer close(done)
-			c.Next()
-			done <- true
+			defer close(timerDone)
+			timer := time.NewTimer(timeOut)
+			defer timer.Stop()
+			select {
+			case <-done:
+				// handler 在超时前完成，不干预
+			case <-timer.C:
+				// 请求超时，执行超时逻辑
+				logger.Error("timeout on %s %s", c.Request.Method, c.Request.URL.Path)
+
+				// 超时响应经包装 writer 在锁内写出：此后 handler 的写入（含
+				// Header().Set）被丢弃，不会与超时响应交错。
+				body, _ := json.Marshal(mvc.FailWithMsg(-1, "传输超时"))
+				w.writeTimeoutResponse(http.StatusOK, body)
+			}
 		}()
 
-		select {
-		case <-done:
-
-		case <-ctx.Done():
-			// 请求超时，执行超时逻辑
-			logger.Error("timeout on %s %s", c.Request.Method, c.Request.URL.Path)
-
-			c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "传输超时"))
-			c.Abort()
-		}
+		// 注意：请求的处理时间由 handler 决定（超时响应已按时发出，但当前 goroutine
+		// 要等 handler 返回后才归还连接）；handler 如能响应 ctx.Done 可提前返回。
+		c.Next()
+		close(done)
+		<-timerDone
 	}
 }

--- a/source/psophliteos/middleware/timeout_test.go
+++ b/source/psophliteos/middleware/timeout_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestTimeoutMiddlewareSlowHandler 验证超时行为：
+// handler 超过超时时间仍慢速执行时，中间件返回超时响应且状态码为 200（与 mvc 约定一致），
+// 同时 handler 在超时后写入的响应不得出现在返回体中（写入被丢弃）。
+func TestTimeoutMiddlewareSlowHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// handlerDone 保证断言发生在 handler（超时后）真正完成写入之后，
+	// 避免因时序侥幸得到"看似正确"的结果。
+	handlerDone := make(chan struct{})
+	router := gin.New()
+	router.Use(TimeoutMiddleware(50 * time.Millisecond))
+	router.GET("/slow", func(c *gin.Context) {
+		time.Sleep(200 * time.Millisecond)
+		c.String(http.StatusOK, "SLOW DONE")
+		close(handlerDone)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	router.ServeHTTP(w, req)
+	<-handlerDone
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "SLOW DONE") {
+		t.Fatalf("超时后 handler 的写入不应出现在响应中: %q", w.Body.String())
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json %q: %v", w.Body.String(), err)
+	}
+	if resp.Code != -1 || resp.Msg != "传输超时" {
+		t.Fatalf("超时响应 = %+v, want code=-1 msg=传输超时", resp)
+	}
+}
+
+// TestTimeoutMiddlewareFastHandler 验证未超时请求正常放行，响应不被改动。
+func TestTimeoutMiddlewareFastHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TimeoutMiddleware(200 * time.Millisecond))
+	router.GET("/fast", func(c *gin.Context) {
+		c.String(http.StatusOK, "FAST DONE")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/fast", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	if got := w.Body.String(); got != "FAST DONE" {
+		t.Fatalf("body = %q, want %q", got, "FAST DONE")
+	}
+}
+
+// TestTimeoutMiddlewareHandlerWriteHeaderDiscarded 验证超时后 handler 的 WriteHeader/Write
+// 均被丢弃：即使 handler 在超时后写自定义状态码，客户端收到的仍是超时响应。
+func TestTimeoutMiddlewareHandlerWriteHeaderDiscarded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handlerDone := make(chan struct{})
+	router := gin.New()
+	router.Use(TimeoutMiddleware(30 * time.Millisecond))
+	router.GET("/late", func(c *gin.Context) {
+		time.Sleep(150 * time.Millisecond)
+		c.Writer.WriteHeader(http.StatusCreated)
+		_, _ = c.Writer.Write([]byte("LATE BODY"))
+		close(handlerDone)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/late", nil)
+	router.ServeHTTP(w, req)
+	<-handlerDone
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200（超时响应）(body=%q)", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "LATE BODY") {
+		t.Fatalf("超时后 handler 写入不应出现在响应中: %q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "传输超时") {
+		t.Fatalf("响应应包含超时消息: %q", w.Body.String())
+	}
+}

--- a/source/psophliteos/router/system/sys_upgrade.go
+++ b/source/psophliteos/router/system/sys_upgrade.go
@@ -14,10 +14,13 @@ func (s *UpgradeRouter) InitUpgradeRouter(Router *gin.RouterGroup) (R gin.IRoute
 
 	// 升级/重启属敏感操作：叠加 SSO 单会话校验，避免未登录客户端直接触发。
 	// 与 /api/v1/* 反代同一套活跃会话模型；前端 defHttp 请求自动携带 token。
+	// 升级两段式：先上传暂存（upgrade），再确认执行（upgrade/confirm）。
+	// 确认接口与上传同样受 SSO 与超时中间件保护，避免未登录客户端误触发重启。
 	upgradeRouter := Router.Group("api", middleware.SSO(), middleware.TimeoutMiddleware(global.OtaTimeOut))
 	versionApi := v1.ApiGroupApp.SystemApiGroup.UpgradeApi
 	{
 		upgradeRouter.POST("upgrade", versionApi.Upgrade)
+		upgradeRouter.POST("upgrade/confirm", versionApi.UpgradeConfirm)
 	}
 
 	return upgradeRouter


### PR DESCRIPTION
## 背景

MYS-381（P1）：MYS-377 代码审查发现 sophliteos 升级流程防误操作缺失 + Timeout 中间件 goroutine 泄漏。

## 修复内容

### 1. 升级流程两段式 + 互斥（`source/psophliteos/api/v1/system/sys_upgrade.go`）

- **两段式**：`POST /api/upgrade` 仅上传暂存（提示「请点击确认升级执行」），新增 `POST /api/upgrade/confirm` 才真正执行升级/重启。持令牌一次请求无法再直接触发"上传+5秒后整进程重启"
- **状态互斥**：`upgradeMu` 保护 `pendingUpgrade / upgradeInFlight`；升级/重启进行中，上传与确认均返回明确错误（如「升级正在进行中」），避免双浏览器/重复请求误触；重复 confirm 幂等（只会执行一次）
- **BlockAllRequests 回滚**：`syscall.Exec` 失败（二进制被替换/删除、无权限）时回滚 `global.BlockAllRequests` 并复位 in-flight 状态，平台继续提供服务而非永久 503；记录告警日志（原实现在 Exec 失败后会 `os.Exit(0)` 直接退出进程）
- `restartDelay`/`execSelf` 提取为可注入变量便于测试
- **连带修复**：`saveFile` 原先在返回时无条件删除已保存文件（defer），导致升级暂存 / OTA 上传 MD5 校验必然失败——改为仅在写入失败路径清理，文件由调用方负责（升级清理用完整路径 `removeUpgradePackage`）

### 2. Timeout 中间件 goroutine 泄漏与超时后写响应（`source/psophliteos/middleware/timeout.go`）

- **goroutine 泄漏**：原实现 `done := make(chan bool)` 无缓冲，主 select 走 `ctx.Done()` 后子 goroutine 的 `done <- true` 永久阻塞——改为子 goroutine `close(done)` 发完成信号，永不阻塞；主 goroutine `<-timerDone` join 定时协程，建立 happens-before
- **超时后写响应**：`timeoutWriter` 包装 gin.ResponseWriter，超时标记（锁内原子）后 handler 的 WriteHeader/Write/WriteString/Flush/Header() 全部丢弃；超时响应在锁内写出（Content-Type 显式设置 + Flush 保证及时送达，真实 net/http 冒烟验证 ~300ms 收到）
- 结构上 handler 链仍在主 goroutine 执行（无并发写 gin.Context，panic 由 gin.Recovery 正常兜底），辅助 goroutine 只做超时定时

### 3. 路由

`router/system/sys_upgrade.go` 新增 `POST api/upgrade/confirm`（与上传同受 SSO + Timeout 中间件保护）。

## 测试

- 新增 `api/v1/system/sys_upgrade_test.go`：两段式流程、无暂存确认被拒、10 并发 confirm 恰好 1 成功（幂等）、非法文件名拒绝、Exec 失败回滚 BlockAllRequests 与 in-flight
- 新增 `middleware/timeout_test.go`：慢 handler 超时（响应为超时消息、handler 后写不混入）、快 handler 正常放行、超时后 WriteHeader/Write 被丢弃
- `go test -race ./...` 全量通过；`go vet`、`gofmt` 干净
- 真实 net/http 冒烟：fast 正常 1ms；slow handler 301ms 收到 `{"code":-1,"msg":"传输超时"}`（http 200，Content-Type application/json）

🤖 Generated with [Claude Code](https://claude.com/claude-code)