### PR TITLE
feat(se-rag-core): 内置网关故障转移链 CF Worker → 阿里云 FC 网关 → 纯 BM25 (MYS-405)

### DIFF
--- a/source/se-rag-core/README.md
+++ b/source/se-rag-core/README.md
@@ -12,6 +12,7 @@ SE 系列知识库的 **Go RAG 检索核心**，替代现行 Python 栈（numpy 
 - **多知识库兼容**：不同知识库用不同 `-index-dir` / `--docs-dir` 即可，复用同一检索核心仅换目录
 - **供应商可切换**：siliconflow / sophnet 两族 embedding 与 reranker，可配置不写死
 - **内置默认 key（混淆内嵌）**：预置 siliconflow 免费 key，源码中以 XOR 混淆字节内嵌（不落明文）；模型固定 `BAAI/bge-m3`（embedding）与 `BAAI/bge-reranker-v2-m3`（rerank）；使用内置 key 时强制限流（并发≤1、单次≤2段落）；用户自备 key 放开
+- **内置网关故障转移链**：内置 key 请求经自建网关转发 SiliconFlow——主网关 Cloudflare Worker（`*.workers.dev`）不可达（连接超时 / 5xx / DNS 失败）时自动切换阿里云函数计算（FC3.0）同协议网关（`*.fcapp.run`，国内直连）；两网关均不可达时降级纯 BM25（见下文「内置网关故障转移链」）
 - **供应商切换校验**：索引记录 embedding 指纹（`<provider>.<model>@<dim>`），切换供应商/模型后 `se-rag doctor` 检测并提示重建
 - **检索输出含来源信息**：每条结果标记源文件的相对路径与片段行号区间
 - **纯 Go，静态链接，零 C 依赖**：`CGO_ENABLED=0`，无 pip / aarch64 wheel 依赖
@@ -118,6 +119,25 @@ export SE_RAG_RERANK_KEY="sk-user-rerank-key"
 > **关于内置 key**：内置 siliconflow key 以 XOR 混淆字节内嵌于源码（不落明文），是免费额度、用于默认开箱即用的
 > throwaway key（限流，避免滥用）。生产/共享部署应通过 `SE_RAG_EMBED_KEY` / `SE_RAG_RERANK_KEY`
 > 环境变量注入自备 key（也即放开限流），切勿在公共镜像或日志中泄露内置 key。
+
+## 内置网关故障转移链
+
+内置 key 的上游链路为「网关 → SiliconFlow 源站」，网关承担鉴权与模型白名单（仅两模型）。为消除单点，
+内置网关部署了两份同协议镜像，请求按有序列表轮转、失败自动切换：
+
+| 优先级 | 网关 | 地址 | 说明 |
+|--------|------|------|------|
+| 1 | Cloudflare Worker（主） | `se-rag-gateway.zetao-zhang.workers.dev` | 默认路径；对 `*.workers.dev` DNS 污染走 IP 优先 + DoH 兜底拨号，作用范围仅限该域名 |
+| 2 | 阿里云函数计算 FC3.0（备） | `se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run` | 国内直连免备案；`fcapp.run` 走系统 DNS，不受 IP 优先逻辑影响 |
+| 3 | 纯 BM25（兜底） | — | 两网关均不可达时自动降级，离线可用（`mode=bm25`） |
+
+行为约定：
+
+- 同一 key / 同路径（`/v1/embeddings`、`/v1/rerank`）/ 同模型白名单，内置 key 零改动
+- 5xx / 429 / 连接错误（超时、DNS 失败）→ 有界重试（最多 6 次）并轮转至 FC 网关；4xx 快速失败不转移
+- 故障转移链可配置：`Provider.BaseURL`（主）+ `Provider.FallbackBaseURL`（备，默认 FC 网关）；
+  两者相同即显式禁用故障转移；`se-rag` CLI 默认即启用
+- 用户自备 key 不经网关，直达官方 SiliconFlow，无故障转移项
 
 ## 多知识库扩展
 

