### PR TITLE
fix(bmssm): 用户删除权限收敛 + sqlite 文件目录权限收紧 (MYS-388)

### DIFF
--- a/source/pbmssm/build/deb/postinst
+++ b/source/pbmssm/build/deb/postinst
@@ -7,6 +7,9 @@ set -e
 
 # 运行目录（DB / 日志 / JWT secret 持久化）
 mkdir -p /var/lib/bmssm /var/log/bmssm
+# MYS-388 权限收紧：DB 明文存 LLM key/会话等敏感数据，目录仅 root 可进（0700），
+# DB 文件由 bmssm 启动时显式 chmod 0600（database.InitDB）
+chmod 0700 /var/lib/bmssm
 
 # 确保 iptables + iptables-persistent 已装（firewall 规则持久化依赖）
 if ! command -v iptables >/dev/null 2>&1; then

--- a/source/pbmssm/database/db.go
+++ b/source/pbmssm/database/db.go
@@ -3,6 +3,9 @@
 package database
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/jinzhu/gorm"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	_ "github.com/mattn/go-sqlite3"
@@ -20,11 +23,32 @@ var globalDB *gorm.DB
 func RegisterModel(m ...interface{}) { models = append(models, m...) }
 
 // InitDB 打开/创建 sqlite 文件，设置全局句柄并返回 *gorm.DB。
+// 权限收紧（MYS-388）：DB 明文存 LLM API key/forwardKey/会话等敏感数据，
+// 目录显式 0700、文件显式 0600（不依赖 umask，创建与已有文件均强制），
+// 防止本机其他本地用户读取密钥。
 func InitDB(path string) (*gorm.DB, error) {
+	if dir := filepath.Dir(path); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			logger.Error("mkdir %s failed: %v", dir, err)
+			return nil, err
+		}
+		_ = os.Chmod(dir, 0o700)
+		// 文件不存在时预建为空文件（0600），避免 sqlite 按默认 umask 创建
+		// （如 0644）后再次 chmod 之间留出可读窗口
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			if f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600); err == nil {
+				_ = f.Close()
+			}
+		}
+	}
 	db, err := gorm.Open("sqlite3", path)
 	if err != nil {
 		logger.Error("open sqlite %s failed: %v", path, err)
 		return nil, err
+	}
+	// 已有文件也强制收紧（兼容旧安装遗留的宽松权限）
+	if err := os.Chmod(path, 0o600); err != nil {
+		logger.Warn("chmod %s 0600 failed: %v", path, err)
 	}
 	globalDB = db
 	return db, nil

--- a/source/pbmssm/database/db_test.go
+++ b/source/pbmssm/database/db_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -20,5 +21,76 @@ func TestInitDB(t *testing.T) {
 	// migration 框架可调用，无模型时不报错
 	if err := Migrate(db); err != nil {
 		t.Fatalf("Migrate: %v", err)
+	}
+}
+
+// TestInitDBFilePermissions 新建 DB 时目录应 0700、文件应 0600（sqlite 明文存密钥/会话数据）。
+func TestInitDBFilePermissions(t *testing.T) {
+	sub := filepath.Join(t.TempDir(), "nested")
+	dbPath := filepath.Join(sub, "bmssm.db")
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.DB().Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	fi, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat db file: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("expected db file 0600, got %o", fi.Mode().Perm())
+	}
+
+	di, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("stat db dir: %v", err)
+	}
+	if di.Mode().Perm() != 0o700 {
+		t.Fatalf("expected db dir 0700, got %o", di.Mode().Perm())
+	}
+}
+
+// TestInitDBHealsLoosePermissions 已存在但权限过松（0644）的 DB 文件，InitDB 应强制收紧为 0600。
+func TestInitDBHealsLoosePermissions(t *testing.T) {
+	sub := filepath.Join(t.TempDir(), "nested")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	dbPath := filepath.Join(sub, "bmssm.db")
+	if f, err := os.OpenFile(dbPath, os.O_CREATE|os.O_RDWR, 0o644); err != nil {
+		t.Fatalf("pre-create db: %v", err)
+	} else {
+		f.Close()
+	}
+
+	db, err := InitDB(dbPath)
+	if err != nil {
+		t.Fatalf("InitDB: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.DB().Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	fi, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat db file: %v", err)
+	}
+	if fi.Mode().Perm() != 0o600 {
+		t.Fatalf("expected db file healed to 0600, got %o", fi.Mode().Perm())
+	}
+
+	di, err := os.Stat(sub)
+	if err != nil {
+		t.Fatalf("stat db dir: %v", err)
+	}
+	if di.Mode().Perm() != 0o700 {
+		t.Fatalf("expected db dir healed to 0700, got %o", di.Mode().Perm())
 	}
 }

