### PR TITLE
fix(bmssm): 收紧 temp token 改密流程，关闭默认凭据接管链 (MYS-385)

### DIFF
--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -186,8 +186,8 @@ func getNormalToken(t *testing.T, r *gin.Engine) string {
 	t.Helper()
 	tempToken := loginTempToken(t, r)
 
-	// 改密（临时 token 可调 /password，不校验旧密码）
-	body, _ := json.Marshal(user.ChangePasswordRequest{NewPassword: "realpass"})
+	// 临时 token 改密：需校验旧密码（当前为默认密码 admin）；成功后不签发正式 token
+	body, _ := json.Marshal(user.ChangePasswordRequest{OldPassword: "admin", NewPassword: "realpass"})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/password", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -300,13 +300,13 @@ func TestTempTokenRestricted(t *testing.T) {
 	}
 }
 
-// TestChangePasswordFlow 临时 token 改密 → 拿到正式 token → 正式 token 可访问受保护端点。
+// TestChangePasswordFlow 临时 token 改密（不签发正式 token）→ 新密码重新登录拿正式 token → 可访问受保护端点。
 func TestChangePasswordFlow(t *testing.T) {
 	r := setupCompatTest(t)
 	tempToken := loginTempToken(t, r)
 
-	// 临时 token 调 /password（不传 oldPassword）
-	body, _ := json.Marshal(user.ChangePasswordRequest{NewPassword: "brandnew"})
+	// 临时 token 调 /password（需带旧密码=默认密码）
+	body, _ := json.Marshal(user.ChangePasswordRequest{OldPassword: "admin", NewPassword: "brandnew"})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/password", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -317,18 +317,40 @@ func TestChangePasswordFlow(t *testing.T) {
 	}
 	resp := assertSsmOK(t, w.Body.Bytes(), "change password")
 	m, _ := resp.Result.(map[string]interface{})
-	newToken, _ := m["token"].(string)
+	// 安全收紧：temp 改密成功不再签发正式 token，必须重新登录
+	if newToken, _ := m["token"].(string); newToken != "" {
+		t.Fatal("change password: temp token flow must not return a formal token")
+	}
+
+	// 用新密码重新登录拿正式 token
+	body2, _ := json.Marshal(user.LoginRequest{Username: "admin", Password: "brandnew"})
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/login", bytes.NewBuffer(body2))
+	req2.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("relogin: expected 200, got %d body=%s", w2.Code, w2.Body.String())
+	}
+	var resp2 response.Result
+	if err := json.Unmarshal(w2.Body.Bytes(), &resp2); err != nil {
+		t.Fatalf("relogin unmarshal: %v", err)
+	}
+	if resp2.Result == nil {
+		t.Fatal("relogin: empty result")
+	}
+	m2 := resp2.Result.(map[string]interface{})
+	newToken, _ := m2["token"].(string)
 	if newToken == "" {
-		t.Fatal("change password: should return new normal token")
+		t.Fatal("relogin: should return normal token")
 	}
 
 	// 新正式 token 可访问受保护端点
-	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/device/basic", nil)
-	req2.Header.Set("Authorization", "Bearer "+newToken)
-	r.ServeHTTP(w2, req2)
-	if w2.Code != http.StatusOK {
-		t.Fatalf("new token access: expected 200, got %d body=%s", w2.Code, w2.Body.String())
+	w3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/device/basic", nil)
+	req3.Header.Set("Authorization", "Bearer "+newToken)
+	r.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusOK {
+		t.Fatalf("new token access: expected 200, got %d body=%s", w3.Code, w3.Body.String())
 	}
 }
 

