### PR TITLE
[sophliteos] MYS-382 操作审计修复（Bearer 前缀）+ 移除硬编码 admin 口令 + 服务器超时加固

### DIFF
--- a/source/psophliteos/README.md
+++ b/source/psophliteos/README.md
@@ -17,7 +17,7 @@
 - `build`/`scrip`/`release`: 构建脚本/部署脚本/产物落点
 
 ## 编译依赖
-- go >= 1.19
+- go >= 1.21（服务器超时加固使用了 Go 1.20+ 的 http.ResponseController，见 `middleware/deadline.go`）
 - arm64 静态交叉编译需要 aarch64-linux-musl-gcc（由 `build/fetch-musl-toolchain.sh` 自动下载，也可用系统包预装）
 - 前端构建需要 pnpm（或 yarn 兜底）
 
@@ -55,6 +55,23 @@ sudo dpkg -i release/sophliteos_soc_2.1.0.deb     # arm 设备
 sudo dpkg -i release/sophliteos_pcie_2.1.0.deb    # x86 开发机
 ```
 安装后由 systemd 服务 `sophliteos` 拉起，监听 :8080。前端页面由二进制内嵌资源提供，运行时不再需要独立 web 目录。
+
+## 配置
+
+部署配置为 `/opt/sophon/sophliteos/config/sophliteos.yaml`（deb conffile，升级保留改动）。
+
+- **admin 口令不随仓库提交**（MYS-382）。本地 sqlite 的 admin 占位记录（无在线登录入口，
+  登录走 bmssm 反代鉴权）密码由部署期注入：
+  ```bash
+  # systemd 环境变量或 EnvironmentFile 注入
+  echo 'Environment=SOPHLITEOS_ADMIN_PASSWORD=<md5>' >> /etc/systemd/system/sophliteos.service.d/override.conf
+  systemctl daemon-reload && systemctl restart sophliteos
+  ```
+  也可经外部覆盖配置文件（`server.admin-password`）。不注入则以空口令占位。
+- **超时配置**（升级相关与常规读超时分离）：
+  - `server.read-timeout`（默认 `30s`）：常规 HTTP 读/写超时，慢连接有界
+  - `server.read-header-timeout`（默认 `10s`）：请求头读取超时（防慢速请求头攻击）
+  - `server.ota-timeout`（默认 `12m`）：OTA 分片上传/固件升级长超时（兼容旧键 `server.timeout`）
 
 ---
 

--- a/source/psophliteos/config/sophliteos.yaml
+++ b/source/psophliteos/config/sophliteos.yaml
@@ -1,10 +1,16 @@
 server:
   port: 8080
-  # 前端静态资源已 go:embed 进单文件二进制，无需 www 磁盘路径。
-  # 本地 admin 记录的 MD5 口令（遗留：登录实际走 /api/v1/login 反代到 bmssm 鉴权）。
-  # 仅用于初始化本地 sqlite 的 admin 占位记录，无在线登录入口；如需保留请改为强口令。
-  admin-password: c3284d0f94606de1fd2af172aba15bf3
-  timeout: 12m
+  # 本地 admin 占位记录的 MD5 口令。明文口令不随仓库提交（MYS-382）：
+  # 部署期通过环境变量 SOPHLITEOS_ADMIN_PASSWORD 注入（systemd 环境变量/EnvironmentFile），
+  # 或经外部覆盖本配置文件（server.admin-password）。缺省时以空口令占位——
+  # 登录实际走 /api/v1/login 反代到 bmssm 鉴权，此记录无在线登录入口。
+  # admin-password: <部署期注入>
+  # 常规 HTTP 读/写超时（非 OTA 升级接口）：慢连接不会长期占用连接。
+  read-timeout: 30s
+  # 读取请求头超时：拒绝"慢速请求头"式慢连接攻击（slowloris）。
+  read-header-timeout: 10s
+  # OTA/升级长超时（分片上传、固件升级需更长窗口；旧配置键 server.timeout 自动兼容）。
+  ota-timeout: 12m
 
 log:
   path: /var/log/sophliteos

--- a/source/psophliteos/database/dbconnect.go
+++ b/source/psophliteos/database/dbconnect.go
@@ -3,6 +3,7 @@ package database
 import (
 	"database/sql"
 	"fmt"
+	"os"
 	"regexp"
 	"sophliteos/logger"
 	"strings"
@@ -37,6 +38,20 @@ type DBUtil struct {
 
 func GetDBUtil(db *gorm.DB) *DBUtil {
 	return &DBUtil{db: db}
+}
+
+// adminPassword 返回本地 admin 占位记录的 MD5 口令（MYS-382）。
+// 明文口令不再随仓库提交：优先取部署期注入的环境变量 SOPHLITEOS_ADMIN_PASSWORD，
+// 其次为外部覆盖配置文件中的 server.admin-password（旧版模板/存量部署兼容），
+// 两者都缺省时返回空串（该记录无在线登录入口，登录走 bmssm 反代鉴权）。
+func adminPassword() string {
+	if p := os.Getenv("SOPHLITEOS_ADMIN_PASSWORD"); p != "" {
+		return p
+	}
+	conf := &config.Conf
+	conf.Lock()
+	defer conf.Unlock()
+	return conf.GetViper().GetString("server.admin-password")
 }
 
 func InitDB() {
@@ -76,7 +91,7 @@ func InitDB() {
 			UserID:     "admin",
 			Status:     "",
 			UserName:   admin,
-			Password:   v.GetString("server.admin-password"),
+			Password:   adminPassword(),
 			Token:      "",
 			Address:    "",
 			Role:       "",

--- a/source/psophliteos/database/dbconnect_test.go
+++ b/source/psophliteos/database/dbconnect_test.go
@@ -1,0 +1,25 @@
+package database
+
+import (
+	"testing"
+
+	"sophliteos/config"
+)
+
+// adminPassword 注入优先级（MYS-382）：
+// 环境变量 SOPHLITEOS_ADMIN_PASSWORD > 外部配置 server.admin-password > 空串。
+// 仓库模板已不含明文口令，验证环境变量通道在未配置外部覆盖时依然可用。
+func TestAdminPasswordPrecedence(t *testing.T) {
+	// 与 InitBase 相同的启动顺序：先加载配置（测试环境无配置文件，viper 保持空）
+	config.LoadConfig()
+
+	t.Setenv("SOPHLITEOS_ADMIN_PASSWORD", "env-md5")
+	if got := adminPassword(); got != "env-md5" {
+		t.Fatalf("env var not honored: got %q, want env-md5", got)
+	}
+
+	t.Setenv("SOPHLITEOS_ADMIN_PASSWORD", "")
+	if got := adminPassword(); got != "" {
+		t.Fatalf("no injection sources: got %q, want empty", got)
+	}
+}

--- a/source/psophliteos/global/global.go
+++ b/source/psophliteos/global/global.go
@@ -7,13 +7,14 @@ import (
 )
 
 var (
-	TimeOut          time.Duration
-	OtaTimeOut       time.Duration
-	Version          services.BuildInfo
-	BlockAllRequests bool
-	DeviceType       string
-	SSmLists         types.SsmList
-	SdkVersion       string
-	Resource         types.Resource
-	LoginError       int
+	TimeOut           time.Duration // 常规 HTTP 读/写超时 + 常规路由 ctx 超时（server.read-timeout）
+	OtaTimeOut        time.Duration // OTA/升级长超时（server.ota-timeout，兼容旧 server.timeout）
+	ReadHeaderTimeOut time.Duration // 请求头读取超时（server.read-header-timeout）
+	Version           services.BuildInfo
+	BlockAllRequests  bool
+	DeviceType        string
+	SSmLists          types.SsmList
+	SdkVersion        string
+	Resource          types.Resource
+	LoginError        int
 )

--- a/source/psophliteos/initialization/init.go
+++ b/source/psophliteos/initialization/init.go
@@ -18,7 +18,13 @@ func InitBase() {
 	v := conf.GetViper()
 	logLevel := v.GetString("log.level")
 	logPath := v.GetString("log.path")
-	timeout := v.GetString("server.timeout")
+	readTimeout := v.GetString("server.read-timeout")
+	readHeaderTimeout := v.GetString("server.read-header-timeout")
+	// ota-timeout 优先；旧配置键 server.timeout 自动兼容（存量部署保留 12m 语义）
+	otaTimeout := v.GetString("server.ota-timeout")
+	if otaTimeout == "" {
+		otaTimeout = v.GetString("server.timeout")
+	}
 	conf.Unlock()
 
 	// 日志处理
@@ -27,11 +33,29 @@ func InitBase() {
 	// 初始化sqlite（保留 OptLog/Alarm 本地记录）
 	database.InitDB()
 
-	global.TimeOut, _ = time.ParseDuration("30s")
-	global.OtaTimeOut, _ = time.ParseDuration(timeout)
+	// 常规与 OTA/升级超时分离（MYS-382）：常规 30s（可配置），
+	// OTA/升级 12m（大分片上传/固件升级需更长窗口）；请求头 10s 防慢连接攻击。
+	global.TimeOut = parseDurationOr(readTimeout, "30s")
+	global.OtaTimeOut = parseDurationOr(otaTimeout, "12m")
+	global.ReadHeaderTimeOut = parseDurationOr(readHeaderTimeout, "10s")
 	global.BlockAllRequests = false
 	global.Version = services.VersionInit("release_version.txt")
 
 	// ssm SubscribeAlarm 已移除：告警由 ssm /api/v1/* 直接提供，sophliteos 不再订阅。
-	logger.Info("InitBase done (ssm proxy mode)")
+	logger.Info("InitBase done (ssm proxy mode), timeouts: read=%s header=%s ota=%s ctx=%s",
+		global.TimeOut, global.ReadHeaderTimeOut, global.OtaTimeOut, global.TimeOut)
+}
+
+// parseDurationOr 解析时长配置；非法值回退默认并告警，避免超时配置被意外置零（0=不限时）。
+func parseDurationOr(v, def string) time.Duration {
+	raw := v
+	if raw == "" {
+		raw = def
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		logger.Error("invalid duration %q, fallback to %s: %v", v, def, err)
+		d, _ = time.ParseDuration(def)
+	}
+	return d
 }

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"sophliteos/config"
+	"sophliteos/global"
 	"sophliteos/logger"
 	"sophliteos/middleware"
 	"sophliteos/router"
@@ -106,7 +107,9 @@ func Routers(webFS fs.FS) *gin.Engine {
 	// 活跃会话校验与连接数/频率限制），被新登录踢掉时主动收 SESSION_OFFLINE
 	Router.GET("/api/sso/events", middleware.SSOEvents)
 
-	// /api/v1/* 反代到 bmssm（鉴权由 bmssm 处理）；前置 SSO 单会话校验
+	// /api/v1/* 反代到 bmssm（鉴权由 bmssm 处理）；前置 SSO 单会话校验。
+	// DeadlineMiddleware 把连接 deadline 延长到 ota-timeout：LLM 流式响应/
+	// 长文件下载经反代回流的耗时可能远超常规 30s（MYS-382 超时分离）。
 	bmssmTarget, err := url.Parse("http://" + bmssmServer)
 	if err == nil {
 		proxy := httputil.NewSingleHostReverseProxy(bmssmTarget)
@@ -121,17 +124,23 @@ func Routers(webFS fs.FS) *gin.Engine {
 			// 长连接支持（含 WebSocket）
 			MaxIdleConns: 100,
 		}
-		Router.Any("/api/v1/*any", middleware.SSO(), func(c *gin.Context) {
-			proxy.ServeHTTP(c.Writer, c.Request)
-		})
+		Router.Any("/api/v1/*any",
+			middleware.SSO(),
+			middleware.DeadlineMiddleware(global.OtaTimeOut),
+			func(c *gin.Context) {
+				proxy.ServeHTTP(c.Writer, c.Request)
+			})
 		// Reasonix agent WS：同源 8080 → bmssm 主 server /agent/ws。
 		// 复用同一 proxy（其 Director/Transport 已支持 WebSocket 升级）。
 		// 注意：不加 SSO 中间件。WS 升级请求来自同源页面，前端 PicoWs 以
 		// 子协议 token.<forward_key> 鉴权（bmssm serveWS 校验），不携带 SSO 所需的
-		// Authorization Bearer 头；SSO() 会因拿不到 token 而 401 中断升级。
-		Router.Any("/agent/ws", func(c *gin.Context) {
-			proxy.ServeHTTP(c.Writer, c.Request)
-		})
+		// Authorization Bearer 或 ?token=；SSO() 会因拿不到 token 而 401 中断升级。
+		// DeadlineMiddleware 延长 WS 数据期连接 deadline，避免空闲链路被常规超时掐断。
+		Router.Any("/agent/ws",
+			middleware.DeadlineMiddleware(global.OtaTimeOut),
+			func(c *gin.Context) {
+				proxy.ServeHTTP(c.Writer, c.Request)
+			})
 	} else {
 		logger.Error("bmssm server url parse error: %v", err)
 	}

--- a/source/psophliteos/initialization/server.go
+++ b/source/psophliteos/initialization/server.go
@@ -22,10 +22,15 @@ func InitServer(router *gin.Engine) server {
 
 	logger.Info("Starting HTTP service at %s", address)
 
+	// 加固（MYS-382）：
+	//   ReadHeaderTimeout  请求头读取有界（默认 10s）——慢速请求头攻击（slowloris）不会占用连接；
+	//   Read/WriteTimeout  常规超时（默认 30s）——常规请求的读/写都有界；
+	// OTA 上传、升级、SSE、反代流式长请求由路由层的 DeadlineMiddleware/心跳刷新延长（见 router/）。
 	return &http.Server{
-		Addr:         ":" + address,
-		Handler:      router,
-		ReadTimeout:  global.OtaTimeOut,
-		WriteTimeout: global.OtaTimeOut,
+		Addr:              ":" + address,
+		Handler:           router,
+		ReadHeaderTimeout: global.ReadHeaderTimeOut,
+		ReadTimeout:       global.TimeOut,
+		WriteTimeout:      global.TimeOut,
 	}
 }

--- a/source/psophliteos/middleware/deadline.go
+++ b/source/psophliteos/middleware/deadline.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"net/http"
+	"sophliteos/logger"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// DeadlineMiddleware 把当前请求所占用连接的读写 deadline 延长到 now+d。
+//
+// 服务器层已用常规 ReadTimeout/WriteTimeout（默认 30s）对所有请求做了有界约束
+// （MYS-382），但 OTA 分片上传（50MB/片）与固件升级在慢速链路上需要更长窗口；
+// 本中间件借助 Go 1.20+ 的 http.NewResponseController 在请求处理前延长连接
+// deadline，实现"升级相关超时与常规读超时分离、慢速连接有界"。
+func DeadlineMiddleware(d time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		rc := http.NewResponseController(c.Writer)
+		dl := time.Now().Add(d)
+		if err := rc.SetReadDeadline(dl); err != nil {
+			logger.Debug("extend read deadline failed on %s: %v", c.Request.URL.Path, err)
+		}
+		if err := rc.SetWriteDeadline(dl); err != nil {
+			logger.Debug("extend write deadline failed on %s: %v", c.Request.URL.Path, err)
+		}
+		c.Next()
+	}
+}

--- a/source/psophliteos/middleware/sso.go
+++ b/source/psophliteos/middleware/sso.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/http"
+	"sophliteos/logger"
 	"strings"
 	"sync"
 	"time"
@@ -187,6 +188,18 @@ func resolveQueryTicket(c *gin.Context) string {
 }
 
 // SSO 单会话中间件。受保护路由（/api/v1/* 除 login/password，以及本地敏感路由）校验：
+// SSOUserByToken 返回活跃会话的用户名：仅当 token 精确匹配当前活跃会话时
+// 才可解析。操作审计（SaveOptLog）用它在本地无 user 表（鉴权在 bmssm）的
+// 情况下把请求归因到已登录用户（MYS-382）；token 不匹配/无会话返回 ok=false。
+func SSOUserByToken(token string) (string, bool) {
+	ssoMu.RLock()
+	defer ssoMu.RUnlock()
+	if token == "" || ssoToken == "" || token != ssoToken {
+		return "", false
+	}
+	return ssoUser, true
+}
+
 // 请求 token 必须等于活跃 token（精确比对，同账号新登录也会顶掉旧会话）；
 // 否则 401 SESSION_OFFLINE。无活跃会话时一律 401（MYS-378：未认证客户端不得访问
 // 任何受保护数据，必须先经 /api/v1/login 登录并 /api/sso/register 建立会话）。
@@ -309,6 +322,11 @@ func SSOEvents(c *gin.Context) {
 
 	ctx := c.Request.Context()
 	for {
+		// 常规 WriteTimeout（默认 30s）对长连接式 SSE 过短：每轮循环（含 25s 心跳）
+		// 前刷新写 deadline 到 now+2m，超时窗口有界且始终覆盖下一次心跳（MYS-382）。
+		if err := http.NewResponseController(c.Writer).SetWriteDeadline(time.Now().Add(2 * time.Minute)); err != nil {
+			logger.Debug("sse set write deadline failed: %v", err)
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/source/psophliteos/middleware/sso_test.go
+++ b/source/psophliteos/middleware/sso_test.go
@@ -330,3 +330,42 @@ func TestSSOActiveAndLogout(t *testing.T) {
 		t.Fatal("logout with matching token should clear session")
 	}
 }
+
+// --- 一次性票据单测见上；以下为 MYS-382 审计辅助函数测试 ---
+
+func TestSSOUserByToken(t *testing.T) {
+	// 无活跃会话时不可解析
+	if name, ok := SSOUserByToken("tok-1"); ok {
+		t.Fatalf("no active session: got (%q, true)", name)
+	}
+
+	SSORegister("alice", "tok-1")
+
+	// 活跃 token 精确匹配
+	if name, ok := SSOUserByToken("tok-1"); !ok || name != "alice" {
+		t.Fatalf("active token: got (%q, %v), want (alice, true)", name, ok)
+	}
+	// 未知 token 不可解析
+	if name, ok := SSOUserByToken("tok-2"); ok {
+		t.Fatalf("unknown token must not resolve, got %q", name)
+	}
+	// 空 token 不可解析
+	if name, ok := SSOUserByToken(""); ok {
+		t.Fatalf("empty token must not resolve, got %q", name)
+	}
+
+	// 新登录顶掉旧会话：旧 token 立即失效（审计不得记到旧用户头上）
+	SSORegister("bob", "tok-2")
+	if name, ok := SSOUserByToken("tok-1"); ok {
+		t.Fatalf("stale token must not resolve after re-login, got %q", name)
+	}
+	if name, ok := SSOUserByToken("tok-2"); !ok || name != "bob" {
+		t.Fatalf("new active token: got (%q, %v), want (bob, true)", name, ok)
+	}
+
+	// 登出后不可解析
+	SSOLogout("tok-2")
+	if name, ok := SSOUserByToken("tok-2"); ok {
+		t.Fatalf("token after logout must not resolve, got %q", name)
+	}
+}

--- a/source/psophliteos/mvc/core/token.go
+++ b/source/psophliteos/mvc/core/token.go
@@ -2,6 +2,7 @@ package mvc
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"sophliteos/database"
@@ -23,8 +24,20 @@ func init() {
 	tokenCache = cache.New(2*time.Hour, 5*time.Minute)
 }
 
+// Token 从 Authorization 头提取归一化后的裸 token：
+// 剥离 "Bearer " 前缀并去空白。前端 defHttp 以 `Bearer <jwt>` 发送，
+// 而 tokenCache 与会话按裸 jwt 存储/比对；旧实现直接返回完整头部，
+// 导致 Token→QueryUserWithToken 永远失配、操作审计静默失效（MYS-382）。
 func Token(request *http.Request) string {
-	return request.Header.Get(authorization)
+	header := request.Header.Get(authorization)
+	trimmed := strings.TrimSpace(header)
+	if i := strings.Index(trimmed, " "); i > 0 {
+		// 仅剥离标准的 "Bearer " 前缀；其他非法形式原样返回（查不到即不归因）。
+		if strings.EqualFold(trimmed[:i], "Bearer") {
+			trimmed = strings.TrimSpace(trimmed[i:])
+		}
+	}
+	return trimmed
 }
 
 func GetUser(token string) *database.User {

--- a/source/psophliteos/mvc/core/token_test.go
+++ b/source/psophliteos/mvc/core/token_test.go
@@ -1,0 +1,39 @@
+package mvc
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// Token 必须返回归一化后的裸 token：
+//   - 剥离 "Bearer " 前缀（前端 defHttp 以 `Bearer <jwt>` 发送）
+//   - 容忍头尾空白与大小写变体（HTTP 头值不要求严格格式）
+//
+// 归一化前的旧行为返回完整 Authorization 头（含前缀），导致
+// database.QueryUserWithToken / tokenCache 永远查不到裸 token 记录，
+// 操作审计静默失效（MYS-382）。
+func TestTokenNormalized(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{name: "bearer prefix stripped", header: "Bearer abc.def.ghi", want: "abc.def.ghi"},
+		{name: "bare token passthrough", header: "abc.def.ghi", want: "abc.def.ghi"},
+		{name: "lowercase bearer", header: "bearer abc.def.ghi", want: "abc.def.ghi"},
+		{name: "leading spaces trimmed", header: "   Bearer abc.def.ghi   ", want: "abc.def.ghi"},
+		{name: "multiple spaces after bearer", header: "Bearer   abc.def.ghi", want: "abc.def.ghi"},
+		{name: "empty header", header: "", want: ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/api/device/ota/list", nil)
+			if c.header != "" {
+				req.Header.Set(authorization, c.header)
+			}
+			if got := Token(req); got != c.want {
+				t.Fatalf("Token(%q) = %q, want %q", c.header, got, c.want)
+			}
+		})
+	}
+}

--- a/source/psophliteos/mvc/services/opt/operationlog.go
+++ b/source/psophliteos/mvc/services/opt/operationlog.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"sophliteos/database"
+	"sophliteos/middleware"
 	mvc "sophliteos/mvc/core"
 	"sophliteos/mvc/i18n"
 	"strings"
@@ -27,6 +28,24 @@ func clientIP(remoteAddr string) string {
 	return remoteAddr
 }
 
+// userNameFor 解析请求的操作人。
+//
+// 本地无 user 表（鉴权由 bmssm 反代完成，User.Token 从不写入），
+// database.QueryUserWithToken 对任何在线请求都查不到记录；若直接依赖 DB，
+// 操作日志会全部静默丢弃。因此优先取 SSO 活跃会话（登录成功时前端在
+// /api/sso/register 注册的 (username, token)），DB 仅作 legacy 记录兜底
+// （MYS-382）。两者都解析不到（无会话/未知 token）返回空串，不落审计。
+func userNameFor(request *http.Request) string {
+	token := mvc.Token(request)
+	if name, ok := middleware.SSOUserByToken(token); ok {
+		return name
+	}
+	if user := mvc.GetUser(token); user != nil {
+		return user.UserName
+	}
+	return ""
+}
+
 func SaveOptLog(request *http.Request, operationType string, parameters ...interface{}) {
 	operationContent := i18n.GetString(mvc.GetLang(request), operationType)
 	if parameters != nil && len(parameters) > 0 {
@@ -34,7 +53,6 @@ func SaveOptLog(request *http.Request, operationType string, parameters ...inter
 	}
 
 	ip := clientIP(request.RemoteAddr)
-	user := mvc.GetUser(mvc.Token(request))
 	if operationContent == "登录" {
 		database.SaveOptLog(database.OptLog{
 			UserName:         "admin",
@@ -47,11 +65,12 @@ func SaveOptLog(request *http.Request, operationType string, parameters ...inter
 		return
 	}
 
-	if user == nil {
+	userName := userNameFor(request)
+	if userName == "" {
 		return
 	}
 	database.SaveOptLog(database.OptLog{
-		UserName:         user.UserName,
+		UserName:         userName,
 		CreatedTime:      time.Now(),
 		OperationType:    strings.Split(request.RequestURI, "?")[0],
 		OperationContent: operationContent,

--- a/source/psophliteos/mvc/services/opt/operationlog_test.go
+++ b/source/psophliteos/mvc/services/opt/operationlog_test.go
@@ -1,0 +1,103 @@
+package services
+
+import (
+	"database/sql"
+	"net/http/httptest"
+	"testing"
+
+	"sophliteos/database"
+	"sophliteos/middleware"
+
+	"github.com/jinzhu/gorm"
+)
+
+// initTestDB 打开一个空的 sqlite 内存库，避免 SSO 未命中时
+// database.QueryUserWithToken 因全局 DB 为 nil 而 panic。
+func initTestDB(t *testing.T) {
+	t.Helper()
+	sqlDb, err := sql.Open("sqlite3_with_go_func", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db, err := gorm.Open("sqlite3", sqlDb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.DB = db
+}
+
+// 操作审计的用户名解析（MYS-382）：
+// 前端以 `Authorization: Bearer <jwt>` 发请求，SSO 会话按裸 token 注册。
+// 解析顺序：SSO 活跃会话（本地无 user 表，鉴权在 bmssm）→ DB legacy 记录兜底。
+// 这里只测不依赖 DB 的路径：Bearer 头→SSO 会话解析为用户名。
+func TestUserNameFor(t *testing.T) {
+	initTestDB(t)
+	cases := []struct {
+		name         string
+		registerUser string // 空表示不注册会话
+		registerTok  string
+		authHeader   string
+		want         string
+	}{
+		{
+			name:         "bearer header matches active session",
+			registerUser: "tester",
+			registerTok:  "tok-alice",
+			authHeader:   "Bearer tok-alice",
+			want:         "tester",
+		},
+		{
+			name:         "bare header matches active session",
+			registerUser: "tester2",
+			registerTok:  "tok-bob",
+			authHeader:   "tok-bob",
+			want:         "tester2",
+		},
+		{
+			name:         "unknown token cannot be attributed",
+			registerUser: "tester",
+			registerTok:  "tok-alice",
+			authHeader:   "Bearer tok-other",
+			want:         "",
+		},
+		{
+			name:         "no registered session cannot be attributed",
+			registerUser: "",
+			registerTok:  "",
+			authHeader:   "Bearer tok-whatever",
+			want:         "",
+		},
+		{
+			name:         "no auth header cannot be attributed",
+			registerUser: "tester",
+			registerTok:  "tok-alice",
+			authHeader:   "",
+			want:         "",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			// 复位会话状态到本用例前提
+			resetSSOSession()
+			if c.registerUser != "" {
+				middleware.SSORegister(c.registerUser, c.registerTok)
+			}
+
+			req := httptest.NewRequest("GET", "/api/upgrade", nil)
+			if c.authHeader != "" {
+				req.Header.Set("Authorization", c.authHeader)
+			}
+			if got := userNameFor(req); got != c.want {
+				t.Fatalf("userNameFor = %q, want %q", got, c.want)
+			}
+		})
+	}
+
+	resetSSOSession()
+}
+
+func resetSSOSession() {
+	middleware.SSORegister("", "reset-token")
+	middleware.SSOLogout("reset-token")
+}

--- a/source/psophliteos/router/system/sys_ota.go
+++ b/source/psophliteos/router/system/sys_ota.go
@@ -2,6 +2,7 @@ package system
 
 import (
 	v1 "sophliteos/api/v1"
+	"sophliteos/global"
 	"sophliteos/middleware"
 
 	"github.com/gin-gonic/gin"
@@ -13,7 +14,13 @@ func (s *OtaRouter) InitOtaRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
 
 	// OTA 上传/升级属敏感操作：叠加 SSO 单会话校验 + bmssm JWT 校验，避免未登录
 	// 客户端向 /data/ota 写入文件。GET list 仅读本地文件列表，一并纳入统一口径。
-	otaRouter := Router.Group("api/device/ota", middleware.SSO(), middleware.RequireBMSSMToken())
+	// DeadlineMiddleware 延长连接读写 deadline 到 ota-timeout：50MB/片的分片上传
+	// 在慢速链路上需要比常规 30s 更长的窗口（MYS-382 超时分离）。
+	otaRouter := Router.Group("api/device/ota",
+		middleware.SSO(),
+		middleware.RequireBMSSMToken(),
+		middleware.DeadlineMiddleware(global.OtaTimeOut),
+		middleware.TimeoutMiddleware(global.OtaTimeOut))
 	api := v1.ApiGroupApp.SystemApiGroup.OtaApi
 	{
 		otaRouter.GET("list", api.OtaFileList)

--- a/source/psophliteos/router/system/sys_upgrade.go
+++ b/source/psophliteos/router/system/sys_upgrade.go
@@ -15,7 +15,13 @@ func (s *UpgradeRouter) InitUpgradeRouter(Router *gin.RouterGroup) (R gin.IRoute
 	// 升级两段式：先上传暂存（upgrade），再确认执行（upgrade/confirm）。
 	// 升级/重启属敏感操作：叠加 SSO 单会话 + bmssm JWT 校验，与 /api/v1/* 反代
 	// 同一套活跃会话模型，避免未登录客户端直接触发；前端 defHttp 请求自动携带 token。
-	upgradeRouter := Router.Group("api", middleware.SSO(), middleware.RequireBMSSMToken(), middleware.TimeoutMiddleware(global.OtaTimeOut))
+	// DeadlineMiddleware 将连接读写 deadline 延长到 ota-timeout：固件升级执行
+	// 时间可远超常规 30s（MYS-382 超时分离）。
+	upgradeRouter := Router.Group("api",
+		middleware.SSO(),
+		middleware.RequireBMSSMToken(),
+		middleware.DeadlineMiddleware(global.OtaTimeOut),
+		middleware.TimeoutMiddleware(global.OtaTimeOut))
 	versionApi := v1.ApiGroupApp.SystemApiGroup.UpgradeApi
 	{
 		upgradeRouter.POST("upgrade", versionApi.Upgrade)


### PR DESCRIPTION
## 背景

MYS-377 代码审查发现的 P1 问题（本 issue MYS-382）：

1. **操作审计静默失效**：`mvc.Token(request)` 返回完整 `Authorization` 头（含 `Bearer ` 前缀），而 `database.QueryUserWithToken` / `tokenCache` 按裸 token 存查 → 永远失配 → `user == nil` → OTA 上传、升级操作日志全部被静默丢弃。
2. **硬编码凭据**：`config/sophliteos.yaml` 中的明文 admin MD5（`c3284d0f...`）随仓库提交，并注入本地 sqlite admin 记录。
3. **服务器超时缺失**：明文 HTTP 监听 `:8080`，`ReadTimeout`/`WriteTimeout` 全线取 12m（含常规接口），`ReadHeaderTimeout` 未设置，慢连接可长时间占用连接。

## 修复内容

### 1. 审计修复
- `mvc/core/token.go`：`Token()` 归一化——剥离 `Bearer ` 前缀（大小写不敏感）+ 去空白。
- `mvc/services/opt/operationlog.go`：操作人解析改为 **SSO 活跃会话优先、DB legacy 兜底**。本地无 user 表（鉴权由 bmssm 反代完成，`User.Token` 从不写入），仅靠 DB 查不到任何在线用户；登录成功时前端在 `/api/sso/register` 已注册 `(username, token)`，审计据此归因（新增 `middleware.SSOUserByToken`）。

### 2. 移除硬编码 admin 口令
- `config/sophliteos.yaml` 删除明文 MD5，改为部署期注入：环境变量 `SOPHLITEOS_ADMIN_PASSWORD` 优先，外部覆盖配置文件（`server.admin-password`）兜底（${README} 已更新部署说明）。
- `database/dbconnect.go` 初始化逻辑保持向后兼容（新增 `adminPassword()`，缺省空口令占位；该记录无在线登录入口）。

### 3. 服务器超时加固（升级/常规超时分离）
- `http.Server`：新增 `ReadHeaderTimeout`（默认 10s，防慢速请求头攻击），常规 `Read/WriteTimeout` 收窄到 30s，均有界。
- 新配置：`server.read-timeout` / `server.read-header-timeout` / `server.ota-timeout`（兼容旧键 `server.timeout`）。
- OTA 上传、升级、`/api/v1/*` 反代、`/agent/ws` 路由经新 `middleware.DeadlineMiddleware`（Go 1.20+ `http.ResponseController`）把连接 deadline 延长到 ota-timeout（12m）；SSE 每轮循环刷新写 deadline（now+2m，覆盖 25s 心跳）。`go.mod` 1.19 → 1.21。

## 验证

**单测**（`go build` / `go vet` / `go test ./...` 全绿）：
- `mvc/core/token_test.go`：Bearer 前缀剥离（含大小写/空白变体）
- `middleware/sso_test.go`：`SSOUserByToken` 活跃会话匹配/未知 token/登出/被顶
- `mvc/services/opt/operationlog_test.go`：Bearer 头→SSO 会话归因
- `database/dbconnect_test.go`：admin 口令注入优先级

**SE7 测试机端到端**（172.26.166.185，arm64 静态交叉编译二进制 + docker 隔离实例，端口 18082）：
- ✅ Bearer 头 OTA 分片上传成功（md5 校验通过），`opt_log` 真实落库：`('mys382-tester', '/api/device/ota/chunked', '升级包上传')`
- ✅ 错误 token / 无 token 访问受保护端点 → 401
- ✅ sqlite `user` 表 admin 记录口令 = 环境变量注入值（仓库/二进制中已无旧 MD5）
- ✅ 慢速请求头连接约 10s 被切断（ReadHeaderTimeout 生效）
- ✅ SSE 连接存活超 35s（写 deadline 刷新生效，常规 30s 超时未误伤长连接）
- ✅ 启动日志确认超时生效：`timeouts: read=30s header=10s ota=12m0s`

## 说明

- **TLS 未在本变更引入**：仓库部署拓扑中无前置 TLS 层（浏览器直连 `:8080`），引入 TLS 涉及证书管理/端口变更的部署改造，超出本 issue 范围；建议由部署侧（systemd/网关）先行，后续单独评估。
- `/api/v1/*` 的 bmssm 反代在容器隔离环境无法连到宿主 9779，该项未做设备端到端（外层仅加了 deadline 延长，不改变代理逻辑）。

Co-Authored-By: Claude <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