--- a/source/pbmssm/mvc/user/controller.go
+++ b/source/pbmssm/mvc/user/controller.go
@@ -126,6 +126,20 @@ func (ctrl *Controller) isAdmin(c *gin.Context) bool {
 	return u.Role == "superuser" || u.Role == "admin"
 }
 
+// isSuperuser 判断当前请求用户是否为 superuser（用户管理的最高权限角色）。
+func (ctrl *Controller) isSuperuser(c *gin.Context) bool {
+	actor, _ := c.Get("user")
+	actorStr, _ := actor.(string)
+	if actorStr == "" {
+		return false
+	}
+	u, err := ctrl.svc.FindUser(actorStr)
+	if err != nil {
+		return false
+	}
+	return u.Role == "superuser"
+}
+
 // CreateUser 处理 POST /api/v1/user（受保护，仅 superuser/admin）。
 func (ctrl *Controller) CreateUser(c *gin.Context) {
 	if !ctrl.isAdmin(c) {
@@ -142,10 +156,7 @@ func (ctrl *Controller) CreateUser(c *gin.Context) {
 	}
 	// 仅 superuser 可创建管理员级账号；admin 只能创建普通 user。
 	if req.Role == "superuser" || req.Role == "admin" {
-		actor, _ := c.Get("user")
-		actorStr, _ := actor.(string)
-		u, err := ctrl.svc.FindUser(actorStr)
-		if err != nil || u.Role != "superuser" {
+		if !ctrl.isSuperuser(c) {
 			c.JSON(http.StatusForbidden, response.Fail("superuser role required to create admin"))
 			return
 		}
@@ -174,7 +185,12 @@ func (ctrl *Controller) DeleteUser(c *gin.Context) {
 	}
 	actor, _ := c.Get("user")
 	actorStr, _ := actor.(string)
-	if err := ctrl.svc.DeleteUser(name); err != nil {
+	// 操作者角色传入 service：superuser 账号仅 superuser 可删（MYS-388）
+	actorRole := "admin"
+	if ctrl.isSuperuser(c) {
+		actorRole = "superuser"
+	}
+	if err := ctrl.svc.DeleteUser(actorRole, name); err != nil {
 		ctrl.auditWrite(c, actorStr, "delete_user:"+name, "user", "failed")
 		c.JSON(http.StatusForbidden, response.Fail(err.Error()))
 		return

--- a/source/pbmssm/mvc/user/controller_test.go
+++ b/source/pbmssm/mvc/user/controller_test.go
@@ -306,3 +306,91 @@ func TestControllerDeleteUser(t *testing.T) {
 		t.Fatal("victim should not be able to login after deletion")
 	}
 }
+
+// TestControllerDeleteAdminUserForbidden 即使 superuser 也不能删除默认 admin 账号（HTTP 403）。
+func TestControllerDeleteAdminUserForbidden(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.DELETE("/user/:name", ctrl.DeleteUser)
+
+	secret := auth.EffectiveSecret(config.Conf.GetViper().GetString("server.authSecret"))
+	tokenStr, _, _ := auth.IssueToken("admin", secret, false)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/admin", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestControllerAdminCannotDeleteSuperuser admin 角色调用 DELETE /user/:name 删 superuser 应 403。
+func TestControllerAdminCannotDeleteSuperuser(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+
+	_ = ctrl.svc.CreateUser("boss", "pass1", "admin")
+	_ = ctrl.svc.CreateUser("sroot", "srootpwd", "superuser")
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.DELETE("/user/:name", ctrl.DeleteUser)
+
+	// 用 admin 角色账号（非 superuser）发起删除
+	secret := auth.EffectiveSecret(config.Conf.GetViper().GetString("server.authSecret"))
+	tokenStr, _, _ := auth.IssueToken("boss", secret, false)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/sroot", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	// 目标 superuser 账号必须仍在
+	if _, err := ctrl.svc.Login("sroot", "srootpwd"); err != nil {
+		t.Fatalf("superuser account should still exist: %v", err)
+	}
+}
+
+// TestControllerSuperuserCanDeleteSuperuser superuser 角色删 superuser 账号应 200。
+func TestControllerSuperuserCanDeleteSuperuser(t *testing.T) {
+	ctrl, _, cleanup := setupController(t)
+	defer cleanup()
+
+	_ = ctrl.svc.CreateUser("admin", "admin", "superuser")
+	_ = ctrl.svc.CreateUser("sroot", "srootpwd", "superuser")
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.DELETE("/user/:name", ctrl.DeleteUser)
+
+	secret := auth.EffectiveSecret(config.Conf.GetViper().GetString("server.authSecret"))
+	tokenStr, _, _ := auth.IssueToken("admin", secret, false)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/user/sroot", nil)
+	req.Header.Set("Authorization", "Bearer "+tokenStr)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+
+	_, err := ctrl.svc.Login("sroot", "srootpwd")
+	if err == nil {
+		t.Fatal("deleted superuser should not be able to login")
+	}
+}

--- a/source/pbmssm/mvc/user/service.go
+++ b/source/pbmssm/mvc/user/service.go
@@ -61,10 +61,23 @@ func (s *UserService) CreateUser(username, password, role string) error {
 	return s.db.Create(&user).Error
 }
 
-// DeleteUser 按 username 删除用户（禁止删除 admin）。
-func (s *UserService) DeleteUser(username string) error {
+// DeleteUser 按 username 删除用户，actorRole 是操作者的角色（"superuser"/"admin"）。
+// 规则：默认 admin 账号禁止删除；superuser 账号仅 superuser 可删；admin 可删普通 user。
+func (s *UserService) DeleteUser(actorRole, username string) error {
 	if username == "admin" {
 		return errors.New("cannot delete default admin user")
+	}
+	// 目标账号不存在时明确报错，避免低权限者借删除接口探知用户名
+	var target User
+	if err := s.db.Where("username = ?", username).First(&target).Error; err != nil {
+		if gorm.IsRecordNotFoundError(err) {
+			return errors.New("user not found")
+		}
+		return err
+	}
+	// 权限收敛（MYS-388）：superuser 账号仅 superuser 可删，防 admin 移除最高权限账号
+	if target.Role == "superuser" && actorRole != "superuser" {
+		return errors.New("superuser role required to delete superuser")
 	}
 	return s.db.Where("username = ?", username).Delete(&User{}).Error
 }

--- a/source/pbmssm/mvc/user/service_test.go
+++ b/source/pbmssm/mvc/user/service_test.go
@@ -104,7 +104,7 @@ func TestServiceDeleteUser(t *testing.T) {
 
 	_ = svc.CreateUser("tempuser", "temppwd", "user")
 
-	err := svc.DeleteUser("tempuser")
+	err := svc.DeleteUser("admin", "tempuser")
 	if err != nil {
 		t.Fatalf("DeleteUser: %v", err)
 	}
@@ -122,9 +122,56 @@ func TestDeleteAdminNotAllowed(t *testing.T) {
 
 	_ = svc.CreateUser("admin", "admin", "superuser")
 
-	err := svc.DeleteUser("admin")
+	err := svc.DeleteUser("superuser", "admin")
 	if err == nil {
 		t.Fatal("should not allow deleting admin")
+	}
+}
+
+// TestAdminCannotDeleteSuperuser admin 角色（无法创建管理员账号）不允许删除 superuser 账号。
+func TestAdminCannotDeleteSuperuser(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	_ = svc.CreateUser("sroot", "srootpwd", "superuser")
+
+	err := svc.DeleteUser("admin", "sroot")
+	if err == nil {
+		t.Fatal("admin actor should not be able to delete superuser")
+	}
+
+	// 目标账号必须仍在
+	if _, err := svc.Login("sroot", "srootpwd"); err != nil {
+		t.Fatalf("superuser account should still exist: %v", err)
+	}
+}
+
+// TestSuperuserCanDeleteSuperuser superuser 角色可以删除其他 superuser 账号。
+func TestSuperuserCanDeleteSuperuser(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	_ = svc.CreateUser("sroot", "srootpwd", "superuser")
+
+	err := svc.DeleteUser("superuser", "sroot")
+	if err != nil {
+		t.Fatalf("superuser actor should be able to delete superuser: %v", err)
+	}
+
+	_, err = svc.Login("sroot", "srootpwd")
+	if err == nil {
+		t.Fatal("deleted superuser should not be able to login")
+	}
+}
+
+// TestDeleteNonexistentUser 删除不存在的用户应报错（而非静默成功）。
+func TestDeleteNonexistentUser(t *testing.T) {
+	db := setupTestDB(t)
+	svc := NewService(db)
+
+	err := svc.DeleteUser("superuser", "ghost")
+	if err == nil {
+		t.Fatal("should fail when deleting nonexistent user")
 	}
 }
 


### PR DESCRIPTION
## 背景
MYS-377 代码审查发现（P1），MYS-388。

## 修复内容

### 1. 用户删除权限收敛（superuser 仅 superuser 可删）
- `mvc/user/service.go`：`DeleteUser` 增加 `actorRole` 参数。规则：默认 admin 账号禁止删除（保留）；目标为 superuser 账号时，仅 superuser 角色操作者可删；admin 删普通 user 保留；目标不存在时明确报错
- `mvc/user/controller.go`：提取 `isSuperuser()` 判断（CreateUser 的内联检查同步重构复用）；DeleteUser 将操作者角色传入 service
- 封堵路径：admin 角色（无权限创建管理员账号）此前可删除 superuser 账号，形成锁死/持久化攻击面

### 2. sqlite 文件/目录权限收紧
- `database/db.go` `InitDB`：目录 `MkdirAll` 0700 + 显式 chmod 0700；DB 文件以 0600 预建（避免 umask 窗口）+ 打开后强制 chmod 0600（兼容旧安装遗留 0644）
- `build/deb/postinst`：`/var/lib/bmssm` 显式 `chmod 0700`
- 封堵路径：sqlite 明文存 LLM API key/forwardKey/会话内容，原 0644/0755 时本机任意本地用户可读

## 测试
TDD（先红后绿）：
- service：admin 删 superuser 拒绝且目标仍在 / superuser 删 superuser 成功 / 删不存在用户报错 / 默认 admin 仍禁删
- controller：admin 删 superuser → HTTP 403 / superuser 删 superuser → 200 / superuser 删默认 admin → 403
- database：新建 DB 文件 0600、目录 0700；已存在 0644 文件被强制收紧为 0600

验证：`go build ./...`、`go vet ./...`、`go test ./...` 全部通过；实测新建 DB 文件 mode 600、目录 mode 700、重启复用保持 600。

## 改动文件
- source/pbmssm/mvc/user/service.go（+17）
- source/pbmssm/mvc/user/controller.go（+26/-7）
- source/pbmssm/mvc/user/service_test.go / controller_test.go（+139 测试）
- source/pbmssm/database/db.go（+24）、db_test.go（+72 测试）
- source/pbmssm/build/deb/postinst（+3）