--- a/source/se-rag-core/internal/config/config.go
+++ b/source/se-rag-core/internal/config/config.go
@@ -22,6 +22,11 @@ func BuiltinKey() string {
 // GatewayBaseURL 是内置默认网关（se-rag-gateway Worker）地址，白名单仅 BAAI/bge-m3、BAAI/bge-reranker-v2-m3。
 const GatewayBaseURL = "https://se-rag-gateway.zetao-zhang.workers.dev/v1"
 
+// GatewayFCBaseURL 是内置网关故障转移第二跳：阿里云函数计算（FC3.0）上部署的同协议网关镜像，
+// 国内直连（*.workers.dev 在该网络下不可达时使用）。与 CF 网关完全同协议：同 key / 同路径 /
+// 同模型白名单，内置 key 零改动即可切换。
+const GatewayFCBaseURL = "https://se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run/v1"
+
 // 官方 SiliconFlow 地址：用户自备 key 时回落直达，不再经网关中转。
 const officialSiliconflowBaseURL = "https://api.siliconflow.cn/v1"
 
@@ -32,7 +37,11 @@ type Provider struct {
 	APIKey  string // 用户自备 key；空则用内置
 	Model   string
 	BaseURL string
-	Dim     int // embedding 维度（reranker 不适用，置 0）
+	// FallbackBaseURL 内置 key 时故障转移的第二网关（默认 GatewayFCBaseURL）：
+	// BaseURL（默认 CF Worker）不可达时自动切换；不适用于用户自备 key（直达官方 SiliconFlow）。
+	// 置空自动取 GatewayFCBaseURL；想禁用故障转移时显式置为与 BaseURL 相同的值。
+	FallbackBaseURL string
+	Dim             int // embedding 维度（reranker 不适用，置 0）
 }
 
 // Product 一个产品的文档库与索引配置（se7 / se8 / se9...）。
@@ -84,4 +93,25 @@ func (p Provider) EffectiveBaseURL() string {
 		return officialSiliconflowBaseURL
 	}
 	return p.BaseURL
+}
+
+// EffectiveBaseURLs 依 key 归属决定上游地址有序列表（网关故障转移链）：
+// 内置 key → [BaseURL（默认 CF Worker），FallbackBaseURL（默认阿里云 FC 网关）]，CF 不可达
+// 时自动切换 FC；相同地址去重。用户自备 key → 官方 SiliconFlow 直达，不经网关、无故障转移项。
+func (p Provider) EffectiveBaseURLs() []string {
+	if p.APIKey != "" {
+		return []string{officialSiliconflowBaseURL}
+	}
+	primary := p.BaseURL
+	if primary == "" {
+		primary = GatewayBaseURL
+	}
+	fallback := p.FallbackBaseURL
+	if fallback == "" {
+		fallback = GatewayFCBaseURL
+	}
+	if fallback == primary {
+		return []string{primary}
+	}
+	return []string{primary, fallback}
 }