--- a/source/pbmssm/mvc/user/controller.go
+++ b/source/pbmssm/mvc/user/controller.go
@@ -60,6 +60,8 @@ func (ctrl *Controller) auditWrite(c *gin.Context, username, action, resource, r
 // Login 处理 POST /api/v1/login。
 // 若提供的密码等于配置的默认密码，视为用户未改密，签发临时 token 并返回 changePass=true，
 // 前端据此引导改密；否则签发正常 token。
+// 临时 token 仅限调用 /api/v1/password 完成首登改密（Auth 中间件 403 其余端点），
+// 且改密必须提供旧密码、新密码不得等于默认密码、改密后强制重新登录（见 ChangePassword）。
 func (ctrl *Controller) Login(c *gin.Context) {
 	var req LoginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -184,10 +186,13 @@ func (ctrl *Controller) DeleteUser(c *gin.Context) {
 }
 
 // ChangePassword 处理 POST /api/v1/password（受保护，临时 token 可调）。
-//   - 临时 token（c.Get("temp")==true）：不校验旧密码，直接设新密码（首次改密场景）。
-//   - 正式 token：必须校验旧密码（svc.Login 验证），通过后才改。
-//
-// 改密成功后签发新的正式 token 返回。
+//   - 所有改密（含临时 token）必须提供并通过旧密码校验（svc.Login 验证），
+//     防止持有默认密码之外的凭据者（如 token 泄露）擅自改密。
+//   - 新密码不得等于配置的默认密码，确保改密后默认凭据永久失效（bcrypt 不再匹配），
+//     关闭"默认密码可登录 → 临时 token → 改密"的循环接管链。
+//   - 临时 token 改密成功后不签发正式 token：临时通道仅用于首登改密，
+//     必须用新密码重新登录获得正式 token，避免临时授权自动升级为完整能力。
+//   - 正式 token 改密成功后签发新的正式 token 返回（保持既有行为）。
 func (ctrl *Controller) ChangePassword(c *gin.Context) {
 	var req ChangePasswordRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -202,16 +207,26 @@ func (ctrl *Controller) ChangePassword(c *gin.Context) {
 		return
 	}
 
+	if req.OldPassword == "" {
+		c.JSON(http.StatusBadRequest, response.Fail("old password required"))
+		return
+	}
+
 	tempVal, _ := c.Get("temp")
 	isTemp, _ := tempVal.(bool)
 
-	// 正式 token 需校验旧密码
-	if !isTemp {
-		if _, err := ctrl.svc.Login(usernameStr, req.OldPassword); err != nil {
-			ctrl.auditWrite(c, usernameStr, "change_password", "auth", "failed")
-			c.JSON(http.StatusUnauthorized, response.Fail("invalid old password"))
-			return
-		}
+	// 无论临时/正式 token，改密都必须校验旧密码
+	if _, err := ctrl.svc.Login(usernameStr, req.OldPassword); err != nil {
+		ctrl.auditWrite(c, usernameStr, "change_password", "auth", "failed")
+		c.JSON(http.StatusUnauthorized, response.Fail("invalid old password"))
+		return
+	}
+
+	// 新密码不得等于默认密码（默认凭据一旦改掉即永久失效）
+	if req.NewPassword == getDefaultPassword() {
+		ctrl.auditWrite(c, usernameStr, "change_password", "auth", "failed")
+		c.JSON(http.StatusBadRequest, response.Fail("new password must not be the default password"))
+		return
 	}
 
 	if err := ctrl.svc.ChangePassword(usernameStr, req.NewPassword); err != nil {
@@ -220,7 +235,14 @@ func (ctrl *Controller) ChangePassword(c *gin.Context) {
 		return
 	}
 
-	// 改密成功，签发正式 token
+	// 临时 token 改密成功：不签发正式 token，强制用新密码重新登录
+	if isTemp {
+		ctrl.auditWrite(c, usernameStr, "change_password", "auth", "success")
+		c.JSON(http.StatusOK, response.OK(gin.H{"message": "password changed, please re-login"}))
+		return
+	}
+
+	// 正式 token 改密成功，签发新的正式 token
 	var role string
 	if u, err := ctrl.svc.FindUser(usernameStr); err == nil {
 		role = u.Role

--- a/source/pbmssm/mvc/user/controller_security_test.go
+++ b/source/pbmssm/mvc/user/controller_security_test.go
@@ -1,0 +1,307 @@
+package user
+
+// 默认凭据接管链安全测试（MYS-385）：
+//   - 默认密码登录只能拿到 temp token（changePass=true）
+//   - temp token 仅能用于改密（其余端点 403）
+//   - temp 改密必须校验旧密码
+//   - 新密码不得等于默认密码
+//   - temp 改密成功不签发正式 token，强制重新登录
+//   - 改密后默认密码永久失效，新密码登录拿到正式 token
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"bmssm/config"
+	"bmssm/middleware"
+	"bmssm/pkg/auth"
+	"bmssm/pkg/response"
+)
+
+// setupSecurityRouter 挂载 login/password/user 路由（password 与 user 走真实 Auth 中间件，
+// 使 c.Get("user")/c.Get("temp") 与线上一致）。
+func setupSecurityRouter(ctrl *Controller) *gin.Engine {
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	{
+		api.POST("/password", ctrl.ChangePassword)
+		api.GET("/user", ctrl.ListUsers)
+	}
+	r.POST("/api/v1/login", ctrl.Login)
+	return r
+}
+
+func securitySecret() string {
+	return auth.EffectiveSecret(config.Conf.GetViper().GetString("server.authSecret"))
+}
+
+func securityDoJSON(t *testing.T, r http.Handler, method, path, token string, body interface{}) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader *bytes.Reader
+	if body != nil {
+		b, _ := json.Marshal(body)
+		reader = bytes.NewReader(b)
+	} else {
+		reader = bytes.NewReader(nil)
+	}
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, reader)
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// securityLogin 登录并解析 LoginResponse。
+func securityLogin(t *testing.T, r http.Handler, username, password string) (*httptest.ResponseRecorder, LoginResponse) {
+	t.Helper()
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/login", "", LoginRequest{Username: username, Password: password})
+	var resp response.Result
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal login envelope: %v body=%s", err, w.Body.String())
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var lr LoginResponse
+	if err := json.Unmarshal(raw, &lr); err != nil {
+		t.Fatalf("unmarshal login result: %v body=%s", err, w.Body.String())
+	}
+	return w, lr
+}
+
+// TestLoginDefaultPasswordIssuesOnlyTempToken 用默认密码登录必须签发 temp token 并标记 changePass。
+func TestLoginDefaultPasswordIssuesOnlyTempToken(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	r := setupSecurityRouter(ctrl)
+	w, lr := securityLogin(t, r, "admin", "admin")
+	if w.Code != http.StatusOK {
+		t.Fatalf("login with default password: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	if !lr.ChangePass {
+		t.Fatal("expected changePass=true for default password login")
+	}
+	if lr.Token == "" {
+		t.Fatal("expected temp token to be issued")
+	}
+	username, temp, err := auth.ParseToken(lr.Token, securitySecret())
+	if err != nil {
+		t.Fatalf("parse temp token: %v", err)
+	}
+	if username != "admin" {
+		t.Fatalf("expected username admin, got %s", username)
+	}
+	if !temp {
+		t.Fatal("expected token to carry temp=true")
+	}
+}
+
+// TestTempTokenCannotAccessOtherEndpoints temp token 访问改密之外的端点必须 403。
+func TestTempTokenCannotAccessOtherEndpoints(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	tempToken, _, err := auth.IssueToken("admin", securitySecret(), true)
+	if err != nil {
+		t.Fatalf("issue temp token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodGet, "/api/v1/user", tempToken, nil)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("temp token on /api/v1/user: expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestTempChangePasswordRejectsWrongOldPassword temp 改密也须校验旧密码（当前密码=默认密码）。
+func TestTempChangePasswordRejectsWrongOldPassword(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	tempToken, _, err := auth.IssueToken("admin", securitySecret(), true)
+	if err != nil {
+		t.Fatalf("issue temp token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", tempToken,
+		ChangePasswordRequest{OldPassword: "wrong-old", NewPassword: "NewPass123"})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("temp change password with wrong old password: expected 401, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestTempChangePasswordRejectsDefaultNewPassword 新密码不得等于默认密码（防止改密后默认凭据仍有效）。
+func TestTempChangePasswordRejectsDefaultNewPassword(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	tempToken, _, err := auth.IssueToken("admin", securitySecret(), true)
+	if err != nil {
+		t.Fatalf("issue temp token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", tempToken,
+		ChangePasswordRequest{OldPassword: "admin", NewPassword: "admin"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("temp change password to default password: expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestChangePasswordRequiresOldPassword 改密请求必须提供旧密码。
+func TestChangePasswordRequiresOldPassword(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	tempToken, _, err := auth.IssueToken("admin", securitySecret(), true)
+	if err != nil {
+		t.Fatalf("issue temp token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", tempToken,
+		ChangePasswordRequest{OldPassword: "", NewPassword: "NewPass123"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("change password without old password: expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestTempChangePasswordSuccessForcesReLogin temp 改密成功：
+// 不签发正式 token；旧默认密码失效；新密码登录返回正式 token 且 changePass=false。
+func TestTempChangePasswordSuccessForcesReLogin(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	tempToken, _, err := auth.IssueToken("admin", securitySecret(), true)
+	if err != nil {
+		t.Fatalf("issue temp token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", tempToken,
+		ChangePasswordRequest{OldPassword: "admin", NewPassword: "NewPass123"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("temp change password: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	// 响应中不得携带可直接使用的正式 token
+	var resp response.Result
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var cpr ChangePasswordResponse
+	if err := json.Unmarshal(raw, &cpr); err != nil {
+		t.Fatalf("unmarshal result: %v body=%s", err, w.Body.String())
+	}
+	if cpr.Token != "" {
+		t.Fatalf("temp change password must not return a formal token, got %q", cpr.Token)
+	}
+
+	// 改密后：默认密码登录必须失败
+	w2, _ := securityLogin(t, r, "admin", "admin")
+	if w2.Code == http.StatusOK {
+		t.Fatal("login with default password must fail after password changed")
+	}
+
+	// 新密码登录：正常签发正式 token，changePass=false
+	w3, lr := securityLogin(t, r, "admin", "NewPass123")
+	if w3.Code != http.StatusOK {
+		t.Fatalf("login with new password: expected 200, got %d body=%s", w3.Code, w3.Body.String())
+	}
+	if lr.ChangePass {
+		t.Fatal("expected changePass=false after password changed")
+	}
+	_, temp, err := auth.ParseToken(lr.Token, securitySecret())
+	if err != nil {
+		t.Fatalf("parse new token: %v", err)
+	}
+	if temp {
+		t.Fatal("expected formal token after real password login")
+	}
+	// 正式 token 可访问其他端点
+	w4 := securityDoJSON(t, r, http.MethodGet, "/api/v1/user", lr.Token, nil)
+	if w4.Code != http.StatusOK {
+		t.Fatalf("formal token on /api/v1/user: expected 200, got %d body=%s", w4.Code, w4.Body.String())
+	}
+}
+
+// TestFormalChangePasswordRejectsWrongOldPassword 正式 token 改密仍须校验旧密码（既有行为回归）。
+func TestFormalChangePasswordRejectsWrongOldPassword(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("alice", "pass123", "user")
+
+	formalToken, _, err := auth.IssueToken("alice", securitySecret(), false)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", formalToken,
+		ChangePasswordRequest{OldPassword: "wrong", NewPassword: "NewPass456"})
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("formal change password with wrong old password: expected 401, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestFormalChangePasswordRejectsDefaultNewPassword 正式改密同样禁止将密码改回默认值。
+func TestFormalChangePasswordRejectsDefaultNewPassword(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("alice", "pass123", "user")
+
+	formalToken, _, err := auth.IssueToken("alice", securitySecret(), false)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", formalToken,
+		ChangePasswordRequest{OldPassword: "pass123", NewPassword: "admin"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("formal change password to default: expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestFormalChangePasswordSuccessReturnsNewToken 正式 token 改密成功返回新正式 token（既有行为回归）。
+func TestFormalChangePasswordSuccessReturnsNewToken(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+	_ = ctrl.svc.CreateUser("alice", "pass123", "user")
+
+	formalToken, _, err := auth.IssueToken("alice", securitySecret(), false)
+	if err != nil {
+		t.Fatalf("issue token: %v", err)
+	}
+	r := setupSecurityRouter(ctrl)
+	w := securityDoJSON(t, r, http.MethodPost, "/api/v1/password", formalToken,
+		ChangePasswordRequest{OldPassword: "pass123", NewPassword: "NewPass456"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("formal change password: expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp response.Result
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	raw, _ := json.Marshal(resp.Result)
+	var cpr ChangePasswordResponse
+	if err := json.Unmarshal(raw, &cpr); err != nil {
+		t.Fatalf("unmarshal result: %v body=%s", err, w.Body.String())
+	}
+	if cpr.Token == "" {
+		t.Fatal("formal change password must return a new formal token")
+	}
+	// 新密码可登录
+	if _, err := ctrl.svc.Login("alice", "NewPass456"); err != nil {
+		t.Fatalf("new password should work after change: %v", err)
+	}
+}

--- a/source/pbmssm/mvc/user/service.go
+++ b/source/pbmssm/mvc/user/service.go
@@ -94,7 +94,7 @@ func (s *UserService) FindUser(username string) (*User, error) {
 }
 
 // ChangePassword 修改指定用户的密码：用 bcrypt 重新哈希并写回 DB。
-// 调用方负责校验旧密码（正式 token）或跳过（临时 token 首次改密）。
+// 调用方负责校验旧密码（控制器对临时/正式 token 一律校验）以及新密码不得等于默认密码。
 func (s *UserService) ChangePassword(username, newPassword string) error {
 	hash, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {


### PR DESCRIPTION
## 背景

MYS-385（P0，源自 MYS-377 代码审查）：bmssm 默认凭据接管链——LAN 内任何人触达登录口 → 用默认密码登录 → 拿 temp token → 改密**无需旧密码** → 拿正式 token → 完整 admin 永久接管设备。

## 修复内容

`source/pbmssm/mvc/user/controller.go`（ChangePassword 收紧）：

1. **旧密码必填 + 一律校验**：temp token 改密也必须提供并通过旧密码校验（首登时旧密码即默认密码）。temp token 不再是"万能钥匙"，防 token 泄露后被滥用。
2. **新密码不得等于默认密码**：改密后默认凭据 bcrypt 永久失效，"默认密码 → temp token → 改密"循环接管链关闭。
3. **temp 改密成功不签发正式 token**：强制用新密码重新登录；临时授权不会自动升级为完整能力。正式 token 改密行为不变（仍校验旧密码、成功签发新 token）。

未改密账号仅能获得 temp token，且只能调用 `/api/v1/password`（Auth 中间件 + 终端 WS/文件下载处已 403，本次测试补覆盖）。

## 兼容性确认

- **前端已兼容**（`psophliteos`）：首登改密表单（ChangePasswordForm.vue）本就传 `oldPassword` 且改密成功后强制退登重新登录（`handleLoginOut` + `handleBackLogin`），无需前端改动。
- **出厂流程不变**：新设备 admin/admin 登录 → changePass=true → 强制改密（传默认密码为旧密）→ 用新密码重新登录 → 正常使用。
- **运维通道**：`bmssm --reset-password`（需本机 shell 权限）重置为默认密码后，用户仍走首登改密，闭环不变。

## 测试

- 新增 9 个安全用例 `mvc/user/controller_security_test.go`：默认密码登录签发 temp token、temp token 访问其他端点 403、temp 改密错旧密 401、新密码=默认密码 400、缺旧密码 400、temp 改密成功不返回正式 token + 默认密码失效 + 新密码登录获正式 token、正式 token 改密回归（错旧密 401 / 改回默认 400 / 成功返回新 token）。
- 更新 `mvc/compat/controller_test.go`：原 `TestChangePasswordFlow` 断言的是旧漏洞行为（不传旧密码、改密直接返回正式 token），已改为新语义（改密后重新登录拿正式 token 再访问受保护端点）。
- `go build ./... && go vet ./... && go test ./...` 全量通过（32 个包）。

## 残余风险说明

默认凭据期"先到先得"的竞速接管（攻击者抢在管理员改密前完成首登改密）无法由后端逻辑根除——新设备必须存在初始凭据。建议后续在产品流程层跟进（如设备唯一初始密码/序列号绑定、装机脚本强制初始化改密），本 PR 已把窗口收益降至"仅能抢跑一次"并让默认凭据永久失效。

Co-Authored-By: Claude <noreply@anthropic.com>