### PR TITLE
[MYS-386] fix(bmssm/psophliteos): llm-proxy/config 改 admin-only，封堵 forwardKey 泄露

### DIFF
--- a/source/pbmssm/mvc/llmproxy/controller.go
+++ b/source/pbmssm/mvc/llmproxy/controller.go
@@ -21,7 +21,8 @@ func DefaultController() *Controller {
 }
 
 // GetConfig GET /api/v1/llm-proxy/config
-// 返回已存配置（LLM/VLM 各 key 脱敏；ForwardKey 明文）。
+// 返回已存配置（LLM/VLM 各 key 脱敏；ForwardKey 明文——仅 superuser/admin
+// 可访问，路由注册于 admin 组，MYS-386：forwardKey 是 /agent/ws 唯一凭据）。
 func (ctrl *Controller) GetConfig(c *gin.Context) {
 	cfg := ctrl.svc.LoadConfig()
 	written := ctrl.svc.ForwardKeyWritten()

--- a/source/pbmssm/mvc/llmproxy/test_test.go
+++ b/source/pbmssm/mvc/llmproxy/test_test.go
@@ -40,6 +40,59 @@ func setupTestController(t *testing.T) (*Controller, *httptest.Server) {
 	return &Controller{svc: svc}, upstream
 }
 
+// TestToResponseIncludesForwardKey 锁定响应契约（MYS-386）：
+// ConfigResponse JSON 含完整性 forwardKey（路由层限定仅 admin 可读），
+// 且 LLM/VLM 上游 key 不出现（仅 hasKey 布尔）。
+func TestToResponseIncludesForwardKey(t *testing.T) {
+	c := Config{ID: 1, LLMApiKey: "llm-secret", VLMApiKey: "vlm-secret", ForwardKey: "forward-secret"}
+	b, err := json.Marshal(c.ToResponse(true))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if m["forwardKey"] != "forward-secret" {
+		t.Errorf("forwardKey = %v, want plaintext 'forward-secret'", m["forwardKey"])
+	}
+	if m["llmApiKey"] != nil || m["vlmApiKey"] != nil {
+		t.Errorf("upstream keys leaked into response: %v", m)
+	}
+	if m["llmHasKey"] != true || m["vlmHasKey"] != true {
+		t.Errorf("hasKey flags = %v/%v, want true/true", m["llmHasKey"], m["vlmHasKey"])
+	}
+}
+
+// TestGetConfigReturnsForwardKey 验证 GET config 控制器返回完整性 forwardKey
+// （配合路由层 admin-only，构成「仅管理员可得 key」的完整链路）。
+func TestGetConfigReturnsForwardKey(t *testing.T) {
+	db := setupTestDB(t)
+	t.Cleanup(func() { db.Close() })
+	svc := NewService(db)
+	_ = svc.LoadConfig() // 生成并落库 forwardKey
+
+	ctrl := &Controller{svc: svc}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/llm-proxy/config", nil)
+	rec := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(rec)
+	ctx.Request = req
+	ctrl.GetConfig(ctx)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		Result ConfigResponse `json:"result"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Result.ForwardKey == "" {
+		t.Errorf("forwardKey empty in GetConfig response")
+	}
+}
+
 // TestRunTestAllOK 验证一键测试两个场景都通过。
 func TestRunTestAllOK(t *testing.T) {
 	ctrl, _ := setupTestController(t)

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -149,7 +149,8 @@ type SaveRequest struct {
 	VLMOverride *bool  `json:"vlmOverrideModel"`
 }
 
-// ConfigResponse 配置响应（各 key 脱敏为 hasKey 布尔；ForwardKey 明文返回供前端展示）。
+// ConfigResponse 配置响应（各 key 脱敏为 hasKey 布尔；ForwardKey 明文返回供
+// 前端展示/WS 连接——该响应仅经 admin 组路由输出，见 router.go MYS-386）。
 type ConfigResponse struct {
 	LLMApiBase      string    `json:"llmApiBase"`
 	LLMModel        string    `json:"llmModel"`

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -119,8 +119,8 @@ func Register(r *gin.Engine) {
 		// 端口状态
 		api.GET("/ports/listening", portsC.Listening)
 
-		// LLM 转发配置（读）
-		api.GET("/llm-proxy/config", llmproxyCtrl.GetConfig)
+		// LLM 转发配置（读）：admin-only（返回的 forwardKey 是 /agent/ws 的
+		// 唯一凭据，可驱动 root 权限 agent，泄给普通用户等同绕过账号体系）
 		// 模型列表（从供应商拉取，供前端弹窗选择）
 		api.GET("/llm-proxy/models", llmproxyCtrl.ListModels)
 		// Reasonix 服务状态（读）——AI agent 后端由 agentproxy 管理
@@ -176,6 +176,9 @@ func Register(r *gin.Engine) {
 		admin.DELETE("/docker/image/:id", dockerCtrl.RemoveImage)
 
 		// LLM 转发配置（写）
+		// 读（GetConfig）也在此组：响应含 forwardKey 明文（/agent/ws 唯一凭据，
+		// 驱动 root 权限 reasonix agent），仅 superuser/admin 可读（MYS-386）。
+		admin.GET("/llm-proxy/config", llmproxyCtrl.GetConfig)
 		admin.PUT("/llm-proxy/config", llmproxyCtrl.SaveConfig)
 		admin.POST("/llm-proxy/forward-key/reset", llmproxyCtrl.ResetForwardKey)
 		admin.POST("/llm-proxy/forward-key/write-picoclaw", llmproxyCtrl.WriteForwardKey)

--- a/source/pbmssm/router/router_test.go
+++ b/source/pbmssm/router/router_test.go
@@ -4,12 +4,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/sqlite"
 
 	"bmssm/config"
+	"bmssm/database"
 	"bmssm/global"
+	"bmssm/mvc/user"
+	"bmssm/pkg/auth"
 )
 
 func init() { gin.SetMode(gin.ReleaseMode) }
@@ -58,12 +64,28 @@ func TestHealthz(t *testing.T) {
 	}
 }
 
-// TestLlmProxyRoutes 验证 llm-proxy 配置路由已注册：
-// 无 token 时 GET/PUT 均返回 401（Auth 中间件），而非 404。
+// TestLlmProxyRoutes 验证 llm-proxy 配置路由的访问控制（MYS-386）：
+// - 无 token：401（Auth 中间件拦截，路由已注册而非 404）
+// - 普通用户（role=user）：403 —— P0 回归：forwardKey 是 /agent/ws 唯一凭据，
+//   不得泄露给非管理员
+// - 管理员（role=admin）：200，响应含完整性 forwardKey（供 WebChat WS 连接）
 func TestLlmProxyRoutes(t *testing.T) {
 	gin.SetMode(gin.ReleaseMode)
 	// Auth 中间件读取 config.Conf；测试需先初始化（用默认值即可）
 	config.LoadFromDir(t.TempDir())
+
+	// RequireAdmin 查 users 表（database.DB() 全局句柄）；注入 user/admin 两行
+	db := newRouterTestDB(t)
+	oldDB := database.DB()
+	database.SetDB(db)
+	t.Cleanup(func() { database.SetDB(oldDB) })
+	if err := db.Create(&user.User{Username: "alice", Password: "x", Role: "user"}).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	if err := db.Create(&user.User{Username: "root", Password: "x", Role: "admin"}).Error; err != nil {
+		t.Fatalf("create admin: %v", err)
+	}
+
 	r := gin.New()
 	Register(r)
 
@@ -82,4 +104,65 @@ func TestLlmProxyRoutes(t *testing.T) {
 	if w2.Code != http.StatusUnauthorized {
 		t.Fatalf("PUT config without token = %d, want 401", w2.Code)
 	}
+
+	// 普通用户 GET → 403
+	w3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/llm-proxy/config", nil)
+	req3.Header.Set("Authorization", "Bearer "+issueTestToken(t, "alice"))
+	r.ServeHTTP(w3, req3)
+	if w3.Code != http.StatusForbidden {
+		t.Fatalf("GET config with user token = %d, want 403, body=%s", w3.Code, w3.Body.String())
+	}
+
+	// 管理员 GET → 200 且返回完整性 forwardKey（WebChat WS 连接依赖）
+	w4 := httptest.NewRecorder()
+	req4 := httptest.NewRequest(http.MethodGet, "/api/v1/llm-proxy/config", nil)
+	req4.Header.Set("Authorization", "Bearer "+issueTestToken(t, "root"))
+	r.ServeHTTP(w4, req4)
+	if w4.Code != http.StatusOK {
+		t.Fatalf("GET config with admin token = %d, want 200, body=%s", w4.Code, w4.Body.String())
+	}
+	var out struct {
+		Code   int `json:"code"`
+		Result struct {
+			ForwardKey string `json:"forwardKey"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(w4.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal admin response: %v body=%s", err, w4.Body.String())
+	}
+	if out.Code != 0 {
+		t.Fatalf("admin GET code = %d, body=%s", out.Code, w4.Body.String())
+	}
+	if out.Result.ForwardKey == "" {
+		t.Errorf("admin GET returned empty forwardKey, body=%s", w4.Body.String())
+	}
+}
+
+// newRouterTestDB 建临时 sqlite：迁移 RequireAdmin 需要的 users 表及
+// 已注册业务模型（llmproxy Config 等，保证 GetConfig 可落库读配置）。
+func newRouterTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open("sqlite3", filepath.Join(t.TempDir(), "test.db"))
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := db.AutoMigrate(&user.User{}).Error; err != nil {
+		t.Fatalf("migrate users: %v", err)
+	}
+	if err := database.Migrate(db); err != nil {
+		t.Fatalf("migrate registered models: %v", err)
+	}
+	return db
+}
+
+// issueTestToken 用默认/持久化 secret 签发测试 JWT（与 Auth 中间件同 secret）。
+func issueTestToken(t *testing.T, username string) string {
+	t.Helper()
+	tok, _, err := auth.IssueToken(username, auth.EffectiveSecret(""), false)
+	if err != nil {
+		t.Fatalf("issue token for %s: %v", username, err)
+	}
+	return tok
 }

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -1242,6 +1242,15 @@
       const cfg = await getAgentConfig();
       forwardKey = cfg?.forwardKey || '';
     }