--- a/source/se-rag-core/internal/config/config_test.go
+++ b/source/se-rag-core/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -68,6 +69,52 @@ func TestUserKeyOverrides(t *testing.T) {
 func TestGatewayBaseURLShape(t *testing.T) {
 	if !strings.Contains(GatewayBaseURL, "workers.dev") {
 		t.Errorf("GatewayBaseURL %q should be the gateway worker host", GatewayBaseURL)
+	}
+}
+
+func TestGatewayFCBaseURLShape(t *testing.T) {
+	if !strings.Contains(GatewayFCBaseURL, "fcapp.run") {
+		t.Errorf("GatewayFCBaseURL %q should be the Alibaba FC gateway host", GatewayFCBaseURL)
+	}
+	if GatewayFCBaseURL == GatewayBaseURL {
+		t.Errorf("FC fallback must differ from CF gateway, got %q", GatewayFCBaseURL)
+	}
+}
+
+// 故障转移链：内置 key → [CF 网关, FC 网关]；自备 key → 官方 SiliconFlow 直达（无故障转移项）。
+func TestEffectiveBaseURLs(t *testing.T) {
+	d := DefaultConfig()
+	p := d.Products[0].Embedder
+	want := []string{GatewayBaseURL, GatewayFCBaseURL}
+	if got := p.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint(want) {
+		t.Errorf("builtin effective base urls = %v, want %v", got, want)
+	}
+
+	// 自备 key → 仅官方地址，不经网关
+	u := p
+	u.APIKey = "user-key"
+	if got := u.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint([]string{officialSiliconflowBaseURL}) {
+		t.Errorf("user-key effective base urls = %v, want [official]", got)
+	}
+}
+
+// 显式指定主/备地址与去重：主地址为空回落默认 CF；备与主相同则去重为单地址。
+func TestEffectiveBaseURLsExplicitAndDedup(t *testing.T) {
+	d := DefaultConfig()
+	p := d.Products[0].Embedder
+
+	custom := p
+	custom.BaseURL = "https://gw.example.com/v1"
+	custom.FallbackBaseURL = "https://fb.example.com/v1"
+	if got := custom.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint([]string{"https://gw.example.com/v1", "https://fb.example.com/v1"}) {
+		t.Errorf("custom base urls = %v", got)
+	}
+
+	// 备与主相同 → 去重（显式禁用故障转移）
+	dup := p
+	dup.FallbackBaseURL = GatewayBaseURL
+	if got := dup.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint([]string{GatewayBaseURL}) {
+		t.Errorf("dedup base urls = %v", got)
 	}
 }
 

--- a/source/se-rag-core/internal/embed/embed_test.go
+++ b/source/se-rag-core/internal/embed/embed_test.go
@@ -55,7 +55,7 @@ func TestSiliconflowEmbedderBatchLeq2(t *testing.T) {
 	defer srv.Close()
 
 	// 用内置 key 模式构造（useBuiltinKey=true → 启用限流）
-	e, err := newSiliconflowEmbedder(srv.URL, "key", "BAAI/bge-m3", 2, true)
+	e, err := newSiliconflowEmbedder([]string{srv.URL}, "key", "BAAI/bge-m3", 2, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +85,7 @@ func TestPostJSONRetries(t *testing.T) {
 	}))
 	defer srv.Close()
 	var out map[string]any
-	if err := postJSON(context.Background(), srv.URL, "k", map[string]any{}, &out); err != nil {
+	if err := postJSON(context.Background(), []string{srv.URL}, "k", map[string]any{}, &out); err != nil {
 		t.Fatalf("expected retry success, got %v", err)
 	}
 }
@@ -99,7 +99,7 @@ func TestPostJSONNoRetryOn4xx(t *testing.T) {
 	}))
 	defer srv.Close()
 	var out map[string]any
-	err := postJSON(context.Background(), srv.URL, "k", map[string]any{}, &out)
+	err := postJSON(context.Background(), []string{srv.URL}, "k", map[string]any{}, &out)
 	if err == nil {
 		t.Fatal("expected auth error")
 	}
@@ -133,7 +133,7 @@ func TestSiliconflowReranker(t *testing.T) {
 		w.Write([]byte(`{"results":[{"index":1,"relevance_score":0.9},{"index":0,"relevance_score":0.5}]}`))
 	}))
 	defer srv.Close()
