### PR TITLE
fix(se-rag-core): 索引持久化原子写入+完整标记，Open 缺 bm25.gob 显式报错杜绝 query panic (MYS-391)

### DIFF
--- a/source/se-rag-core/README.md
+++ b/source/se-rag-core/README.md
@@ -131,8 +131,11 @@ mkdir -p docs/se8
 ./bin/se-rag doctor -index-dir ./rag-se8
 ```
 
-索引直接落盘到各自 `-index-dir/`（`meta.json` + `vectors.gob` + `bm25.gob` + `chunks.gob`），
-各知识库互不影响，可并存。
+索引直接落盘到各自 `-index-dir/`（`meta.json` + `vectors.gob` + `bm25.gob` + `chunks.gob` +
+`.complete` 完成标记），各知识库互不影响，可并存。保存为原子写入：先写临时文件、移除旧
+完成标记、再 rename 替换、最后写回完成标记，构建中断只可能留下"无标记"状态而不会是半套
+/混合代索引；`.complete` 或 `bm25.gob` 缺失时 query 显式报错并提示重建。
+注意：本版本之前的旧索引目录（无 `.complete`）升级后需重新 `se-rag build` 一次。
 
 ## 测试
 

--- a/source/se-rag-core/cmd/se-rag/main_test.go
+++ b/source/se-rag-core/cmd/se-rag/main_test.go
@@ -57,7 +57,7 @@ func TestCLIBuildQueryDoctorHappyPath(t *testing.T) {
 	if err := runBuild(rc); err != nil {
 		t.Fatalf("build failed: %v", err)
 	}
-	for _, f := range []string{"meta.json", "vectors.gob", "bm25.gob", "chunks.gob"} {
+	for _, f := range []string{"meta.json", "vectors.gob", "bm25.gob", "chunks.gob", ".complete"} {
 		if _, err := os.Stat(filepath.Join(idx, f)); err != nil {
 			t.Errorf("expected %s at %s: %v", f, idx, err)
 		}

--- a/source/se-rag-core/internal/docstore/docstore.go
+++ b/source/se-rag-core/internal/docstore/docstore.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"encoding/gob"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -16,13 +19,24 @@ import (
 //
 //	meta.json      指纹元信息
 //	vectors.gob    vector.Index
-//	bm25.gob       bm25.Index
+//	bm25.gob       bm25.Index（SaveIndex 始终写入，无 BM25 时写入空索引）
 //	chunks.gob     []chunker.Chunk
+//	.complete      完整标记：原子保存的最后一笔，Open 以其存在作为"索引完整"判据
+//
+// 保存采用"全部先写临时文件 → 再 rename 替换 → 最后写完成标记"，构建中途被
+// kill/断电不会留下"meta 已落盘但缺 bm25.gob"的半套索引：标记缺失时 Open 显式
+// 报错并提示重建，杜绝读侧 panic。
 //
 // product 仅用作 Meta.Product 标签，不参与磁盘路径。
 type Store struct {
 	IndexDir string
 }
+
+// completeMark 索引完整标记文件名。
+const completeMark = ".complete"
+
+// ErrIncomplete 索引不完整（缺完成标记或缺失 bm25.gob），需要重新运行 se-rag build 重建。
+var ErrIncomplete = errors.New("index incomplete: needs rebuild")
 
 func (s *Store) productDir(product string) string {
 	_ = product // product 仅标签，不用于路径
@@ -51,29 +65,74 @@ func (s *Store) SaveIndex(product string, meta Meta, vecs [][]float32, chunkIDs 
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	if err := writeJSON(filepath.Join(dir, "meta.json"), meta); err != nil {
+
+	// 1) 全部先编码到内存：任何编码失败都不触碰磁盘，旧索引保持完整可用
+	mb, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
 		return err
 	}
-
 	gi := &vector.Index{Dim: meta.Dim}
 	for i, v := range vecs {
 		gi.Add(v, chunkIDs[i])
 	}
-	if err := os.WriteFile(filepath.Join(dir, "vectors.gob"), gi.Serialize(), 0o644); err != nil {
-		return err
+	vb := gi.Serialize()
+	if bm == nil {
+		bm = bm25.Build(nil, nil) // 无 BM25 时写入空索引，保证 bm25.gob 四件套总齐全
 	}
-
-	if bm != nil {
-		if err := os.WriteFile(filepath.Join(dir, "bm25.gob"), bm.Serialize(), 0o644); err != nil {
-			return err
-		}
-	}
-
+	bb := bm.Serialize()
 	cb, err := gobEncode(chunks)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(dir, "chunks.gob"), cb, 0o644)
+
+	// 2) 临时文件全部写成功之后再改动正式文件：任一步写失败即返回，磁盘上仍是完整旧索引
+	for _, f := range [...]struct {
+		name string
+		data []byte
+	}{
+		{"meta.json", mb},
+		{"vectors.gob", vb},
+		{"bm25.gob", bb},
+		{"chunks.gob", cb},
+	} {
+		if err := writeTmp(dir, f.name, f.data); err != nil {
+			return err
+		}
+	}
+
+	// 3) 先移除旧完成标记再 rename 替换：标记存在 ⟺ 四件套完整且属同一代。
+	//    旧标记若不先移除，rename 逐文件替换期间崩溃会留下"标记仍在 + 混合代文件"的
+	//    静默错误状态；移除后任何中断都只可能留下"无标记"状态，读侧走到 ErrIncomplete
+	//    而非读到混合代数据。代价是保存写入窗口内（毫秒级）读侧短暂不可用，离线构建可接受。
+	if err := os.Remove(filepath.Join(dir, completeMark)); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	for _, name := range []string{"meta.json", "vectors.gob", "bm25.gob", "chunks.gob"} {
+		if err := renameTmp(dir, name); err != nil {
+			return err
+		}
+	}
+
+	// 4) 完成标记最后落盘
+	return writeTmpRename(dir, completeMark, []byte("ok\n"))
+}
+
+// writeTmp 写同目录临时文件（不落正式名，供统一 rename 替换）。
+func writeTmp(dir, name string, data []byte) error {
+	return os.WriteFile(filepath.Join(dir, "."+name+".tmp"), data, 0o644)
+}
+
+// renameTmp 将临时文件原子替换为正式名（同一文件系统内 rename 原子）。
+func renameTmp(dir, name string) error {
+	return os.Rename(filepath.Join(dir, "."+name+".tmp"), filepath.Join(dir, name))
+}
+
+// writeTmpRename 原子落盘：写临时文件后 rename（完成标记等需要在最后一步原子出现时使用）。
+func writeTmpRename(dir, name string, data []byte) error {
+	if err := writeTmp(dir, name, data); err != nil {
+		return err
+	}
+	return renameTmp(dir, name)
 }
 
 type Loaded struct {
@@ -86,6 +145,16 @@ type Loaded struct {
 
 func (s *Store) Open(product string) (*Loaded, error) {
 	dir := s.productDir(product)
+	if _, err := os.Stat(filepath.Join(dir, completeMark)); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// 区分"从未构建"与"半套写入"：目录都不存在时提示先构建，而非误报索引损坏
+			if _, derr := os.Stat(dir); errors.Is(derr, fs.ErrNotExist) {
+				return nil, fmt.Errorf("no index at %s: run `se-rag build` first", dir)
+			}
+			return nil, fmt.Errorf("%w: completion mark %q missing at %s (half-written index)", ErrIncomplete, completeMark, dir)
+		}
+		return nil, err
+	}
 	l := &Loaded{ChunkByID: map[string]chunker.Chunk{}}
 
 	mb, err := os.ReadFile(filepath.Join(dir, "meta.json"))
@@ -105,11 +174,14 @@ func (s *Store) Open(product string) (*Loaded, error) {
 		return nil, err
 	}
 
-	if bdata, rerr := os.ReadFile(filepath.Join(dir, "bm25.gob")); rerr == nil {
-		l.BM25, err = bm25.Load(bdata)
-		if err != nil {
-			return nil, err
-		}
+	// bm25.gob 为必选文件：缺失说明索引不完整（构建中断/被外部删除），显式报错而非静默容忍
+	bdata, err := os.ReadFile(filepath.Join(dir, "bm25.gob"))
+	if err != nil {
+		return nil, fmt.Errorf("%w: bm25.gob missing at %s", ErrIncomplete, dir)
+	}
+	l.BM25, err = bm25.Load(bdata)
+	if err != nil {
+		return nil, err
 	}
 
 	cdata, err := os.ReadFile(filepath.Join(dir, "chunks.gob"))
@@ -166,8 +238,4 @@ func gobEncode(v any) ([]byte, error) {
 
 func gobDecode(data []byte, v any) error {
 	return gob.NewDecoder(bytes.NewReader(data)).Decode(v)
-}
-
-func writeFile(path string, data []byte) error {
-	return os.WriteFile(path, data, 0o644)
 }

--- a/source/se-rag-core/internal/docstore/docstore_test.go
+++ b/source/se-rag-core/internal/docstore/docstore_test.go
@@ -1,6 +1,8 @@
 package docstore
 
 import (
+	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -59,5 +61,126 @@ func TestOpenRoundTrip(t *testing.T) {
 	}
 	if _, ok := l.ChunkByID["c0"]; !ok {
 		t.Error("chunk index not restored")
+	}
+}
+
+// saveTestIndex 保存一套完整索引（meta/vectors/bm25/chunks + 完成标记）。
+func saveTestIndex(t *testing.T, s *Store) {
+	t.Helper()
+	chunks := []chunker.Chunk{{ChunkID: "c0", Text: "SE7 使用 BM1684X", SourceFile: "sdk.md", LineStart: 1, LineEnd: 1}}
+	meta := s.BuildMeta("se7", "siliconflow", "BAAI/bge-m3", 2, chunks)
+	bmi := bm25.Build([]string{"SE7 使用 BM1684X"}, []string{"c0"})
+	if err := s.SaveIndex("se7", meta, [][]float32{{1, 0}}, []string{"c0"}, bmi, chunks); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestOpenMissingBM25Errors 模拟构建中途被 kill 留下的"缺 bm25.gob 的合法索引"
+// （meta.json 已落盘但 bm25.gob 缺失）：Open 必须显式报 ErrIncomplete，而非静默返回 nil BM25。
+func TestOpenMissingBM25Errors(t *testing.T) {
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "index")}
+	saveTestIndex(t, s)
+	if err := os.Remove(filepath.Join(s.IndexDir, "bm25.gob")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Open("se7"); !errors.Is(err, ErrIncomplete) {
+		t.Fatalf("Open = %v, want ErrIncomplete (index missing bm25.gob)", err)
+	}
+}
+
+// TestOpenMissingCompleteMarkErrors 完成标记缺失（半套写入的另一个信号）同样必须报错。
+func TestOpenMissingCompleteMarkErrors(t *testing.T) {
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "index")}
+	saveTestIndex(t, s)
+	if err := os.Remove(filepath.Join(s.IndexDir, completeMark)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.Open("se7"); !errors.Is(err, ErrIncomplete) {
+		t.Fatalf("Open = %v, want ErrIncomplete (completion mark missing)", err)
+	}
+}
+
+// TestOpenNeverBuiltDirHintsRebuild 从未构建（目录不存在）报"先 build"提示，而非误报损坏。
+func TestOpenNeverBuiltDirHintsRebuild(t *testing.T) {
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "no-such-index")}
+	_, err := s.Open("se7")
+	if err == nil {
+		t.Fatal("Open on never-built dir should error")
+	}
+	if errors.Is(err, ErrIncomplete) {
+		t.Errorf("Open = %v, want 'run build first' hint, not ErrIncomplete", err)
+	}
+}
+
+// TestSaveIndexNilBM25Openable 保存时无 BM25 写入空 bm25 索引：Open 正常、四件套齐全、
+// BM25.Search 返回空结果（vector-only 索引语义，且消除 nil 解引用可能）。
+func TestSaveIndexNilBM25Openable(t *testing.T) {
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "index")}
+	chunks := []chunker.Chunk{{ChunkID: "c0", Text: "SE7 使用 BM1684X", SourceFile: "sdk.md", LineStart: 1, LineEnd: 1}}
+	meta := s.BuildMeta("se7", "siliconflow", "BAAI/bge-m3", 2, chunks)
+	if err := s.SaveIndex("se7", meta, [][]float32{{1, 0}}, []string{"c0"}, nil, chunks); err != nil {
+		t.Fatal(err)
+	}
+	l, err := s.Open("se7")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.BM25 == nil {
+		t.Fatal("BM25 should be non-nil (empty index)")
+	}
+	if got := l.BM25.Search("BM1684X", 1); len(got) != 0 {
+		t.Errorf("empty bm25 index should return no results, got %+v", got)
+	}
+	if _, err := os.Stat(filepath.Join(s.IndexDir, "bm25.gob")); err != nil {
+		t.Errorf("bm25.gob should exist after save: %v", err)
+	}
+}
+
+// TestSaveIndexWritesCompleteSet 完整保存后：四件套 + 完成标记齐全，且不残留临时文件。
+func TestSaveIndexWritesCompleteSet(t *testing.T) {
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "index")}
+	saveTestIndex(t, s)
+	for _, name := range []string{"meta.json", "vectors.gob", "bm25.gob", "chunks.gob", completeMark} {
+		if _, err := os.Stat(filepath.Join(s.IndexDir, name)); err != nil {
+			t.Errorf("missing %s after SaveIndex: %v", name, err)
+		}
+	}
+	entries, err := os.ReadDir(s.IndexDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name()[0] == '.' && e.Name() != completeMark {
+			t.Errorf("stale temp file left: %s", e.Name())
+		}
+	}
+}
+
+// TestSaveFailureKeepsOldIndexIntact 保存中途失败（目录只读）不得破坏已存在的完整索引。
+func TestSaveFailureKeepsOldIndexIntact(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 0500 does not block writes")
+	}
+	s := &Store{IndexDir: filepath.Join(t.TempDir(), "index")}
+	saveTestIndex(t, s)
+	if err := os.Chmod(s.IndexDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(s.IndexDir, 0o755) //nolint:errcheck
+	chunks := []chunker.Chunk{{ChunkID: "c0", Text: "SE7 使用 BM1684X", SourceFile: "sdk.md", LineStart: 1, LineEnd: 1}}
+	meta := s.BuildMeta("se7", "siliconflow", "BAAI/bge-m3", 2, chunks)
+	if err := s.SaveIndex("se7", meta, [][]float32{{1, 0}}, []string{"c0"}, nil, chunks); err == nil {
+		t.Fatal("SaveIndex into read-only dir should fail")
+	}
+	// 旧索引仍然完整可读，未被半套数据污染
+	l, err := s.Open("se7")
+	if err != nil {
+		t.Fatalf("old index lost after failed save: %v", err)
+	}
+	if l.BM25.Search("BM1684X", 1)[0].ChunkID != "c0" {
+		t.Error("old bm25 data not intact")
+	}
+	if _, err := os.Stat(filepath.Join(s.IndexDir, completeMark)); err != nil {
+		t.Errorf("completion mark removed by failed save: %v", err)
 	}
 }

--- a/source/se-rag-core/internal/docstore/meta.go
+++ b/source/se-rag-core/internal/docstore/meta.go
@@ -1,7 +1,6 @@
 package docstore
 
 import (
-	"encoding/json"
 	"strconv"
 )
 
@@ -24,12 +23,4 @@ func (m Meta) Fingerprint() string {
 // FpName 组合 provider 与 model 的规范名（供调用方写入 EmbeddedFingerprint）。
 func FpName(providerName, model string) string {
 	return providerName + "." + model
-}
-
-func writeJSON(path string, v any) error {
-	b, err := json.MarshalIndent(v, "", "  ")
-	if err != nil {
-		return err
-	}
-	return writeFile(path, b)
 }

--- a/source/se-rag-core/internal/retriever/retriever.go
+++ b/source/se-rag-core/internal/retriever/retriever.go
@@ -84,9 +84,9 @@ func (r *Retriever) Search(ctx context.Context, query string, product string, to
 
 func (r *Retriever) hybrid(ctx context.Context, loaded *docstore.Loaded, query string, q []float32, topM int) []Result {
 	vecRes := loaded.Vector.Search(q, vectorTopK)
-	bmRes := loaded.BM25.Search(query, bm25TopK)
-	if bmRes == nil {
-		bmRes = []bm25.Result{}
+	var bmRes []bm25.Result
+	if loaded.BM25 != nil { // 防御：BM25 缺失（不应发生，Open 已校验）时退化为纯向量融合
+		bmRes = loaded.BM25.Search(query, bm25TopK)
 	}
 	fused := fusion.RRF(toRankedVec(vecRes), toRankedBM25(bmRes), rrfK)
 
@@ -128,6 +128,10 @@ func (r *Retriever) hybrid(ctx context.Context, loaded *docstore.Loaded, query s
 
 func (r *Retriever) bm25Fallback(loaded *docstore.Loaded, query string, topM int, out *SearchOutcome, t0 time.Time) (*SearchOutcome, error) {
 	out.Mode = "bm25"
+	if loaded.BM25 == nil {
+		// 防御：BM25 缺失（不应发生，Open 已校验）时返回显式错误而非 panic
+		return nil, fmt.Errorf("%w: bm25 index unavailable", docstore.ErrIncomplete)
+	}
 	bmRes := loaded.BM25.Search(query, topM)
 	scoreFor := map[string]float64{}
 	order := make([]string, 0, len(bmRes))

--- a/source/se-rag-core/internal/retriever/retriever_test.go
+++ b/source/se-rag-core/internal/retriever/retriever_test.go
@@ -2,12 +2,15 @@ package retriever
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"se-rag-core/internal/bm25"
 	"se-rag-core/internal/chunker"
 	"se-rag-core/internal/docstore"
+	"se-rag-core/internal/vector"
 )
 
 type fakeEmbed struct {
@@ -107,5 +110,53 @@ func TestCheckFingerprintDimension(t *testing.T) {
 	}
 	if err := CheckFingerprint(3, 1024); err == nil {
 		t.Error("dim mismatch should error")
+	}
+}
+
+// TestSearchIncompleteIndexNoPanic 模拟缺 bm25.gob 的半套索引目录：
+// Open 显式报错（ErrIncomplete），query 返回错误而绝不 panic（回归 MYS-391 的 nil 解引用崩溃）。
+func TestSearchIncompleteIndexNoPanic(t *testing.T) {
+	s := buildTestStore(t)
+	if err := os.Remove(filepath.Join(s.IndexDir, "bm25.gob")); err != nil {
+		t.Fatal(err)
+	}
+	r := &Retriever{Store: s, Embedder: &fakeEmbed{vec: []float32{1, 0}}, Reranker: &fakeRerank{}}
+	if _, err := r.Search(context.Background(), "BM1684X 芯片", "se7", 8); err == nil {
+		t.Fatal("Search on incomplete index should error, got nil")
+	}
+}
+
+// TestHybridNilBM25VectorOnly 防御：loaded.BM25 为 nil 时 hybrid 退化为纯向量融合，不 panic。
+func TestHybridNilBM25VectorOnly(t *testing.T) {
+	v := &vector.Index{Dim: 2}
+	v.Add([]float32{1, 0}, "a")
+	v.Add([]float32{0, 1}, "b")
+	loaded := &docstore.Loaded{
+		Vector: v,
+		ChunkByID: map[string]chunker.Chunk{
+			"a": {ChunkID: "a", Text: "SE7 芯片", SourceFile: "sdk.md", LineStart: 1, LineEnd: 1},
+			"b": {ChunkID: "b", Text: "OTA 升级", SourceFile: "faq.md", LineStart: 3, LineEnd: 3},
+		},
+	}
+	r := &Retriever{}
+	res := r.hybrid(context.Background(), loaded, "SE7", []float32{1, 0}, 8)
+	if len(res) == 0 {
+		t.Fatal("expected vector-only results, got none")
+	}
+	if res[0].ChunkID != "a" {
+		t.Errorf("res[0] = %q, want pure vector hit %q", res[0].ChunkID, "a")
+	}
+}
+
+// TestBm25FallbackNilBM25Error 防御：loaded.BM25 为 nil 时兜底路径返回显式错误，不 panic。
+func TestBm25FallbackNilBM25Error(t *testing.T) {
+	loaded := &docstore.Loaded{ChunkByID: map[string]chunker.Chunk{}}
+	r := &Retriever{}
+	out, err := r.bm25Fallback(loaded, "SE7", 8, &SearchOutcome{}, time.Now())
+	if err == nil {
+		t.Fatal("bm25Fallback with nil BM25 should error, got nil")
+	}
+	if out != nil {
+		t.Errorf("out = %+v, want nil on error", out)
 	}
 }


### PR DESCRIPTION
## 背景

MYS-377 代码审查（P1）：`SaveIndex` 非原子写入 —— meta→vectors→bm25→chunks 逐文件落盘，构建中途被 kill/断电留下"meta 已落盘但缺 bm25.gob"的半套索引；`Open` 静默容忍缺失（`if rerr == nil`），`loaded.BM25` 可为 nil，query 时 `loaded.BM25.Search(...)` nil 解引用 panic（hybrid 与 BM25 兜底路径均崩）。

## 修复内容

**docstore（原子持久化 + 完整性判据）**
- `SaveIndex`：全部编码到内存 → 四件套先写 `.name.tmp`（任一写失败即返回，旧索引不受影响）→ **移除旧完成标记** → 逐文件 rename 原子替换 → 最后写回 `.complete` 标记。构建中断只可能留下"无标记"状态（`ErrIncomplete`），杜绝"标记在 + 混合代文件"的静默错误；保存写入窗口内（毫秒级）读侧暂不可用，离线构建可接受
- `bm == nil` 时写入空 bm25 索引，`bm25.gob` 恒存在
- `Open`：完成标记缺失或 `bm25.gob` 缺失 → 显式返回 `ErrIncomplete`（含重建提示）；目录不存在 → 提示先执行 `se-rag build`

**retriever（防御，杜绝 panic）**
- `hybrid`：`loaded.BM25 == nil` 时退化为纯向量融合
- `bm25Fallback`：`loaded.BM25 == nil` 时返回显式错误

**测试（TDD，先 RED 后 GREEN）**：`TestSearchIncompleteIndexNoPanic` 在修复前复现真实 nil 指针 panic（`bm25.(*Index).Search(0x0)`）；另含 Open 缺 bm25.gob / 缺 `.complete` 报错、保存失败不破坏旧索引（chmod 0500，root 下自跳过）、nil-BM25 保存可打开、无临时文件残留等 9 项新测试，全量 `go test ./...` + `go vet` 通过。

**兼容性注意**：本改动前的旧索引目录（无 `.complete`）升级后 Open 会报 `ErrIncomplete`，需重新执行一次 `se-rag build`（README 已注明）。se-rag 为离线构建工具，重建成本低。

## 验证

- 本地：`go build` / `go vet` / `go test -count=1 ./...` 全绿
- 端到端（x86 + aarch64 测试机 172.26.166.185）：`build` 正常落盘 `.complete`；重保存覆盖正常；删除 `bm25.gob` 后 query 输出 `index incomplete: needs rebuild: bm25.gob missing`、退出码 1、无 panic