+    // MYS-386：llm-proxy/config 已改为 admin-only。非管理员（或配置读取
+    // 失败）拿不到 forwardKey，空 token 会持续 WS 握手失败重连，这里
+    // 明确提示并跳过连接，避免无限重连。
+    if (!forwardKey) {
+      statusText.value = '未连接';
+      statusClass.value = 'bad';
+      errorMsg.value = '无法连接智能体：配置读取失败（需管理员权限，或服务未就绪），请刷新页面重试';
+      return;
+    }
     if (ws) {
       ws.close();
       ws = null;


### PR DESCRIPTION
## 背景

MYS-377 代码审查发现（严重，P0）：`GET /api/v1/llm-proxy/config` 仅 Auth 保护，对任意登录用户明文返回 `forwardKey`。该 key 是 `/agent/ws` 的唯一凭据，普通用户拿到即可绕过账号体系直连 agent（以 root 执行工具）。

## 修复内容

**后端（pbmssm）**
- `router.go`：`GET /llm-proxy/config` 从 Auth 组移入 admin 组（`RequireAdmin`，与 `PUT`/reset/write-picoclaw 写入侧同级），仅 superuser/admin 可读
- 保留响应含完整 forwardKey 的契约（管理员前端 WebChat 的 WS 连接依赖此 key 作子协议 token）

**前端（psophliteos）**
- `WebChat.vue`：`connect()` 拿不到 forwardKey（403/非管理员/服务未就绪）时明确提示"配置读取失败（需管理员权限…）"并跳过连接，避免空 token 无限握手重连
- `apiConfig` 页面不消费明文 key，无需改动（其所有写操作本已是 admin-only）

**依赖关系说明（issue 需确认事项）**
- 唯一依赖明文 key 的调用方是 WebChat（`/agent/ws` 子协议 `token.<key>` 认证，浏览器 WS 无法带 Authorization 头）；picoclaw 同步在 bmssm 服务端直接写 `devproxy.key`，不依赖该接口
- 采用 admin-only 方案而非"普通用户脱敏"：前端 getUserInfo 为 mock（无真实角色感知），脱敏值同样无法支撑普通用户连接 WS，admin-only 更简洁且与文件/用户管理同级

## 测试

- `router_test.go` TestLlmProxyRoutes 扩展：无 token 401 / 普通用户 403（P0 回归）/ 管理员 200 且含完整 forwardKey
- `test_test.go` 新增响应契约用例：forwardKey 明文、上游 key 不泄露（仅 hasKey 布尔）
- `go build ./...`、`go vet ./...`、`go test ./...` 全部通过（32 个包）
- 前端 `vue-tsc --noEmit` src 零错误；`vite build` 成功，降级逻辑已确认进入产物