-	r := &siliconflowReranker{baseURL: srv.URL, apiKey: "k", model: "BAAI/bge-reranker-v2-m3"}
+	r := &siliconflowReranker{baseURLs: []string{srv.URL}, apiKey: "k", model: "BAAI/bge-reranker-v2-m3"}
 	got, err := r.Rerank(context.Background(), "q", []string{"a", "b"}, 2)
 	if err != nil {
 		t.Fatal(err)

--- a/source/se-rag-core/internal/embed/failover_test.go
+++ b/source/se-rag-core/internal/embed/failover_test.go
@@ -1,0 +1,160 @@
+package embed
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// 以下测试覆盖网关故障转移链（CF Worker → 阿里云 FC 网关）：
+// postJSON / siliconflow embedder 在首网关 5xx/连接失败时轮转到第二网关，两者都失败时有界退出。
+
+func always500(url string, hits *atomic.Int64, fail int64) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		if fail < 0 || hits.Load() <= fail {
+			w.WriteHeader(500)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[]}`))
+	}))
+}
+
+// 主网关 5xx 不可达 → 下一尝试轮转到 FC 网关并成功；两地址都被请求过。
+func TestPostJSONFailoverToSecondURL(t *testing.T) {
+	var cfHits, fcHits atomic.Int64
+	cf := always500("cf", &cfHits, -1)
+	defer cf.Close()
+	fc := always500("fc", &fcHits, 0) // 首次即成功
+	defer fc.Close()
+
+	var out map[string]any
+	if err := postJSON(context.Background(), []string{cf.URL, fc.URL}, "k", map[string]any{}, &out); err != nil {
+		t.Fatalf("expected failover success, got %v", err)
+	}
+	if cfHits.Load() == 0 {
+		t.Error("primary gateway was never attempted")
+	}
+	if fcHits.Load() == 0 {
+		t.Error("fallback gateway was never attempted")
+	}
+}
+
+// 连接层失败（非 HTTP 响应）同样触发轮转：首地址连接拒绝 → FC 成功。
+func TestPostJSONFailoverOnConnRefused(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1,0]}]}`))
+	}))
+	defer srv.Close()
+	// 127.0.0.1:1 连接立即被拒（无服务监听）
+	var out map[string]any
+	if err := postJSON(context.Background(), []string{"http://127.0.0.1:1/v1/embeddings", srv.URL + "/embeddings"}, "k", map[string]any{"model": "m", "input": []string{"hi"}}, &out); err != nil {
+		t.Fatalf("expected failover on conn refused, got %v", err)
+	}
+}
+
+// 两地址都 5xx → 有界失败（总尝试数 = maxAttempts，不无限挂起），报错指明多网关不可达。
+func TestPostJSONAllGatewaysFailBounded(t *testing.T) {
+	var hits atomic.Int64
+	s1 := always500("s1", &hits, -1)
+	defer s1.Close()
+	var hits2 atomic.Int64
+	s2 := always500("s2", &hits2, -1)
+	defer s2.Close()
+
+	var out map[string]any
+	err := postJSON(context.Background(), []string{s1.URL, s2.URL}, "k", map[string]any{}, &out)
+	if err == nil {
+		t.Fatal("expected error when all gateways fail")
+	}
+	total := hits.Load() + hits2.Load()
+	if total != maxAttempts {
+		t.Errorf("total attempts = %d, want bounded %d", total, maxAttempts)
+	}
+	if !strings.Contains(err.Error(), "gateway") {
+		t.Errorf("error should mention gateways, got %q", err)
+	}
+}
+
+// siliconflow embedder 全链故障转移：CF 5xx → FC 正常返回 embedding。
+func TestSiliconflowEmbedderFailover(t *testing.T) {
+	var cfHits atomic.Int64
+	cf := always500("cf", &cfHits, -1)
+	defer cf.Close()
+	fc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1,0]}]}`))
+	}))
+	defer fc.Close()
+
+	e, err := newSiliconflowEmbedder([]string{cf.URL, fc.URL}, "k", "BAAI/bge-m3", 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	vecs, err := e.Embed(context.Background(), []string{"SE7 芯片"})
+	if err != nil {
+		t.Fatalf("embedder failover failed: %v", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) != 2 {
+		t.Fatalf("vecs = %v want 1x2", vecs)
+	}
+	if cfHits.Load() == 0 {
+		t.Error("CF gateway was never attempted before failover")
+	}
+}
+
+// reranker 同样带故障转移：CF 5xx → FC 返回精排结果。
+func TestSiliconflowRerankerFailover(t *testing.T) {
+	var cfHits atomic.Int64
+	cf := always500("cf", &cfHits, -1)
+	defer cf.Close()
+	fc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"results":[{"index":0,"relevance_score":0.9}]}`))
+	}))
+	defer fc.Close()
+
+	r, err := newSiliconflowReranker([]string{cf.URL, fc.URL}, "k", "BAAI/bge-reranker-v2-m3", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	order, err := r.Rerank(context.Background(), "q", []string{"a", "b"}, 1)
+	if err != nil {
+		t.Fatalf("reranker failover failed: %v", err)
+	}
+	if len(order) != 1 || order[0] != 0 {
+		t.Fatalf("order = %v want [0]", order)
+	}
+	if cfHits.Load() == 0 {
+		t.Error("CF gateway was never attempted before failover")
+	}
+}
+
+// 4xx 快速失败不轮转：首网关 401 时不请求 FC（键/路径错误在任何网关都会复现）。
+func TestPostJSONNoFailoverOn4xx(t *testing.T) {
+	var cfHits, fcHits atomic.Int64
+	cf := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cfHits.Add(1)
+		w.WriteHeader(401)
+	}))
+	defer cf.Close()
+	fc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fcHits.Add(1)
+		w.WriteHeader(200)
+	}))
+	defer fc.Close()
+
+	var out map[string]any
+	err := postJSON(context.Background(), []string{cf.URL, fc.URL}, "k", map[string]any{}, &out)
+	if err == nil {
+		t.Fatal("expected auth error")
+	}
+	if fcHits.Load() != 0 {
+		t.Errorf("fallback attempted %d times on 4xx, want 0", fcHits.Load())
+	}
+}

--- a/source/se-rag-core/internal/embed/gateway_transport_test.go
+++ b/source/se-rag-core/internal/embed/gateway_transport_test.go
@@ -65,9 +65,10 @@ func TestDialWithResolveGatewayPrefersHardcodedIP(t *testing.T) {
 	}
 }
 
-// 作用范围收窄：非内置网关域名（如官方回落 api.siliconflow.cn、sophnet）直接走系统拨号，不做 IP 覆盖。
+// 作用范围收窄：非内置网关域名（官方回落 api.siliconflow.cn、sophnet、FC 网关 fcapp.run）
+// 直接走系统拨号，不做 IP 覆盖。阿里云 FC 网关是国内域名，走系统 DNS 不受 IP 优先逻辑影响。
 func TestDialWithResolveNonGatewayPassesThrough(t *testing.T) {
-	for _, host := range []string{"api.siliconflow.cn", "www.sophnet.com", "127.0.0.1"} {
+	for _, host := range []string{"api.siliconflow.cn", "www.sophnet.com", "se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run", "127.0.0.1"} {
 		addr := net.JoinHostPort(host, "443")
 		base, calls := recordingBase(map[string]bool{addr: true})
 		_, err := dialWithResolve(context.Background(), "tcp", addr, base, fakeResolver{})

--- a/source/se-rag-core/internal/embed/httpclient.go
+++ b/source/se-rag-core/internal/embed/httpclient.go
@@ -29,16 +29,23 @@ func newGatewayAwareClient(base DialContext) *http.Client {
 	return &http.Client{Transport: tr}
 }
 
-// postJSON POST JSON 到 url，带 Bearer 鉴权。
-// 5xx/429/连接错误 → 指数退避重试（最多6次）；4xx → 快速失败不重试。
-func postJSON(ctx context.Context, url, key string, payload, out any) error {
+// postJSON POST JSON 到 urls（有序网关列表，故障转移链），带 Bearer 鉴权。
+// 5xx/429/连接错误 → 指数退避重试（上限 maxAttempts 次），每次尝试按 attempt%len(urls) 轮转
+// 网关地址：主网关（CF Worker）不可达时下一次即命中 FC 网关，实现 CF → FC 故障转移；
+// 4xx → 快速失败不重试（键/路径/白名单错误在任一网关都会复现，无需转移）。
+// 单地址列表行为与旧版完全一致。
+func postJSON(ctx context.Context, urls []string, key string, payload, out any) error {
+	if len(urls) == 0 {
+		return fmt.Errorf("no gateway base urls configured")
+	}
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return err
 	}
 	var lastErr error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+		u := urls[attempt%len(urls)]
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
 		if err != nil {
 			return err
 		}
@@ -71,6 +78,9 @@ func postJSON(ctx context.Context, url, key string, payload, out any) error {
 	if lastErr == nil {
 		lastErr = fmt.Errorf("no successful response after %d attempts", maxAttempts)
 	}
+	if len(urls) > 1 {
+		return fmt.Errorf("all %d gateway(s) unreachable (tried %s...): %w", len(urls), urls[0], lastErr)
+	}
 	return fmt.Errorf("postJSON failed: %w", lastErr)
 }
 
@@ -83,4 +93,13 @@ func backoff(attempt int) time.Duration {
 		}
 	}
 	return d
+}
+
+// joinPaths 把 base URL 列表展开为具体接口路径列表（保持有序，与故障转移轮转一致）。
+func joinPaths(baseURLs []string, rel string) []string {
+	out := make([]string, len(baseURLs))
+	for i, b := range baseURLs {
+		out[i] = b + rel
+	}
+	return out
 }

--- a/source/se-rag-core/internal/embed/provider.go
+++ b/source/se-rag-core/internal/embed/provider.go
@@ -24,7 +24,7 @@ type Reranker interface {
 func NewEmbedder(cfg config.Provider) (Embedder, error) {
 	switch cfg.Type {
 	case "siliconflow":
-		return newSiliconflowEmbedder(cfg.EffectiveBaseURL(), cfg.EffectiveKey(), cfg.Model, cfg.Dim, cfg.IsBuiltinKey())
+		return newSiliconflowEmbedder(cfg.EffectiveBaseURLs(), cfg.EffectiveKey(), cfg.Model, cfg.Dim, cfg.IsBuiltinKey())
 	case "sophnet":
 		return newSophnetEmbedder(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model, cfg.Dim)
 	default:
@@ -36,7 +36,7 @@ func NewEmbedder(cfg config.Provider) (Embedder, error) {
 func NewReranker(cfg config.Provider) (Reranker, error) {
 	switch cfg.Type {
 	case "siliconflow":
-		return newSiliconflowReranker(cfg.EffectiveBaseURL(), cfg.EffectiveKey(), cfg.Model, cfg.IsBuiltinKey())
+		return newSiliconflowReranker(cfg.EffectiveBaseURLs(), cfg.EffectiveKey(), cfg.Model, cfg.IsBuiltinKey())
 	case "sophnet":
 		return newSophnetReranker(cfg.BaseURL, cfg.EffectiveKey(), cfg.Model)
 	default:

--- a/source/se-rag-core/internal/embed/siliconflow.go
+++ b/source/se-rag-core/internal/embed/siliconflow.go
@@ -5,19 +5,20 @@ import (
 )
 
 // siliconflowEmbedder：OpenAI 兼容 /embeddings 接口，内置 key 时对 Embed 整体限流。
+// baseURLs 为有序网关地址列表（CF → FC 故障转移），请求按列表轮转，首个可达网关命中。
 type siliconflowEmbedder struct {
-	baseURL string
-	apiKey  string
-	model   string
-	dim     int
-	limiter *EmbeddingLimiter
+	baseURLs []string
+	apiKey   string
+	model    string
+	dim      int
+	limiter  *EmbeddingLimiter
 }
 
-func newSiliconflowEmbedder(baseURL, key, model string, dim int, useBuiltinKey bool) (Embedder, error) {
-	if baseURL == "" {
-		baseURL = "https://api.siliconflow.cn/v1"
+func newSiliconflowEmbedder(baseURLs []string, key, model string, dim int, useBuiltinKey bool) (Embedder, error) {
+	if len(baseURLs) == 0 || baseURLs[0] == "" {
+		baseURLs = []string{"https://api.siliconflow.cn/v1"}
 	}
-	e := &siliconflowEmbedder{baseURL: baseURL, apiKey: key, model: model, dim: dim}
+	e := &siliconflowEmbedder{baseURLs: baseURLs, apiKey: key, model: model, dim: dim}
 	if useBuiltinKey {
 		e.limiter = NewEmbeddingLimiter(1) // 内置 key 并发仅 1
 	}
@@ -47,7 +48,7 @@ func (e *siliconflowEmbedder) Embed(ctx context.Context, texts []string) ([][]fl
 func (e *siliconflowEmbedder) embedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	payload := map[string]any{"model": e.model, "input": texts}
 	var resp sfEmbedResp
-	if err := postJSON(ctx, e.baseURL+"/embeddings", e.apiKey, payload, &resp); err != nil {
+	if err := postJSON(ctx, joinPaths(e.baseURLs, "/embeddings"), e.apiKey, payload, &resp); err != nil {
 		return nil, err
 	}
 	out := make([][]float32, len(texts))
@@ -61,23 +62,23 @@ func (e *siliconflowEmbedder) embedBatch(ctx context.Context, texts []string) ([
 
 // NewSiliconflowEmbedderFromURL 测试辅助：显式 baseURL
 func NewSiliconflowEmbedderFromURL(baseURL string) (Embedder, error) {
-	return newSiliconflowEmbedder(baseURL, "test-key", "BAAI/bge-m3", 1024, false)
+	return newSiliconflowEmbedder([]string{baseURL}, "test-key", "BAAI/bge-m3", 1024, false)
 }
 
 // ---- siliconflow reranker ----
 
 type siliconflowReranker struct {
-	baseURL    string
+	baseURLs   []string
 	apiKey     string
 	model      string
 	useBuiltin bool
 }
 
-func newSiliconflowReranker(baseURL, key, model string, useBuiltinKey bool) (Reranker, error) {
-	if baseURL == "" {
-		baseURL = "https://api.siliconflow.cn/v1"
+func newSiliconflowReranker(baseURLs []string, key, model string, useBuiltinKey bool) (Reranker, error) {
+	if len(baseURLs) == 0 || baseURLs[0] == "" {
+		baseURLs = []string{"https://api.siliconflow.cn/v1"}
 	}
-	return &siliconflowReranker{baseURL: baseURL, apiKey: key, model: model, useBuiltin: useBuiltinKey}, nil
+	return &siliconflowReranker{baseURLs: baseURLs, apiKey: key, model: model, useBuiltin: useBuiltinKey}, nil
 }
 
 func (r *siliconflowReranker) Name() string { return "siliconflow." + r.model }
@@ -101,7 +102,7 @@ func (r *siliconflowReranker) Rerank(ctx context.Context, query string, docs []s
 	if r.useBuiltin {
 		// reranker 用并发1简单限流（单次调用本身段数由调用方控制）
 	}
-	if err := postJSON(ctx, r.baseURL+"/rerank", r.apiKey, payload, &resp); err != nil {
+	if err := postJSON(ctx, joinPaths(r.baseURLs, "/rerank"), r.apiKey, payload, &resp); err != nil {
 		return nil, err
 	}
 	order := make([]int, 0, len(resp.Results))

--- a/source/se-rag-core/internal/embed/sophnet.go
+++ b/source/se-rag-core/internal/embed/sophnet.go
@@ -34,7 +34,7 @@ func (e *sophnetEmbedder) Embed(ctx context.Context, texts []string) ([][]float3
 	payload := map[string]any{"model": e.model, "input_texts": texts, "dimensions": e.dim}
 	url := e.baseURL + "/open-apis/projects/easyllms/embeddings"
 	var resp snEmbedResp
-	if err := postJSON(ctx, url, e.apiKey, payload, &resp); err != nil {
+	if err := postJSON(ctx, []string{url}, e.apiKey, payload, &resp); err != nil {
 		return nil, err
 	}
 	out := make([][]float32, len(texts))
@@ -79,7 +79,7 @@ func (r *sophnetReranker) Rerank(ctx context.Context, query string, docs []strin
 	payload := map[string]any{"model": r.model, "query": query, "documents": docs, "top_n": topN}
 	url := r.baseURL + "/open-apis/projects/rerank"
 	var resp snRerankResp
-	if err := postJSON(ctx, url, r.apiKey, payload, &resp); err != nil {
+	if err := postJSON(ctx, []string{url}, r.apiKey, payload, &resp); err != nil {
 		return nil, err
 	}
 	if resp.Status != 0 {

--- a/source/se-rag-core/internal/retriever/failover_test.go
+++ b/source/se-rag-core/internal/retriever/failover_test.go
@@ -1,0 +1,46 @@
+package retriever
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"se-rag-core/internal/config"
+	"se-rag-core/internal/embed"
+)
+
+// 端到端故障转移链（CF Worker → FC 网关 → 纯 BM25）：
+// 用真实 siliconflow embedder 指向两个连接即拒的网关地址，模拟双网关均不可达，
+// 验证检索不 panic、有界失败后降级纯 BM25 并返回结果。
+func TestSearchBM25FallbackBothGatewaysDown(t *testing.T) {
+	s := buildTestStore(t)
+	// 127.0.0.1:1 / :2 本机无服务监听，连接立即被拒（模拟 CF 与 FC 网关都不可达）
+	p := config.Provider{
+		Type:            "siliconflow",
+		Model:           "BAAI/bge-m3",
+		Dim:             1024,
+		BaseURL:         "http://127.0.0.1:1/v1",
+		FallbackBaseURL: "http://127.0.0.1:2/v1",
+	}
+	emb, err := embed.NewEmbedder(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &Retriever{Store: s, Embedder: emb, Reranker: &fakeRerank{}}
+	out, err := r.Search(context.Background(), "BM1684X 芯片", "se7", 8)
+	if err != nil {
+		t.Fatalf("search must not error when both gateways down, got %v", err)
+	}
+	if out.Mode != "bm25" {
+		t.Errorf("mode=%s want bm25 fallback", out.Mode)
+	}
+	if len(out.Results) == 0 {
+		t.Fatal("expected bm25 results when both gateways down")
+	}
+	if out.FallbackReason == "" {
+		t.Error("expected fallback reason carrying gateway failure detail")
+	}
+	if !strings.Contains(out.FallbackReason, "gateway") {
+		t.Errorf("fallback reason should mention gateway failure, got %q", out.FallbackReason)
+	}
+}


### PR DESCRIPTION
## 背景

se-rag-core 内置网关原只有一条路径（自建 Cloudflare Worker），部分国内网络对 `*.workers.dev` 存在 DNS 污染且 CF 服务本身可能不可达。已在阿里云函数计算（FC3.0）部署同协议网关镜像（`*.fcapp.run`，国内直连）。本 PR 为内置 key 构建三级故障转移链：**CF Worker → 阿里云 FC 网关 → 纯 BM25**。

## 改动

### internal/config（`config.go`）
- 新增 `GatewayFCBaseURL` 常量（阿里云 FC 网关地址）
- `Provider` 新增 `FallbackBaseURL` 字段（备网关，默认 FC 网关；置空自动取值）
- 新增 `EffectiveBaseURLs()` 有序地址列表：内置 key → `[BaseURL(CF), FallbackBaseURL(FC)]`，相同地址去重；自备 key → 官方 SiliconFlow 直达（无故障转移项）
- 旧字段 `GatewayBaseURL` / `EffectiveBaseURL()` / `BaseURL` 全部保留，向后兼容

### internal/embed（`httpclient.go` / `siliconflow.go` / `sophnet.go` / `provider.go`）
- `postJSON` 改为多 URL 列表按 attempt 轮转：主网关 5xx/429/连接错误（超时、DNS 失败）→ 下一次尝试即命中 FC 网关；**4xx 快速失败不转移**（键/路径/白名单错误在任一网关均会复现）
- 总尝试数仍为 `maxAttempts=6`（有界，不无限挂起）；失败报错指明不可达网关（`all 2 gateway(s) unreachable (tried <CF>...): <err>`）
- siliconflow embedder/reranker 持 `baseURLs []string`；sophnet 保持单地址
- 单地址列表行为与旧版完全一致（回归保护）

### gateway_transport（确认，无代码改动）
- IP 优先 + DoH 兜底拨号**仅作用于 CF 网关域名** `se-rag-gateway.zetao-zhang.workers.dev`；FC 网关（`fcapp.run`，国内域名）走系统 DNS，不受影响（已补测试：`fcapp.run` 域名直接透传 base 拨号，无 IP 覆盖）

### 测试（新增 8 个用例）
| 场景 | 验证点 |
|------|--------|
| 主网关 5xx → FC 成功 | postJSON / embedder / reranker 三层故障转移 |
| 主网关连接拒绝 → FC 成功 | 网络层错误同样触发轮转 |
| 双网关均 5xx | 总尝试数 = maxAttempts（有界），报错含网关信息 |
| 4xx | 快速失败，不请求备网关 |
| retriever 端到端 | 真实 embedder 指向两个不可达地址 → `mode=bm25` 返回结果、不 panic、有 fallback 原因 |
| config | 内置 key → `[CF, FC]`；自备 key → 官方；显式主/备、去重 |
| transport | `fcapp.run` 域名透传不受 IP 优先影响 |

### README
- 新增「内置网关故障转移链」章节（三级链路表 + 行为约定）

## 验证

- `go vet ./...` / `go test -count=1 ./...` / `go test -race`（embed+retriever）全绿
- 真机 E2E（真实内置 key）：
  - **主路径**：`build` + `query` 经 CF 网关（IP 优先拨号）成功，`mode=hybrid`
  - **双网关不可达模拟**（dead proxy）：`mode=bm25` 降级、5106ms 有界退出、fallback 原因明确、不 panic
- 内置 key 未改动，无新增硬编码凭据

## 遗留事项（FC 部署侧，代码零改动）

实测发现 FC 网关**应用层认识内置 key**（白名单/路径校验均通过），但其**上游转发 hop** 对内置 key 返回平台级 `401 {"code":30014,"message":"Token is invalid."}`（仅在真正转发 SiliconFlow 的请求上触发，如 `wrong-model`/`bad path` 等应用内拒绝请求不受影响）。即 FC 部署侧的源站凭据/上行链路鉴权未打通，需 FC 网关部署方修复；修复后内置 key 自动切换即刻生效，本仓库无需任何改动。
