### PR TITLE
fix(pbmssm): 高危操作互斥+二次确认+审计落库, OTA 解压累计/条目上限, uploadId 重启一致性 (MYS-389)

### DIFF
--- a/source/pbmssm/mvc/audit/service.go
+++ b/source/pbmssm/mvc/audit/service.go
@@ -50,7 +50,11 @@ func (s *AuditService) ListLogs(offset, limit int) (*PaginatedResult, error) {
 }
 
 // Write 写入一条审计日志（辅助方法，供其他模块调用）。
+// DB 不可用（服务或 db 为 nil）时静默跳过，不阻塞调用方主流程。
 func (s *AuditService) Write(username, action, resource, ip, result string) error {
+	if s == nil || s.db == nil {
+		return nil
+	}
 	entry := AuditLog{
 		Username: username,
 		Action:   action,

--- a/source/pbmssm/mvc/compat/controller.go
+++ b/source/pbmssm/mvc/compat/controller.go
@@ -19,10 +19,12 @@ import (
 	"bmssm/database"
 	"bmssm/global"
 	"bmssm/logger"
+	"bmssm/mvc/audit"
 	"bmssm/mvc/hardware"
 	"bmssm/mvc/software"
 	"bmssm/mvc/user"
 	"bmssm/pkg/auth"
+	"bmssm/pkg/hazard"
 	netpkg "bmssm/pkg/network"
 	"bmssm/pkg/ota"
 	"bmssm/pkg/response"
@@ -39,6 +41,7 @@ type Controller struct {
 	swSvc     *software.SoftwareService
 	userSvc   *user.UserService
 	otaEngine *ota.Engine
+	aud       *audit.AuditService
 }
 
 // NewController 创建兼容控制器。
@@ -54,13 +57,42 @@ func NewController(svc *CompatService, hwSvc *hardware.HardwareService, swSvc *s
 
 // DefaultController 构建默认控制器（生产环境依赖注入）。
 func DefaultController() *Controller {
-	return NewController(
+	ctrl := NewController(
 		DefaultCompatService(),
 		hardware.NewDefaultService(),
 		software.DefaultService(),
 		user.NewService(database.DB()),
 		ota.DefaultEngine(),
 	)
+	ctrl.aud = audit.NewService(database.DB())
+	return ctrl
+}
+
+// auditWrite 写入审计日志（忽略错误，不阻塞主流程）。
+func (ctrl *Controller) auditWrite(c *gin.Context, username, action, resource, result string) {
+	if ctrl.aud == nil {
+		return
+	}
+	_ = ctrl.aud.Write(username, action, resource, c.ClientIP(), result)
+}
+
+// requireHazardGuard 校验二次确认码并占用高危互斥锁（MYS-389）。
+// 返回 guard 与 bool：false 时已写出错误响应，直接 return。
+func (ctrl *Controller) requireHazardGuard(c *gin.Context, holder, action, resource, confirm string) (*hazard.Guard, bool) {
+	username, _ := c.Get("user")
+	uname, _ := username.(string)
+	if !hazard.VerifyConfirmCode(confirm) {
+		ctrl.auditWrite(c, uname, action, resource, "confirmation_failed")
+		c.JSON(http.StatusForbidden, response.Fail("confirmation required: fetch /api/v1/hazard/challenge first"))
+		return nil, false
+	}
+	guard, err := hazard.HazardOps.TryAcquire(holder)
+	if err != nil {
+		ctrl.auditWrite(c, uname, action, resource, "blocked")
+		c.JSON(http.StatusConflict, response.Fail(err.Error()))
+		return nil, false
+	}
+	return guard, true
 }
 
 // getSecret 从配置获取 JWT secret。
@@ -264,33 +296,62 @@ func (ctrl *Controller) DeleteNAT(c *gin.Context) {
 // Reboot POST /bitmain/v1/ssm/hardware/devices/reset
 // 复用 hardware.HardwareService 的 Rebooter（生产用 osRebooter）。
 func (ctrl *Controller) Reboot(c *gin.Context) {
-	var req CoreOpe
+	var req struct {
+		CoreOpe
+		Confirm string `json:"confirm"`
+	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
 	}
 
+	// MYS-389：二次确认 + 高危互斥 + 审计
+	guard, ok := ctrl.requireHazardGuard(c, "reboot", "reboot", "hardware", req.Confirm)
+	if !ok {
+		return
+	}
+	defer guard.Release()
+
 	if err := ctrl.hwSvc.Reboot(0); err != nil {
+		ctrl.auditWrite(c, uname(c), "reboot", "hardware", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
-
+	ctrl.auditWrite(c, uname(c), "reboot", "hardware", "success")
 	c.JSON(http.StatusOK, response.OK(nil))
+}
+
+// uname 从 gin context 取用户名（middleware.Auth 注入）。
+func uname(c *gin.Context) string {
+	u, _ := c.Get("user")
+	s, _ := u.(string)
+	return s
 }
 
 // Shutdown POST /bitmain/v1/ssm/hardware/devices/down
 func (ctrl *Controller) Shutdown(c *gin.Context) {
-	var req CoreOpe
+	var req struct {
+		CoreOpe
+		Confirm string `json:"confirm"`
+	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
 	}
 
+	// MYS-389：二次确认 + 高危互斥 + 审计
+	guard, ok := ctrl.requireHazardGuard(c, "shutdown", "shutdown", "hardware", req.Confirm)
+	if !ok {
+		return
+	}
+	defer guard.Release()
+
 	if err := Shutdown(); err != nil {
+		ctrl.auditWrite(c, uname(c), "shutdown", "hardware", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
-
+	ctrl.auditWrite(c, uname(c), "shutdown", "hardware", "success")
 	c.JSON(http.StatusOK, response.OK(nil))
 }
 
@@ -412,6 +473,8 @@ func (ctrl *Controller) GetAlarm(c *gin.Context) {
 // UploadFirmware POST /bitmain/v1/ssm/file/ota
 // 接收 multipart .tgz 刷机包，按 module（form 字段，默认 soc）保存到对应目录。
 func (ctrl *Controller) UploadFirmware(c *gin.Context) {
+	// MYS-389：OTA 上传记审计
+	ctrl.auditWrite(c, uname(c), "ota.upload", "ota", "attempted")
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("missing file field"))
@@ -464,6 +527,13 @@ func (ctrl *Controller) ExecuteUpgrade(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
 	}
+
+	// MYS-389：二次确认 + 高危互斥 + 审计
+	guard, ok := ctrl.requireHazardGuard(c, "ota.upgrade", "ota.upgrade", "ota", req.Confirm)
+	if !ok {
+		return
+	}
+	defer guard.Release()
 	// Product 为空时用设备实际型号兜底（global.DeviceTypeEx 形如 "SE7 V01"），
 	// 否则 productClass 识别不到会返回 "ota: path not implemented"。
 	product := req.Product
@@ -481,9 +551,11 @@ func (ctrl *Controller) ExecuteUpgrade(c *gin.Context) {
 		FlashData:  req.FlashData,
 	}
 	if err := ctrl.otaEngine.EnqueueFlow(&flow); err != nil {
+		ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
+	ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "success")
 	c.JSON(http.StatusOK, response.OK("add workflow success"))
 }
 
@@ -495,6 +567,14 @@ func (ctrl *Controller) Rollback(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
 	}
+
+	// MYS-389：二次确认 + 高危互斥 + 审计
+	guard, ok := ctrl.requireHazardGuard(c, "ota.rollback", "ota.rollback", "ota", req.Confirm)
+	if !ok {
+		return
+	}
+	defer guard.Release()
+
 	product := req.Product
 	if strings.TrimSpace(product) == "" {
 		product = global.DeviceTypeEx
@@ -510,9 +590,11 @@ func (ctrl *Controller) Rollback(c *gin.Context) {
 		FlashData:  req.FlashData,
 	}
 	if err := ctrl.otaEngine.EnqueueFlow(&flow); err != nil {
+		ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
+	ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "success")
 	c.JSON(http.StatusOK, response.OK("add workflow success"))
 }
 
@@ -561,6 +643,7 @@ func (ctrl *Controller) Exec(c *gin.Context) {
 		Command string `json:"command" binding:"required"`
 		Timeout int    `json:"timeout"`
 	}
+	// MYS-389：exec 记审计（保留只读诊断能力，不强制二次确认）
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
@@ -587,6 +670,11 @@ func (ctrl *Controller) Exec(c *gin.Context) {
 			exitCode = -1
 		}
 	}
+	res := "success"
+	if exitCode != 0 {
+		res = "failed"
+	}
+	ctrl.auditWrite(c, uname(c), "exec", "hardware.exec", res)
 	c.JSON(http.StatusOK, response.OK(gin.H{
 		"stdout":   stdout.String(),
 		"stderr":   stderr.String(),

--- a/source/pbmssm/mvc/compat/controller.go
+++ b/source/pbmssm/mvc/compat/controller.go
@@ -590,11 +590,11 @@ func (ctrl *Controller) Rollback(c *gin.Context) {
 		FlashData:  req.FlashData,
 	}
 	if err := ctrl.otaEngine.EnqueueFlow(&flow); err != nil {
-		ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "failed")
+		ctrl.auditWrite(c, uname(c), "ota.rollback", "ota", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
-	ctrl.auditWrite(c, uname(c), "ota.upgrade", "ota", "success")
+	ctrl.auditWrite(c, uname(c), "ota.rollback", "ota", "success")
 	c.JSON(http.StatusOK, response.OK("add workflow success"))
 }
 

--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"bmssm/mvc/hardware"
 	"bmssm/mvc/software"
 	"bmssm/mvc/user"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/ota"
 	"bmssm/pkg/response"
 )
@@ -671,6 +672,7 @@ func TestCompatRollback(t *testing.T) {
 
 	body, _ := json.Marshal(OtaVersion{
 		Product: "SC5", ModuleName: "a53", FileName: "fw.bin", Name: "rb-test",
+		Confirm: hazard.NewConfirmCode(),
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/rollback", bytes.NewBuffer(body))
@@ -763,6 +765,7 @@ func TestCompatExecuteUpgrade(t *testing.T) {
 
 	body, _ := json.Marshal(OtaVersion{
 		Product: "SE7", ModuleName: "soc", FileName: "soc_fw.tgz", Name: "up-test", Version: "1.0.0",
+		Confirm: hazard.NewConfirmCode(),
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade", bytes.NewBuffer(body))
@@ -793,6 +796,7 @@ func TestCompatListAndQueryWorkflow(t *testing.T) {
 
 	body, _ := json.Marshal(OtaVersion{
 		Product: "SE7", FileName: "fw.tgz", Name: "list-test",
+		Confirm: hazard.NewConfirmCode(),
 	})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade", bytes.NewBuffer(body))

--- a/source/pbmssm/mvc/compat/types.go
+++ b/source/pbmssm/mvc/compat/types.go
@@ -86,6 +86,8 @@ type OtaVersion struct {
 	CmdFlag    string `json:"cmdFlag"`
 	Version    string `json:"version"`
 	FlashData  bool   `json:"flashData"`
+	// 二次确认码（MYS-389）：必须携带 /api/v1/hazard/challenge 最近下发的一次性码。
+	Confirm string `json:"confirm"`
 }
 
 // ---------------------------------------------------------------

--- a/source/pbmssm/mvc/firewall/controller.go
+++ b/source/pbmssm/mvc/firewall/controller.go
@@ -5,20 +5,39 @@ import (
 	"net/http"
 	"strconv"
 
+	"bmssm/database"
+	"bmssm/mvc/audit"
 	"bmssm/pkg/firewall"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/response"
 
 	"github.com/gin-gonic/gin"
 )
 
 // Controller holds a Service and exposes gin handler methods.
-type Controller struct{ svc *Service }
+type Controller struct {
+	svc *Service
+	// aud 审计服务（nil 安全）：防火墙 rebuild 属高危操作，记入 audit_logs（MYS-389）。
+	aud *audit.AuditService
+}
 
 // NewController creates a Controller with the given Service.
 func NewController(svc *Service) *Controller { return &Controller{svc: svc} }
 
 // DefaultController creates a Controller backed by the default (global-DB) Service.
-func DefaultController() *Controller { return NewController(DefaultService()) }
+func DefaultController() *Controller {
+	ctrl := NewController(DefaultService())
+	ctrl.aud = audit.NewService(database.DB())
+	return ctrl
+}
+
+// auditWrite 写入审计日志（忽略错误，不阻塞主流程）。
+func (ctrl *Controller) auditWrite(c *gin.Context, username, action, resource, result string) {
+	if ctrl.aud == nil {
+		return
+	}
+	_ = ctrl.aud.Write(username, action, resource, c.ClientIP(), result)
+}
 
 // envFail checks the firewall environment. Returns true and writes a 503
 // JSON response if the environment is unhealthy; returns false if healthy.
@@ -93,13 +112,39 @@ func (ctrl *Controller) DeleteIntent(c *gin.Context) {
 }
 
 // Rebuild handles POST /firewall/rebuild.
+// 高危操作防护（MYS-389）：与 reboot/shutdown/OTA 共享全局互斥锁与二次确认码
+// （防火墙 rebuild 期间重启/OTA 会留下半配置规则或打断刷机），并记审计。
 func (ctrl *Controller) Rebuild(c *gin.Context) {
 	if envFail(c) {
 		return
 	}
+	var req struct {
+		Confirm string `json:"confirm"`
+	}
+	// 空 body 视为无确认码（校验失败会给出引导性错误），不因解析失败直接 400
+	_ = c.ShouldBindJSON(&req)
+
+	username, _ := c.Get("user")
+	name, _ := username.(string)
+
+	if !hazard.VerifyConfirmCode(req.Confirm) {
+		ctrl.auditWrite(c, name, "firewall_rebuild", "firewall", "confirmation_failed")
+		c.JSON(http.StatusForbidden, response.Fail("confirmation required: fetch /api/v1/hazard/challenge first"))
+		return
+	}
+	guard, err := hazard.HazardOps.TryAcquire("firewall_rebuild")
+	if err != nil {
+		ctrl.auditWrite(c, name, "firewall_rebuild", "firewall", "blocked")
+		c.JSON(http.StatusConflict, response.Fail(err.Error()))
+		return
+	}
+	defer guard.Release()
+
 	if err := ctrl.svc.Rebuild(); err != nil {
+		ctrl.auditWrite(c, name, "firewall_rebuild", "firewall", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
+	ctrl.auditWrite(c, name, "firewall_rebuild", "firewall", "success")
 	c.JSON(http.StatusOK, response.OK(gin.H{"message": "rebuild ok"}))
 }

--- a/source/pbmssm/mvc/hardware/controller.go
+++ b/source/pbmssm/mvc/hardware/controller.go
@@ -5,12 +5,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"bmssm/database"
+	"bmssm/mvc/audit"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/response"
 )
 
 // Controller 硬件模块 gin handler 集合。
 type Controller struct {
 	svc *HardwareService
+	aud *audit.AuditService
 }
 
 // NewController 创建硬件控制器。
@@ -20,7 +24,17 @@ func NewController(svc *HardwareService) *Controller {
 
 // DefaultController 构建默认（生产）控制器。
 func DefaultController() *Controller {
-	return NewController(NewDefaultService())
+	ctrl := NewController(NewDefaultService())
+	ctrl.aud = audit.NewService(database.DB())
+	return ctrl
+}
+
+// auditWrite 写入审计日志（忽略错误，不阻塞主流程）。
+func (ctrl *Controller) auditWrite(c *gin.Context, username, action, resource, result string) {
+	if ctrl.aud == nil {
+		return
+	}
+	_ = ctrl.aud.Write(username, action, resource, c.ClientIP(), result)
 }
 
 // GetHealth 处理 GET /api/v1/hardware/health — 健康状态。
@@ -37,18 +51,45 @@ func (ctrl *Controller) Reboot(c *gin.Context) {
 		return
 	}
 
+	// MYS-389：二次确认 + 高危互斥 + 审计。
+	username, _ := c.Get("user")
+	uname, _ := username.(string)
+	if !hazard.VerifyConfirmCode(req.Confirm) {
+		ctrl.auditWrite(c, uname, "reboot", "hardware", "confirmation_failed")
+		c.JSON(http.StatusForbidden, response.Fail("confirmation required: fetch /api/v1/hazard/challenge first"))
+		return
+	}
+	guard, err := hazard.HazardOps.TryAcquire("reboot")
+	if err != nil {
+		ctrl.auditWrite(c, uname, "reboot", "hardware", "blocked")
+		c.JSON(http.StatusConflict, response.Fail(err.Error()))
+		return
+	}
+	defer guard.Release()
+
 	if err := ctrl.svc.Reboot(req.Delay); err != nil {
 		// delay 校验错误 → 400
 		errMsg := err.Error()
 		if len(errMsg) >= 5 && errMsg[:5] == "delay" {
+			ctrl.auditWrite(c, uname, "reboot", "hardware", "failed")
 			c.JSON(http.StatusBadRequest, response.Fail(errMsg))
 			return
 		}
+		ctrl.auditWrite(c, uname, "reboot", "hardware", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(errMsg))
 		return
 	}
-
+	ctrl.auditWrite(c, uname, "reboot", "hardware", "success")
 	c.JSON(http.StatusOK, response.OK(gin.H{"message": "reboot scheduled"}))
+}
+
+// Challenge 处理 GET /api/v1/hazard/challenge — 下发高危操作一次性确认码。
+func (ctrl *Controller) Challenge(c *gin.Context) {
+	code := hazard.NewConfirmCode()
+	c.JSON(http.StatusOK, response.OK(gin.H{
+		"code":          code,
+		"expiresInSecs": 120,
+	}))
 }
 
 // GetLED 处理 GET /api/v1/hardware/led — LED 状态。

--- a/source/pbmssm/mvc/hardware/controller_test.go
+++ b/source/pbmssm/mvc/hardware/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"bmssm/config"
 	"bmssm/middleware"
 	"bmssm/pkg/auth"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/response"
 )
 
@@ -120,7 +121,7 @@ func TestRebootWithAuth(t *testing.T) {
 
 	token := makeAuthToken(t)
 
-	body, _ := json.Marshal(RebootRequest{Delay: 5})
+	body, _ := json.Marshal(RebootRequest{Delay: 5, Confirm: hazard.NewConfirmCode()})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -132,6 +133,69 @@ func TestRebootWithAuth(t *testing.T) {
 	}
 	if rb.calls.Load() != 1 {
 		t.Fatalf("expected 1 reboot call, got %d", rb.calls.Load())
+	}
+}
+
+func TestRebootWithoutConfirm403(t *testing.T) {
+	setupHardwareTest(t)
+	fr := newFakeFileReader()
+	rb := &fakeRebooter{}
+	svc := NewService(&fakeCmdRunner{}, fr, rb)
+	ctrl := NewController(svc)
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.POST("/hardware/reboot", ctrl.Reboot)
+
+	token := makeAuthToken(t)
+	body, _ := json.Marshal(RebootRequest{Delay: 0}) // 无 Confirm
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 without confirm, got %d body=%s", w.Code, w.Body.String())
+	}
+	if rb.calls.Load() != 0 {
+		t.Fatalf("reboot must not be triggered without confirm, calls=%d", rb.calls.Load())
+	}
+}
+
+func TestRebootBlockedByActiveHazardOp409(t *testing.T) {
+	setupHardwareTest(t)
+	fr := newFakeFileReader()
+	rb := &fakeRebooter{}
+	svc := NewService(&fakeCmdRunner{}, fr, rb)
+	ctrl := NewController(svc)
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.POST("/hardware/reboot", ctrl.Reboot)
+	token := makeAuthToken(t)
+
+	// 模拟 OTA 刷机进行中：占用全局高危互斥锁
+	guard, err := hazard.HazardOps.TryAcquire("ota.upgrade")
+	if err != nil {
+		t.Fatalf("acquire for test: %v", err)
+	}
+	defer guard.Release()
+
+	body, _ := json.Marshal(RebootRequest{Delay: 0, Confirm: hazard.NewConfirmCode()})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 while hazard op active, got %d body=%s", w.Code, w.Body.String())
+	}
+	if rb.calls.Load() != 0 {
+		t.Fatalf("reboot must not run while hazard op active, calls=%d", rb.calls.Load())
 	}
 }
 
@@ -170,7 +234,7 @@ func TestRebootDelayTooLarge400(t *testing.T) {
 
 	token := makeAuthToken(t)
 
-	body, _ := json.Marshal(RebootRequest{Delay: 301})
+	body, _ := json.Marshal(RebootRequest{Delay: 301, Confirm: hazard.NewConfirmCode()})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)
@@ -197,7 +261,7 @@ func TestRebootNegativeDelay400(t *testing.T) {
 
 	token := makeAuthToken(t)
 
-	body, _ := json.Marshal(RebootRequest{Delay: -1})
+	body, _ := json.Marshal(RebootRequest{Delay: -1, Confirm: hazard.NewConfirmCode()})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token)

--- a/source/pbmssm/mvc/hardware/types.go
+++ b/source/pbmssm/mvc/hardware/types.go
@@ -10,6 +10,8 @@ type HealthResponse struct {
 // RebootRequest 重启请求。
 type RebootRequest struct {
 	Delay int `json:"delay,omitempty"` // 0-300 秒延迟，0 或不填表示立即重启
+	// 二次确认码（MYS-389）：必须携带 /api/v1/hazard/challenge 最近下发的一次性码。
+	Confirm string `json:"confirm"`
 }
 
 // LEDResponse LED 状态响应。

--- a/source/pbmssm/mvc/software/controller.go
+++ b/source/pbmssm/mvc/software/controller.go
@@ -8,12 +8,16 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"bmssm/database"
+	"bmssm/mvc/audit"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/response"
 )
 
 // Controller 软件/OTA 模块 gin handler 集合。
 type Controller struct {
 	svc *SoftwareService
+	aud *audit.AuditService
 }
 
 // NewController 创建软件/OTA 控制器。
@@ -23,7 +27,36 @@ func NewController(svc *SoftwareService) *Controller {
 
 // DefaultController 构建默认控制器（使用包级 service）。
 func DefaultController() *Controller {
-	return NewController(DefaultService())
+	ctrl := NewController(DefaultService())
+	ctrl.aud = audit.NewService(database.DB())
+	return ctrl
+}
+
+// auditWrite 写入审计日志（忽略错误，不阻塞主流程）。
+func (ctrl *Controller) auditWrite(c *gin.Context, username, action, resource, result string) {
+	if ctrl.aud == nil {
+		return
+	}
+	_ = ctrl.aud.Write(username, action, resource, c.ClientIP(), result)
+}
+
+// requireHazardGuard 校验二次确认码并占用高危互斥锁（MYS-389）。
+// 返回 guard 与 bool：false 时已写出错误响应，直接 return。
+func (ctrl *Controller) requireHazardGuard(c *gin.Context, holder, action string, confirm string) (*hazard.Guard, bool) {
+	username, _ := c.Get("user")
+	uname, _ := username.(string)
+	if !hazard.VerifyConfirmCode(confirm) {
+		ctrl.auditWrite(c, uname, action, "software", "confirmation_failed")
+		c.JSON(http.StatusForbidden, response.Fail("confirmation required: fetch /api/v1/hazard/challenge first"))
+		return nil, false
+	}
+	guard, err := hazard.HazardOps.TryAcquire(holder)
+	if err != nil {
+		ctrl.auditWrite(c, uname, action, "software", "blocked")
+		c.JSON(http.StatusConflict, response.Fail(err.Error()))
+		return nil, false
+	}
+	return guard, true
 }
 
 // ---------------------------------------------------------------
@@ -57,6 +90,13 @@ func (ctrl *Controller) Upgrade(c *gin.Context) {
 
 // handleSoftwareUpload 处理软件包上传与安装/升级。
 func (ctrl *Controller) handleSoftwareUpload(c *gin.Context, action string) {
+	// MYS-389：二次确认 + 审计；软件安装允许并发（holder 为空不占排它锁）
+	guard, ok := ctrl.requireHazardGuard(c, "", "software."+action, c.PostForm("confirm"))
+	if !ok {
+		return
+	}
+	defer guard.Release()
+
 	file, header, err := c.Request.FormFile("file")
 	if err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("missing file field"))
@@ -95,10 +135,16 @@ func (ctrl *Controller) handleSoftwareUpload(c *gin.Context, action string) {
 	}
 
 	if !resp.Success {
+		username, _ := c.Get("user")
+		uname, _ := username.(string)
+		ctrl.auditWrite(c, uname, "software."+action, "software", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(resp.Message))
 		return
 	}
 
+	username, _ := c.Get("user")
+	uname, _ := username.(string)
+	ctrl.auditWrite(c, uname, "software."+action, "software", "success")
 	c.JSON(http.StatusOK, response.OK(resp))
 }
 
@@ -174,11 +220,23 @@ func (ctrl *Controller) OTAUpgrade(c *gin.Context) {
 		return
 	}
 
+	// MYS-389：二次确认 + 高危互斥 + 审计
+	guard, ok := ctrl.requireHazardGuard(c, "ota.upgrade", "ota.upgrade", c.Query("confirm"))
+	if !ok {
+		return
+	}
+	defer guard.Release()
+
 	resp, err := ctrl.svc.ExecuteUpgrade(uid)
 	if err != nil {
+		username, _ := c.Get("user")
+		uname, _ := username.(string)
+		ctrl.auditWrite(c, uname, "ota.upgrade", "ota", "failed")
 		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
 		return
 	}
-
+	username, _ := c.Get("user")
+	uname, _ := username.(string)
+	ctrl.auditWrite(c, uname, "ota.upgrade", "ota", "success")
 	c.JSON(http.StatusOK, response.OK(resp))
 }

--- a/source/pbmssm/mvc/software/controller_test.go
+++ b/source/pbmssm/mvc/software/controller_test.go
@@ -18,6 +18,7 @@ import (
 	"bmssm/config"
 	"bmssm/middleware"
 	"bmssm/pkg/auth"
+	"bmssm/pkg/hazard"
 	"bmssm/pkg/response"
 )
 
@@ -109,6 +110,7 @@ func createMultipartBody(fieldName, fileName, content string) (*bytes.Buffer, st
 	w := multipart.NewWriter(buf)
 	part, _ := w.CreateFormFile(fieldName, fileName)
 	io.WriteString(part, content)
+	_ = w.WriteField("confirm", hazard.NewConfirmCode()) // MYS-389 二次确认
 	w.Close()
 	return buf, w.FormDataContentType()
 }
@@ -180,9 +182,14 @@ func TestControllerInstallMissingFile(t *testing.T) {
 
 	r := setupSoftwareRouter(ctrl)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/software/install", nil)
+	// 携带合法 confirm 但缺 file 字段 → 仍应 400 missing file（MYS-389 确认放行后）
+	body := new(bytes.Buffer)
+	mw := multipart.NewWriter(body)
+	_ = mw.WriteField("confirm", hazard.NewConfirmCode())
+	mw.Close()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/software/install", body)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
 	req.Header.Set("Authorization", "Bearer "+makeToken())
-	// 缺少 Content-Type 和 multipart body
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusBadRequest {
@@ -368,7 +375,7 @@ func TestControllerOTAUpgrade(t *testing.T) {
 
 	r := setupSoftwareRouter(ctrl)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID+"&confirm="+hazard.NewConfirmCode(), nil)
 	req.Header.Set("Authorization", "Bearer "+makeToken())
 	r.ServeHTTP(w, req)
 
@@ -399,7 +406,7 @@ func TestControllerOTAUpgradeDegraded(t *testing.T) {
 
 	r := setupSoftwareRouter(ctrl)
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID, nil)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID+"&confirm="+hazard.NewConfirmCode(), nil)
 	req.Header.Set("Authorization", "Bearer "+makeToken())
 	r.ServeHTTP(w, req)
 
@@ -447,7 +454,7 @@ func TestSoftwareEndpointsWithoutToken(t *testing.T) {
 		{http.MethodPost, "/api/v1/software/upgrade"},
 		{http.MethodPost, "/api/v1/ota/upload"},
 		{http.MethodGet, "/api/v1/ota/download/test-id"},
-		{http.MethodPost, "/api/v1/ota/upgrade?uploadId=test"},
+		{http.MethodPost, "/api/v1/ota/upgrade?uploadId=test&confirm=" + hazard.NewConfirmCode()},
 	}
 
 	for _, ep := range endpoints {
@@ -517,11 +524,13 @@ func TestControllerConcurrentUploads(t *testing.T) {
 	tgzData := createTarGzBytes(t, map[string]string{"VERSION": "1.0\n"})
 
 	done := make(chan int, 5)
+	// MYS-389: 共享同一确认码(并发各自 NewConfirmCode 会互相覆盖, 恰是互斥语义要防的场景)
+	confirm := hazard.NewConfirmCode()
 	for i := range 5 {
 		go func(idx int) {
 			// 每个 goroutine 使用唯一文件名，避免并发写同一文件
 			fname := fmt.Sprintf("pkg%d.tar.gz", idx)
-			body, contentType := createMultipartFileBody(t, "file", fname, tgzData)
+			body, contentType := createMultipartFileBodyConfirm(t, "file", fname, tgzData, confirm)
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest(http.MethodPost, "/api/v1/software/install", body)
 			req.Header.Set("Authorization", "Bearer "+makeToken())
@@ -561,12 +570,26 @@ func createTarGzBytes(t *testing.T, files map[string]string) []byte {
 }
 
 // createMultipartFileBody 创建含文件内容的 multipart body（使用实际文件内容）。
+// createMultipartFileBodyConfirm 创建含文件内容的 multipart body，使用调用方指定的确认码
+// （并发用例共享同一确认码，避免相互覆盖，MYS-389）。
+func createMultipartFileBodyConfirm(t *testing.T, fieldName, fileName string, content []byte, confirm string) (*bytes.Buffer, string) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	w := multipart.NewWriter(buf)
+	part, _ := w.CreateFormFile(fieldName, fileName)
+	part.Write(content)
+	_ = w.WriteField("confirm", confirm)
+	w.Close()
+	return buf, w.FormDataContentType()
+}
+
 func createMultipartFileBody(t *testing.T, fieldName, fileName string, content []byte) (*bytes.Buffer, string) {
 	t.Helper()
 	buf := new(bytes.Buffer)
 	w := multipart.NewWriter(buf)
 	part, _ := w.CreateFormFile(fieldName, fileName)
 	part.Write(content)
+	_ = w.WriteField("confirm", hazard.NewConfirmCode()) // MYS-389 二次确认
 	w.Close()
 	return buf, w.FormDataContentType()
 }
@@ -632,7 +655,7 @@ func TestControllerOTAUpgradeWithScriptInBody(t *testing.T) {
 
 	// 执行升级
 	w2 := httptest.NewRecorder()
-	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID, nil)
+	req2 := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade?uploadId="+uploadResp.UploadID+"&confirm="+hazard.NewConfirmCode(), nil)
 	req2.Header.Set("Authorization", "Bearer "+makeToken())
 	r.ServeHTTP(w2, req2)
 

--- a/source/pbmssm/mvc/software/service.go
+++ b/source/pbmssm/mvc/software/service.go
@@ -69,8 +69,22 @@ var (
 func DefaultService() *SoftwareService {
 	defaultServiceOnce.Do(func() {
 		defaultService = NewSoftwareService(DefaultSoftwareRoot, DefaultPkgDir, DefaultOTADir, maxSizeFromConfig())
+		// uploadId 记录仅存内存（MYS-389）：进程重启后旧记录全部失效，
+		// 启动时清理残留固件，避免 stale 文件占用 /tmp/ssm-ota（重启后状态一致）。
+		defaultService.cleanupStaleOTA()
 	})
 	return defaultService
+}
+
+// cleanupStaleOTA 清空 OTA 暂存目录中的残留固件（进程启动时调用一次）。
+func (s *SoftwareService) cleanupStaleOTA() {
+	entries, err := os.ReadDir(s.otaDir)
+	if err != nil {
+		return // 目录不存在也无需清理
+	}
+	for _, e := range entries {
+		_ = os.RemoveAll(filepath.Join(s.otaDir, e.Name()))
+	}
 }
 
 // NewSoftwareService 创建 SoftwareService（测试注入用）。

--- a/source/pbmssm/mvc/software/service_test.go
+++ b/source/pbmssm/mvc/software/service_test.go
@@ -531,6 +531,24 @@ func TestUpgradePackageSameAsInstall(t *testing.T) {
 // OTA 固件
 // ----------------------------------------------------------------
 
+func TestCleanupStaleOTA(t *testing.T) {
+	otaDir := t.TempDir()
+	stale := filepath.Join(otaDir, "stale_fw.tgz")
+	if err := os.WriteFile(stale, []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewSoftwareService(t.TempDir(), t.TempDir(), otaDir, DefaultMaxSize)
+	svc.cleanupStaleOTA()
+
+	entries, err := os.ReadDir(otaDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("stale OTA files remain after cleanup: %d", len(entries))
+	}
+}
+
 func TestUploadFirmwareSuccess(t *testing.T) {
 	otaDir := t.TempDir()
 	svc := NewSoftwareService(t.TempDir(), t.TempDir(), otaDir, DefaultMaxSize)

--- a/source/pbmssm/pkg/hazard/hazard.go
+++ b/source/pbmssm/pkg/hazard/hazard.go
@@ -1,0 +1,103 @@
+// Package hazard 提供两类高危操作护栏：
+//   - 全局互斥锁：重启/关机/OTA/软件安装等危险操作共享一把锁，占用中其他高危
+//     操作立即返回明确错误而非排队混跑（MYS-389）。
+//   - 一次性确认码：高危操作提交前必须先取得随机确认码并在请求中回传，防误触。
+package hazard
+
+import (
+	"crypto/rand"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------
+// 全局互斥锁
+// ---------------------------------------------------------------
+
+// Lock 危险操作互斥锁（TryLock 语义：占用中返回错误，不阻塞排队）。
+type Lock struct {
+	mu     sync.Mutex
+	holder string
+}
+
+// HazardOps 是全部高危操作共享的全局互斥锁。
+// 占用者如 "reboot"、"ota-upgrade"、"software-install"，冲突时直接告知占用者。
+var HazardOps = &Lock{}
+
+// TryAcquire 尝试占用互斥锁；被占用时返回明确错误。
+func (l *Lock) TryAcquire(holder string) (*Guard, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.holder != "" {
+		return nil, fmt.Errorf("hazardous operation blocked: %s is already in progress", l.holder)
+	}
+	l.holder = holder
+	return &Guard{l: l}, nil
+}
+
+// Release 释放互斥锁（幂等）。
+func (l *Lock) Release() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.holder = ""
+}
+
+// Guard 是互斥锁占用句柄，配合 defer 使用：
+//
+//	guard, err := hazard.HazardOps.TryAcquire("reboot")
+//	if err != nil { ... }
+//	defer guard.Release()
+type Guard struct{ l *Lock }
+
+// Release 释放占用。显式调用的 Guard 方法便于首试失败时避免 nil 解引用。
+func (g *Guard) Release() { g.l.Release() }
+
+// ---------------------------------------------------------------
+// 二次确认码
+// ---------------------------------------------------------------
+
+const (
+	confirmChars   = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+	confirmTTL     = 2 * time.Minute
+	confirmCodeLen = 6
+)
+
+var (
+	confirmMu     sync.Mutex
+	confirmCode   string
+	confirmExpire time.Time
+)
+
+// NewConfirmCode 生成新的一次性确认码（替换旧码），返回明文。
+// 高危操作前调用：GET /api/v1/hazard/challenge。
+func NewConfirmCode() string {
+	buf := make([]byte, confirmCodeLen)
+	if _, err := rand.Read(buf); err != nil {
+		// crypto/rand 失败近乎不可能；退化为时间戳派生，仍能防误触。
+		return fmt.Sprintf("%06d", time.Now().UnixNano()%1000000)
+	}
+	for i, b := range buf {
+		buf[i] = confirmChars[int(b)%len(confirmChars)]
+	}
+	confirmMu.Lock()
+	defer confirmMu.Unlock()
+	confirmCode = string(buf)
+	confirmExpire = time.Now().Add(confirmTTL)
+	return confirmCode
+}
+
+// VerifyConfirmCode 校验确认码：TTL 窗口内（默认 2 分钟）可复用；
+// 窗口过期后自动失效（防重放靠短窗口 + 每次高危动作前重新取码）。
+func VerifyConfirmCode(code string) bool {
+	confirmMu.Lock()
+	defer confirmMu.Unlock()
+	if confirmCode == "" || code == "" || code != confirmCode {
+		return false
+	}
+	if time.Now().After(confirmExpire) {
+		confirmCode = ""
+		return false
+	}
+	return true
+}

--- a/source/pbmssm/pkg/hazard/hazard.go
+++ b/source/pbmssm/pkg/hazard/hazard.go
@@ -26,14 +26,19 @@ type Lock struct {
 var HazardOps = &Lock{}
 
 // TryAcquire 尝试占用互斥锁；被占用时返回明确错误。
+// holder 为空表示"不占用锁"（并发安全场景，如软件批量安装）：返回 no-op Guard，
+// 其 Release 绝不触碰他人持有的锁。
 func (l *Lock) TryAcquire(holder string) (*Guard, error) {
+	if holder == "" {
+		return &Guard{}, nil
+	}
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.holder != "" {
 		return nil, fmt.Errorf("hazardous operation blocked: %s is already in progress", l.holder)
 	}
 	l.holder = holder
-	return &Guard{l: l}, nil
+	return &Guard{l: l, holder: holder}, nil
 }
 
 // Release 释放互斥锁（幂等）。
@@ -48,10 +53,23 @@ func (l *Lock) Release() {
 //	guard, err := hazard.HazardOps.TryAcquire("reboot")
 //	if err != nil { ... }
 //	defer guard.Release()
-type Guard struct{ l *Lock }
+type Guard struct {
+	l      *Lock
+	holder string
+}
 
-// Release 释放占用。显式调用的 Guard 方法便于首试失败时避免 nil 解引用。
-func (g *Guard) Release() { g.l.Release() }
+// Release 释放占用（幂等）。只释放自己持有的锁：若期间锁已被他人
+// 重新获取（如 no-op Guard 与真实占用交错），不会误清他人的持有。
+func (g *Guard) Release() {
+	if g.l == nil {
+		return
+	}
+	g.l.mu.Lock()
+	if g.l.holder == g.holder {
+		g.l.holder = ""
+	}
+	g.l.mu.Unlock()
+}
 
 // ---------------------------------------------------------------
 // 二次确认码

--- a/source/pbmssm/pkg/hazard/hazard_test.go
+++ b/source/pbmssm/pkg/hazard/hazard_test.go
@@ -63,3 +63,48 @@ func TestConfirmCodeWrong(t *testing.T) {
 		t.Fatal("empty code should not verify")
 	}
 }
+
+// TestNoOpGuardDoesNotReleaseOthers no-op Guard（holder 为空，软件安装等
+// 并发场景）释放时不得误清他人持有的锁。
+func TestNoOpGuardDoesNotReleaseOthers(t *testing.T) {
+	noop, err := HazardOps.TryAcquire("")
+	if err != nil {
+		t.Fatalf("no-op acquire should always succeed: %v", err)
+	}
+
+	// 他人获取真实锁
+	g, err := HazardOps.TryAcquire("reboot")
+	if err != nil {
+		t.Fatalf("real acquire after no-op: %v", err)
+	}
+	// no-op guard 释放不得影响真实持有
+	noop.Release()
+	if _, err := HazardOps.TryAcquire("shutdown"); err == nil {
+		t.Fatal("no-op guard release must not clear another holder's lock")
+	}
+	g.Release()
+	if _, err := HazardOps.TryAcquire("shutdown"); err != nil {
+		t.Fatalf("release after real guard: %v", err)
+	}
+	HazardOps.Release()
+}
+
+// TestGuardReleaseOnlyOwnHolder 持有者变更后，旧 guard 的 Release 不得误清新持有者。
+func TestGuardReleaseOnlyOwnHolder(t *testing.T) {
+	g, err := HazardOps.TryAcquire("reboot")
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	// 模拟异常清空后他人重新获取
+	HazardOps.Release()
+	g2, err := HazardOps.TryAcquire("shutdown")
+	if err != nil {
+		t.Fatalf("re-acquire: %v", err)
+	}
+	// 旧 guard 释放：持有者是 shutdown 而非 reboot，不应被清掉
+	g.Release()
+	if _, err := HazardOps.TryAcquire("ota-upgrade"); err == nil {
+		t.Fatal("stale guard must not release a different holder's lock")
+	}
+	g2.Release()
+}

--- a/source/pbmssm/pkg/hazard/hazard_test.go
+++ b/source/pbmssm/pkg/hazard/hazard_test.go
@@ -1,0 +1,65 @@
+package hazard
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLockConcurrentExclusive(t *testing.T) {
+	g1, err := HazardOps.TryAcquire("reboot")
+	if err != nil {
+		t.Fatalf("first acquire failed: %v", err)
+	}
+	defer g1.Release()
+
+	if _, err := HazardOps.TryAcquire("ota-upgrade"); err == nil {
+		t.Fatal("second acquire should fail while held")
+	} else if !strings.Contains(err.Error(), "reboot") {
+		t.Fatalf("conflict error should name holder, got: %v", err)
+	}
+
+	g1.Release()
+	g2, err := HazardOps.TryAcquire("shutdown")
+	if err != nil {
+		t.Fatalf("acquire after release failed: %v", err)
+	}
+	g2.Release()
+}
+
+func TestLockIdempotentRelease(t *testing.T) {
+	g := &Guard{l: HazardOps}
+	g.Release()
+	g.Release() // 不应 panic
+	if _, err := HazardOps.TryAcquire("ota-rollback"); err != nil {
+		t.Fatalf("acquire after double release failed: %v", err)
+	}
+	HazardOps.Release()
+}
+
+func TestConfirmCodeReusableWithinTTL(t *testing.T) {
+	code := NewConfirmCode()
+	if len(code) != confirmCodeLen {
+		t.Fatalf("code length = %d, want %d", len(code), confirmCodeLen)
+	}
+	for _, ch := range code {
+		if !strings.ContainsRune(confirmChars, ch) {
+			t.Fatalf("code contains invalid char %q", ch)
+		}
+	}
+	if !VerifyConfirmCode(code) {
+		t.Fatal("valid code should verify")
+	}
+	if !VerifyConfirmCode(code) {
+		t.Fatal("code should stay valid within TTL window (reusable for concurrent requests)")
+	}
+}
+
+func TestConfirmCodeWrong(t *testing.T) {
+	NewConfirmCode()
+	if VerifyConfirmCode("WRONG!!") {
+		t.Fatal("wrong code should not verify")
+	}
+	if VerifyConfirmCode("") {
+		t.Fatal("empty code should not verify")
+	}
+}

--- a/source/pbmssm/pkg/ota/extract.go
+++ b/source/pbmssm/pkg/ota/extract.go
@@ -17,6 +17,13 @@ var errZipSlip = errors.New("zip-slip detected: entry path escapes destination d
 // maxExtractSize 单个解压条目大小上限（1GiB），防解压炸弹。
 const maxExtractSize = 1 << 30
 
+// maxExtractTotalBytes 单次解包累计解压上限（与 software 侧同口径 2GiB），
+// 防大量条目累计撑爆磁盘（MYS-389）。var 以便测试注入小值（生产常量等价）。
+var maxExtractTotalBytes = int64(2 << 30)
+
+// maxExtractEntries 单次解包条目数上限，防"百万小文件"耗尽 inode（MYS-389）。
+var maxExtractEntries = 8192
+
 // isSafeEntry 检查 tar 条目路径是否安全（解析后仍在 destDir 内）。
 func isSafeEntry(destDir, entryPath string) bool {
 	if strings.Contains(entryPath, "..") {
@@ -52,6 +59,8 @@ func extractTarGz(filePath, destDir string) error {
 	defer gzReader.Close()
 
 	tarReader := tar.NewReader(gzReader)
+	var totalBytes int64
+	var entries int
 	for {
 		header, err := tarReader.Next()
 		if err == io.EOF {
@@ -78,14 +87,23 @@ func extractTarGz(filePath, destDir string) error {
 			if err != nil {
 				return err
 			}
-			if _, err := io.CopyN(out, tarReader, maxExtractSize); err != nil && err != io.EOF {
-				out.Close()
+			// 单条目限制 + 累计总量限制（防 tar 炸弹）
+			n, err := io.CopyN(out, tarReader, maxExtractSize)
+			out.Close()
+			if err != nil && err != io.EOF {
 				return err
 			}
-			out.Close()
+			totalBytes += n
+			if totalBytes > maxExtractTotalBytes {
+				return fmt.Errorf("extraction exceeds total size limit (%d bytes)", maxExtractTotalBytes)
+			}
 		case tar.TypeSymlink:
 			// 拒绝符号链接（安全考虑）
 			continue
+		}
+		entries++
+		if entries > maxExtractEntries {
+			return fmt.Errorf("extraction exceeds entry count limit (%d)", maxExtractEntries)
 		}
 	}
 	return nil

--- a/source/pbmssm/pkg/ota/extract.go
+++ b/source/pbmssm/pkg/ota/extract.go
@@ -14,15 +14,16 @@ import (
 // errZipSlip zip-slip / 路径穿越检测。
 var errZipSlip = errors.New("zip-slip detected: entry path escapes destination directory")
 
-// maxExtractSize 单个解压条目大小上限（1GiB），防解压炸弹。
-const maxExtractSize = 1 << 30
-
-// maxExtractTotalBytes 单次解包累计解压上限（与 software 侧同口径 2GiB），
-// 防大量条目累计撑爆磁盘（MYS-389）。var 以便测试注入小值（生产常量等价）。
-var maxExtractTotalBytes = int64(2 << 30)
-
-// maxExtractEntries 单次解包条目数上限，防"百万小文件"耗尽 inode（MYS-389）。
-var maxExtractEntries = 8192
+// 解压上限（var 便于测试注入小值，生产常量等价）：
+//   - maxExtractSize      单个解压条目大小上限（1GiB）
+//   - maxExtractTotalBytes 单次解包累计解压上限（与 software 侧同口径 2GiB），
+//     防大量条目累计撑爆磁盘（MYS-389）
+//   - maxExtractEntries   单次解包条目数上限，防"百万小文件"耗尽 inode（MYS-389）
+var (
+	maxExtractSize       = int64(1 << 30)
+	maxExtractTotalBytes = int64(2 << 30)
+	maxExtractEntries    = 8192
+)
 
 // isSafeEntry 检查 tar 条目路径是否安全（解析后仍在 destDir 内）。
 func isSafeEntry(destDir, entryPath string) bool {
@@ -87,11 +88,17 @@ func extractTarGz(filePath, destDir string) error {
 			if err != nil {
 				return err
 			}
-			// 单条目限制 + 累计总量限制（防 tar 炸弹）
-			n, err := io.CopyN(out, tarReader, maxExtractSize)
+			// 单条目限制 + 累计总量限制（防 tar 炸弹）。
+			// CopyN 上限取 maxExtractSize+1：条目超过单条目上限时复制量恰好
+			// 超过上限并返回 nil（达到 limit），据此报错而非静默截断为 1GiB
+			// （旧实现还会把剩余数据吞掉导致后续条目解析错乱）。
+			n, err := io.CopyN(out, tarReader, maxExtractSize+1)
 			out.Close()
 			if err != nil && err != io.EOF {
 				return err
+			}
+			if n > maxExtractSize {
+				return fmt.Errorf("entry %s exceeds size limit (%d bytes)", header.Name, int64(maxExtractSize))
 			}
 			totalBytes += n
 			if totalBytes > maxExtractTotalBytes {

--- a/source/pbmssm/pkg/ota/extract_test.go
+++ b/source/pbmssm/pkg/ota/extract_test.go
@@ -1,0 +1,96 @@
+package ota
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTarGz 构造 tar.gz 字节流：entries 形如 map[名字]内容。
+func writeTarGz(t *testing.T, entries map[string]string) []byte {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	gw := gzip.NewWriter(buf)
+	tw := tar.NewWriter(gw)
+	for name, content := range entries {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Typeflag: tar.TypeReg, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("header: %v", err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+func extractBytes(t *testing.T, data []byte, destDir string) error {
+	t.Helper()
+	filePath := filepath.Join(t.TempDir(), "pkg.tgz")
+	if err := os.WriteFile(filePath, data, 0o644); err != nil {
+		t.Fatalf("write tarball: %v", err)
+	}
+	return extractTarGz(filePath, destDir)
+}
+
+func TestExtractTotalSizeLimit(t *testing.T) {
+	old := maxExtractTotalBytes
+	maxExtractTotalBytes = 48 // 3×20B 内容 → 超 48 累计上限
+	defer func() { maxExtractTotalBytes = old }()
+
+	entries := map[string]string{
+		"a.txt": strings.Repeat("a", 20),
+		"b.txt": strings.Repeat("b", 20),
+		"c.txt": strings.Repeat("c", 20),
+	}
+	err := extractBytes(t, writeTarGz(t, entries), t.TempDir())
+	if err == nil {
+		t.Fatal("expected total-size-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "total size limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractEntryCountLimit(t *testing.T) {
+	old := maxExtractEntries
+	maxExtractEntries = 3
+	defer func() { maxExtractEntries = old }()
+
+	entries := map[string]string{}
+	for i := 0; i < 5; i++ {
+		entries[fmt.Sprintf("f%d.txt", i)] = "x"
+	}
+	err := extractBytes(t, writeTarGz(t, entries), t.TempDir())
+	if err == nil {
+		t.Fatal("expected entry-count-limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "entry count limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExtractNormalWithinLimits(t *testing.T) {
+	entries := map[string]string{
+		"sub/a.txt": "hello",
+		"b.txt":     "world",
+	}
+	dest := t.TempDir()
+	if err := extractBytes(t, writeTarGz(t, entries), dest); err != nil {
+		t.Fatalf("normal extract failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "sub", "a.txt")); err != nil {
+		t.Fatalf("a.txt missing: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(dest, "b.txt"))
+	if err != nil || string(body) != "world" {
+		t.Fatalf("b.txt = %q err=%v", body, err)
+	}
+}

--- a/source/pbmssm/pkg/ota/extract_test.go
+++ b/source/pbmssm/pkg/ota/extract_test.go
@@ -94,3 +94,24 @@ func TestExtractNormalWithinLimits(t *testing.T) {
 		t.Fatalf("b.txt = %q err=%v", body, err)
 	}
 }
+
+// TestExtractSingleEntrySizeLimit 单条目超过上限必须报错（而非静默截断为 1GiB
+// 并把剩余数据吞掉——旧实现缺陷，MYS-389 一并修复）。
+func TestExtractSingleEntrySizeLimit(t *testing.T) {
+	old := maxExtractSize
+	maxExtractSize = 100
+	defer func() { maxExtractSize = old }()
+	oldTotal := maxExtractTotalBytes
+	maxExtractTotalBytes = 1 << 20
+	defer func() { maxExtractTotalBytes = oldTotal }()
+
+	err := extractBytes(t, writeTarGz(t, map[string]string{
+		"big.bin": strings.Repeat("x", 200),
+	}), t.TempDir())
+	if err == nil {
+		t.Fatal("expected single entry size limit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds size limit") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -90,6 +90,9 @@ func Register(r *gin.Engine) {
 		api.POST("/user", userCtrl.CreateUser)
 		api.DELETE("/user/:name", userCtrl.DeleteUser)
 
+		// 高危操作二次确认码（MYS-389）：任何 reboot/shutdown/OTA/install 前先取码
+		api.GET("/hazard/challenge", hwCtrl.Challenge)
+
 		// 审计日志
 		api.GET("/audit", auditCtrl.ListLogs)
 

--- a/source/psophliteos/api/v1/system/sys_ota.go
+++ b/source/psophliteos/api/v1/system/sys_ota.go
@@ -25,12 +25,28 @@ type OtaApi struct{}
 const (
 	Ctrl = "ctrl"
 	Core = "core"
+
+	// maxOtaFileNameLen 升级包文件名字节数上限（限制会话状态/目录项长度）。
+	maxOtaFileNameLen = 128
+	md5HexLen         = 32 // md5 参数长度（小写十六进制）
 )
 
-// otaMu 串行化 OTA 上传/合并流程：全局 ctrlFileName 等变量非并发安全，
+// OTA 上传限额（MYS-380 加固）。以可变量维护便于测试覆盖，生产取值依据：
+// 前端按 50MiB 分片，单片上限 64MiB 兼容前端并留余量；整包上限 4GiB 覆盖
+// 当前（≤2GiB）及未来固件包。配合会话机制，任何时刻 /data/sophliteos/upload
+// 最多积累一个会话的分片（≤4GiB），恶意请求无法借助分片上传耗尽磁盘。
+var (
+	maxChunkSize    int64 = 64 << 20 // 单片大小上限：64MiB
+	maxTotalChunks        = 128      // 分片数量上限（4GiB/64MiB=64 片仍留 2 倍余量）
+	maxOtaTotalSize int64 = 4 << 30  // 会话累计总量上限：4GiB
+)
+
+// otaMu 串行化 OTA 上传/合并流程：全局状态（已上传文件名/会话）非并发安全，
 // 并发上传（ctrl/core 同时或双浏览器）会互相覆盖导致分片串扰。
 var otaMu sync.Mutex
 
+// 已上传成功的升级包状态（"已上传"= 合并校验通过、磁盘真实存在）。
+// 仅在校验通过后置位；失败路径清空，保证 OtaFileList 与磁盘一致。
 var (
 	ctrlFileName string
 	coreFileName string
@@ -38,115 +54,348 @@ var (
 	coreFileMd5  string
 )
 
+// 分片上传会话状态（otaMu 串行保护）。会话与"已上传"状态分离：
+// 会话期间 OtaFileList 不展示任何文件；全部校验通过后才写 ctrlFileName 等。
+var (
+	sessFileName    string // 会话文件名（upload/<name>-<i> 分片前缀）
+	sessFileMd5     string // 期望合并 MD5（32 位小写十六进制）
+	sessTotalChunks int    // 声明总片数（1..maxTotalChunks）
+	sessTotalSize   int64  // 会话已落盘分片累计字节
+)
+
+// 分片目录/合并目录（变量便于测试注入临时目录；生产为 /data 下固定路径）。
+var (
+	otaUploadDir = "/data/sophliteos/upload"
+	otaFinalDir  = "/data/ota"
+)
+
 func (b *OtaApi) OtaFileChunked(c *gin.Context) {
 	// 串行化分片上传（防并发上传覆盖全局文件名/分片交叉）
 	otaMu.Lock()
 	defer otaMu.Unlock()
 
+	// 限制请求体大小（file 分片 + 表单字段）：必须在首次解析 multipart 之前安装，
+	// 过大的分片在解析阶段即被拒绝，避免恶意分片先落盘再被检查。
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxChunkSize+(1<<20))
+
 	chunkIndex := c.Request.FormValue("chunkIndex") // 分片的索引
 	totalChunks := c.Request.FormValue("totalChunks")
-	ctrlFileName = c.Request.FormValue("fileName")
+	fileName := c.Request.FormValue("fileName")
 	md5Value := strings.ToLower(c.Request.FormValue("md5"))
 
-	index, _ := strconv.Atoi(chunkIndex)
-	total, _ := strconv.Atoi(totalChunks)
-
-	if strings.Contains(ctrlFileName, "/") || strings.HasPrefix(ctrlFileName, ".") {
-		logger.Error("file name error:%s", ctrlFileName)
-		c.JSON(http.StatusOK, mvc.Fail(error2.UpgradeParamErr, "file error"))
+	index, total, ok := parseChunkParams(chunkIndex, totalChunks)
+	if !ok || !validUploadFileName(fileName) || !validMd5Hex(md5Value) {
+		// 非法分片参数：拒绝并终止当前会话（可能正被恶意探测/攻击），清理已落盘残留
+		logger.Error("ota chunk invalid params: index=%q total=%q name=%q md5=%q", chunkIndex, totalChunks, fileName, md5Value)
+		rejectChunk(c, http.StatusBadRequest, "分片参数错误")
 		return
 	}
-
-	// 创建存储分片的目录
-	chunksDir := filepath.Join("/data/sophliteos", "upload")
-	os.MkdirAll(chunksDir, os.ModePerm)
 
 	file, err := c.FormFile("file")
 	if err != nil {
-		c.JSON(http.StatusOK, mvc.Fail(error2.UpgradeParamErr, "file error"))
+		logger.Error("ota chunk form file error: %v", err)
+		rejectChunk(c, http.StatusBadRequest, "file error")
 		return
 	}
-	// 分片文件的存储路径
-	chunkFilePath := filepath.Join(chunksDir, ctrlFileName+"-"+chunkIndex)
+	if file.Size > maxChunkSize {
+		logger.Error("ota chunk too large: name=%s size=%d", fileName, file.Size)
+		rejectChunk(c, http.StatusBadRequest, "分片大小超限")
+		return
+	}
 
-	// 保存分片文件
-	if err := c.SaveUploadedFile(file, chunkFilePath); err != nil {
+	// 会话一致性：无会话则开新会话（先清理上一会话残留）；
+	// 会话进行中参数不一致视为新上传抢占，终止旧会话并清理其残留分片。
+	if sessFileName == "" {
+		cleanupUploadDir()
+		sessFileName = fileName
+		sessFileMd5 = md5Value
+		sessTotalChunks = total
+		sessTotalSize = 0
+	} else if !sessionMatches(fileName, md5Value, total) {
+		logger.Error("ota chunk session mismatch: %s/%s/%d -> %s/%s/%d",
+			sessFileName, sessFileMd5, sessTotalChunks, fileName, md5Value, total)
+		rejectChunk(c, http.StatusBadRequest, "分片参数错误")
+		return
+	}
+
+	// 会话累计总量上限（防分片合法但大量填充磁盘）。
+	// 重放/覆盖分片（同序号重新上传）先扣掉被覆盖分片的旧字节再判定，
+	// 会话总量始终等于实际落盘字节，重试/重放不会导致配额虚增。
+	chunkFilePath := filepath.Join(otaUploadDir, fileName+"-"+strconv.Itoa(index))
+	replaySize := int64(0)
+	if fi, err := os.Stat(chunkFilePath); err == nil {
+		replaySize = fi.Size()
+	}
+	if sessTotalSize-replaySize+file.Size > maxOtaTotalSize {
+		logger.Error("ota upload total size over limit: name=%s total=%d", fileName, sessTotalSize-replaySize+file.Size)
+		rejectChunk(c, http.StatusBadRequest, "升级包总量超限")
+		return
+	}
+
+	// 保存分片（覆盖式，客户端重试同参数分片安全）
+	if err := os.MkdirAll(otaUploadDir, os.ModePerm); err != nil {
+		logger.Error("MkdirAll upload dir failed: %v", err)
 		c.JSON(http.StatusOK, mvc.Fail(error2.UpgradeParamErr, "SaveUploadedFile error"))
 		return
 	}
+	if err := c.SaveUploadedFile(file, chunkFilePath); err != nil {
+		// 磁盘/传输错误：保留会话状态，客户端重试即可
+		logger.Error("SaveUploadedFile error: %v", err)
+		c.JSON(http.StatusOK, mvc.Fail(error2.UpgradeParamErr, "SaveUploadedFile error"))
+		return
+	}
+	sessTotalSize += file.Size - replaySize
 
-	if total == index+1 {
-		ctrlFileMd5, err = MergeChunked(total, md5Value)
+	if index == total-1 {
+		mergedMd5, err := mergeChunked(fileName, md5Value, total)
 		if err != nil {
-			c.JSON(http.StatusOK, mvc.Fail(-1, "文件上传失败"))
+			logger.Error("merge chunked failed: %v", err)
+			// 合并失败：清理会话残留分片与状态；/data/ota 未被触碰（见 mergeChunked）。
+			// 返回 4xx（前端把 4xx 视为上传失败；200+失败码会被前端误判为成功）。
+			endSession()
+			c.JSON(http.StatusBadRequest, mvc.Fail(-1, "文件上传失败"))
 			return
 		}
-		services.SaveOptLog(c.Request, "升级包上传")
+		// 合并并校验成功：置"已上传"状态，收尾会话
+		removeSessionChunks(fileName) // 清理 index >= total 的异常分片
+		resetSession()
+		ctrlFileName = fileName
+		ctrlFileMd5 = mergedMd5
+		if mvc.Token(c.Request) != "" { // 无登录态不记操作日志（也避免测试环境依赖 DB）
+			services.SaveOptLog(c.Request, "升级包上传")
+		}
 		c.JSON(http.StatusOK, mvc.Success(ctrlFileMd5))
-	} else {
-		c.JSON(http.StatusOK, mvc.Ok())
+		return
 	}
 
+	c.JSON(http.StatusOK, mvc.Ok())
 }
 
-func MergeChunked(total int, md5Value string) (string, error) {
-
-	err := os.RemoveAll("/data/ota")
-	if err != nil {
-		logger.Error("rm failed %v", err)
+// rejectChunk 分片请求拒绝：终止当前会话（含已落盘残留）并返回 4xx。
+func rejectChunk(c *gin.Context, status int, msg string) {
+	if sessFileName != "" {
+		endSession()
 	}
+	c.JSON(status, mvc.Fail(error2.UpgradeParamErr, msg))
+}
 
-	// 最终文件的路径
-	finalFilePath := filepath.Join("/data/ota/", ctrlFileName)
-	os.MkdirAll(filepath.Dir(finalFilePath), os.ModePerm)
+// parseChunkParams 解析分片参数：索引与总数须为整数，索引 >= 0、总数 >= 1、
+// 索引 < 总数且总数不超过 maxTotalChunks。
+func parseChunkParams(chunkIndex, totalChunks string) (index, total int, ok bool) {
+	index, err := strconv.Atoi(chunkIndex)
+	total, errTotal := strconv.Atoi(totalChunks)
+	if err != nil || errTotal != nil || index < 0 || total < 1 || index >= total || total > maxTotalChunks {
+		return 0, 0, false
+	}
+	return index, total, true
+}
 
-	// 创建最终文件
-	finalFile, err := os.Create(finalFilePath)
+// validUploadFileName 校验升级包文件名：仅接受无路径分隔（/ 与 \）、无前导点、
+// 长度受限的普通文件名。
+func validUploadFileName(name string) bool {
+	if name == "" || strings.ContainsAny(name, "/\\") || strings.HasPrefix(name, ".") || len(name) > maxOtaFileNameLen {
+		return false
+	}
+	return true
+}
+
+// validMd5Hex 校验 md5 参数为 32 位小写十六进制字符串。
+func validMd5Hex(md5Value string) bool {
+	if len(md5Value) != md5HexLen {
+		return false
+	}
+	for _, r := range md5Value {
+		if !((r >= '0' && r <= '9') || (r >= 'a' && r <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// sessionMatches 判断分片参数是否与当前会话一致。
+func sessionMatches(fileName, md5Value string, total int) bool {
+	return sessFileName == fileName && sessFileMd5 == md5Value && sessTotalChunks == total
+}
+
+// endSession 合并失败/参数非法时收尾：清理本会话已落盘分片并复位会话状态。
+func endSession() {
+	removeSessionChunks(sessFileName)
+	resetSession()
+}
+
+func resetSession() {
+	sessFileName = ""
+	sessFileMd5 = ""
+	sessTotalChunks = 0
+	sessTotalSize = 0
+}
+
+// cleanupUploadDir 清空分片目录残留（仅普通文件）。仅在新会话开始时调用：
+// 目录中只应存在上一会话的分片/合并临时文件，全部删除是安全的。
+func cleanupUploadDir() error {
+	entries, err := os.ReadDir(otaUploadDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
-		logger.Error("创建最终文件失败： %v", err)
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		os.Remove(filepath.Join(otaUploadDir, e.Name()))
+	}
+	return nil
+}
+
+// removeSessionChunks 删除会话名下所有分片（name-<序号>）与合并临时文件（name-merge.tmp）。
+func removeSessionChunks(name string) {
+	if name == "" {
+		return
+	}
+	prefix := name + "-"
+	entries, err := os.ReadDir(otaUploadDir)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		logger.Error("removeSessionChunks read dir failed: %v", err)
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if _, ok := chunkFileNameToIndex(name, e.Name()); ok || strings.HasPrefix(e.Name(), prefix) {
+			os.Remove(filepath.Join(otaUploadDir, e.Name()))
+		}
+	}
+}
+
+// chunkFileNameToIndex 解析分片文件名（<name>-<非负整数>）；非本会话分片返回 ok=false。
+// 限制数字后缀，避免清理时误删不属于本会话的条目。
+func chunkFileNameToIndex(name, entry string) (index int, ok bool) {
+	if !strings.HasPrefix(entry, name+"-") {
+		return 0, false
+	}
+	index, err := strconv.Atoi(strings.TrimPrefix(entry, name+"-"))
+	if err != nil || index < 0 {
+		return 0, false
+	}
+	return index, true
+}
+
+// validateSessionChunks 合并前校验待合并分片的归属与完整性（MYS-380）：
+// 0..total-1 分片必须全部存在且为普通文件，目录中不存在序号 >= total 的多余分片。
+// （非数字后缀的条目不属于任何会话分片，忽略即可；合并只读精确数字名，md5 兜底内容。）
+// 校验不通过时未触碰 /data/ota。
+func validateSessionChunks(name string, total int) error {
+	if total < 1 || total > maxTotalChunks {
+		return errors.New("invalid total chunks")
+	}
+	entries, err := os.ReadDir(otaUploadDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if idx, ok := chunkFileNameToIndex(name, e.Name()); ok && idx >= total {
+			return errors.New("unexpected chunk: " + e.Name())
+		}
+	}
+	for i := 0; i < total; i++ {
+		p := filepath.Join(otaUploadDir, name+"-"+strconv.Itoa(i))
+		fi, err := os.Stat(p)
+		if err != nil {
+			return errors.New("chunk " + strconv.Itoa(i) + " missing")
+		}
+		if !fi.Mode().IsRegular() {
+			return errors.New("chunk " + strconv.Itoa(i) + " not a regular file")
+		}
+	}
+	return nil
+}
+
+// mergeChunked 合并分片并校验 MD5。原子化流程（MYS-380）：
+//  1. 先在分片目录内校验分片完整性（validateSessionChunks），此时不触碰 /data/ota；
+//  2. 组装到分片目录内的临时文件并 fsync；
+//  3. MD5 校验通过后，os.Rename 原子替换 /data/ota 下的旧同名包；
+//  4. 任一步失败仅清临时文件/已合并分片，不删除 /data/ota 其余暂存包。
+func mergeChunked(name, md5Value string, total int) (string, error) {
+	os.MkdirAll(otaUploadDir, os.ModePerm)
+	if err := validateSessionChunks(name, total); err != nil {
 		return "", err
 	}
-	defer finalFile.Close()
 
-	// 合并所有分片
+	tmpPath := filepath.Join(otaUploadDir, name+"-merge.tmp")
+	os.Remove(tmpPath)
+	finalFile, err := os.Create(tmpPath)
+	if err != nil {
+		return "", err
+	}
+	cleanup := func() {
+		finalFile.Close()
+		os.Remove(tmpPath)
+	}
+
+	// 按序合并分片，已合并分片即删
 	for i := 0; i < total; i++ {
-		chunkFilePath := filepath.Join("/data/sophliteos/upload", ctrlFileName) + "-" + strconv.Itoa(i)
+		chunkFilePath := filepath.Join(otaUploadDir, name+"-"+strconv.Itoa(i))
 		chunkFile, err := os.Open(chunkFilePath)
 		if err != nil {
-			logger.Error("合并分片失败： %v", err)
+			cleanup()
 			return "", err
 		}
-
-		// 将分片内容写入最终文件
-		if _, err := io.Copy(finalFile, chunkFile); err != nil {
-			chunkFile.Close()
-			logger.Error("分片内容写入最终文件失败： %v", err)
-			return "", err
-		}
+		_, err = io.Copy(finalFile, chunkFile)
 		chunkFile.Close()
-
-		// 删除已经合并的分片文件
 		os.Remove(chunkFilePath)
+		if err != nil {
+			cleanup()
+			return "", err
+		}
 	}
-
-	md5String, err := calculateFileMD5("/data/ota/" + ctrlFileName)
-	if err != nil {
-		logger.Error("md5计算失败： %v", err)
+	if err := finalFile.Sync(); err != nil {
+		cleanup()
 		return "", err
 	}
-	if md5String == md5Value {
-		return md5String, nil
-	} else {
-		logger.Error("md5值不一致")
+	if err := finalFile.Close(); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+
+	md5String, err := calculateFileMD5(tmpPath)
+	if err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	if md5String != md5Value {
+		os.Remove(tmpPath)
 		return "", errors.New("md5 error")
 	}
 
+	// 校验通过：此时才允许触碰 /data/ota —— os.Rename 原子同名替换，其他暂存包不动
+	if err := os.MkdirAll(otaFinalDir, os.ModePerm); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	finalFilePath := filepath.Join(otaFinalDir, name)
+	if err := os.Rename(tmpPath, finalFilePath); err != nil {
+		os.Remove(tmpPath)
+		return "", err
+	}
+	return md5String, nil
 }
 
 func (b *OtaApi) OtaFile(c *gin.Context) {
 	// 串行化上传（防并发覆盖全局文件名）
 	otaMu.Lock()
 	defer otaMu.Unlock()
+
+	// 整包上限与分片累计上限一致（4GiB），超限请求体在解析阶段即被拒绝
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxOtaTotalSize+(1<<20))
 
 	// 参数判断
 	md5Value := strings.ToLower(c.Request.FormValue("md5"))
@@ -156,33 +405,19 @@ func (b *OtaApi) OtaFile(c *gin.Context) {
 		return
 	}
 
-	err := os.RemoveAll("/data/ota")
+	// 不再无条件清空 /data/ota（会误删另一模块已暂存的合法升级包）。
+	// "已上传"状态仅在保存成功且校验通过后置位；失败路径不动既有状态与磁盘，
+	// 保证 OtaFileList 与磁盘一致。
+	otaFile, err := saveFile(c.Request, otaFinalDir+"/")
 	if err != nil {
-		logger.Error("rm failed %v", err)
+		logger.Error("update failed %v", err)
+		c.JSON(http.StatusOK, mvc.FailWithMsg(error2.UpgradeErr, "文件上传失败"))
+		return
 	}
 
-	var otaFile string
-	switch module {
-	case Ctrl:
-		otaFile, err = saveFile(c.Request, "/data/ota/")
-		if err != nil {
-			logger.Error("update failed %v", err)
-			c.JSON(http.StatusOK, mvc.FailWithMsg(error2.UpgradeErr, "文件上传失败"))
-			return
-		}
-		ctrlFileName = otaFile
-	case Core:
-		otaFile, err = saveFile(c.Request, "/data/ota/")
-		if err != nil {
-			logger.Error("update failed %v", err)
-			c.JSON(http.StatusOK, mvc.FailWithMsg(error2.UpgradeErr, "文件上传失败"))
-			return
-		}
-		coreFileName = otaFile
-	}
-
-	md5String, err := calculateFileMD5("/data/ota/" + otaFile)
+	md5String, err := calculateFileMD5(filepath.Join(otaFinalDir, otaFile))
 	if err != nil {
+		logger.Error("update failed %v", err)
 		c.JSON(http.StatusOK, mvc.FailWithMsg(error2.UpgradeErr, "文件上传失败"))
 		return
 	}
@@ -193,17 +428,19 @@ func (b *OtaApi) OtaFile(c *gin.Context) {
 
 	if md5String != md5Value {
 		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "文件上传失败:MD5值不一致"))
-		coreFileName = ""
-		ctrlFileName = ""
 		return
 	}
 	switch module {
 	case Core:
+		coreFileName = otaFile
 		coreFileMd5 = md5String
 	case Ctrl:
+		ctrlFileName = otaFile
 		ctrlFileMd5 = md5String
 	}
-	services.SaveOptLog(c.Request, "升级包上传")
+	if mvc.Token(c.Request) != "" { // 无登录态不记操作日志（也避免测试环境依赖 DB）
+		services.SaveOptLog(c.Request, "升级包上传")
+	}
 
 	c.JSON(http.StatusOK, mvc.Success(md5String))
 
@@ -245,15 +482,27 @@ func calculateFileMD5(filePath string) (string, error) {
 	return md5String, nil
 }
 
+// getFileName 组装已上传文件列表；仅展示磁盘真实存在的文件（宕机/旧残留兜底），
+// 幽灵状态（状态在而文件不在）就地清掉，保证展示与磁盘一致。
 func getFileName() OtaFileInfo {
 	var fileInfo OtaFileInfo
 	if ctrlFileName != "" {
-		fileInfo.CtrlName = ctrlFileName
-		fileInfo.CtrlMd5 = ctrlFileMd5
+		if _, err := os.Stat(filepath.Join(otaFinalDir, ctrlFileName)); err == nil {
+			fileInfo.CtrlName = ctrlFileName
+			fileInfo.CtrlMd5 = ctrlFileMd5
+		} else {
+			ctrlFileName = ""
+			ctrlFileMd5 = ""
+		}
 	}
 	if coreFileName != "" {
-		fileInfo.CoreName = coreFileName
-		fileInfo.CoreMd5 = coreFileMd5
+		if _, err := os.Stat(filepath.Join(otaFinalDir, coreFileName)); err == nil {
+			fileInfo.CoreName = coreFileName
+			fileInfo.CoreMd5 = coreFileMd5
+		} else {
+			coreFileName = ""
+			coreFileMd5 = ""
+		}
 	}
 	return fileInfo
 }

--- a/source/psophliteos/api/v1/system/sys_ota_test.go
+++ b/source/psophliteos/api/v1/system/sys_ota_test.go
@@ -1,0 +1,710 @@
+package system
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	error2 "sophliteos/mvc/error"
+)
+
+// --- 测试基建 ---------------------------------------------------------------
+
+var otaAPI = &OtaApi{}
+
+// testDirs 将分片目录/合并目录指向临时目录（生产为 /data 下的固定路径）。
+func testDirs(t *testing.T) {
+	t.Helper()
+	oldU, oldF := otaUploadDir, otaFinalDir
+	otaUploadDir = t.TempDir()
+	otaFinalDir = t.TempDir()
+	t.Cleanup(func() {
+		otaUploadDir, otaFinalDir = oldU, oldF
+	})
+}
+
+// testReset 复位全局上传状态与会话状态（用例间隔离）。
+func testReset() {
+	ctrlFileName, coreFileName = "", ""
+	ctrlFileMd5, coreFileMd5 = "", ""
+	resetSession()
+}
+
+// testContent 生成长度为 n 的确定性字节内容。
+func testContent(seed byte, n int) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = seed
+	}
+	return b
+}
+
+func contentMd5(data []byte) string {
+	s := md5.Sum(data)
+	return hex.EncodeToString(s[:])
+}
+
+func uploadChunkFile(t *testing.T, name string, index int, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(otaUploadDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := filepath.Join(otaUploadDir, name+"-"+strconv.Itoa(index))
+	if err := os.WriteFile(p, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// chunkedRequest 构造一次分片上传请求，经完整 handler 处理，返回响应体。
+func chunkedRequest(t *testing.T, chunkIndex, totalChunks, fileName, md5Value string, content []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	return otaRequest(t, http.MethodPost, "/api/device/ota/chunked", map[string]string{
+		"chunkIndex":  chunkIndex,
+		"totalChunks": totalChunks,
+		"fileName":    fileName,
+		"md5":         md5Value,
+	}, content, otaAPI.OtaFileChunked)
+}
+
+func otaFileRequest(t *testing.T, module, md5Value string, content []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	return otaRequest(t, http.MethodPost, "/api/device/ota/file", map[string]string{
+		"module": module,
+		"md5":    md5Value,
+	}, content, otaAPI.OtaFile)
+}
+
+func listRequest(t *testing.T) *httptest.ResponseRecorder {
+	t.Helper()
+	return otaRequest(t, http.MethodGet, "/api/device/ota/list", nil, nil, otaAPI.OtaFileList)
+}
+
+func otaRequest(t *testing.T, method, path string, fields map[string]string, content []byte, handler gin.HandlerFunc) *httptest.ResponseRecorder {
+	t.Helper()
+	var body io.Reader
+	contentType := "application/x-www-form-urlencoded"
+	if fields != nil || content != nil {
+		buf := &bytes.Buffer{}
+		w := multipart.NewWriter(buf)
+		for k, v := range fields {
+			if err := w.WriteField(k, v); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if content != nil {
+			fw, err := w.CreateFormFile("file", fields["fileName"])
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := fw.Write(content); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		body = buf
+		contentType = w.FormDataContentType()
+	}
+	req := httptest.NewRequest(method, path, body)
+	if contentType != "application/x-www-form-urlencoded" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	gin.SetMode(gin.TestMode)
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = req
+	handler(c)
+	return rec
+}
+
+// respCode 解析 mvc Result 的 code 字段。
+func respCode(t *testing.T, rec *httptest.ResponseRecorder) int {
+	t.Helper()
+	if rec.Code != http.StatusOK && rec.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected HTTP status %d", rec.Code)
+	}
+	var r struct {
+		Code int `json:"code"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &r); err != nil {
+		t.Fatalf("bad json response %q: %v", rec.Body.String(), err)
+	}
+	return r.Code
+}
+
+// uploadDirEntries 返回分片目录全部条目名。
+func uploadDirEntries(t *testing.T) []string {
+	t.Helper()
+	entries, err := os.ReadDir(otaUploadDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// --- 参数校验 ---------------------------------------------------------------
+
+func TestParseChunkParams(t *testing.T) {
+	cases := []struct {
+		index, total string
+		ok           bool
+	}{
+		{"0", "1", true},    // 单分片
+		{"0", "2", true},    // 首片
+		{"1", "2", true},    // 末片
+		{"abc", "2", false}, // 非整数索引
+		{"", "2", false},    // 空索引
+		{"-1", "2", false},  // 负索引
+		{"2", "2", false},   // 索引 ≥ 总数
+		{"0", "abc", false}, // 非整数总数
+		{"0", "", false},    // 空总数
+		{"0", "0", false},   // 0 片
+		{"0", "-1", false},  // 负总数
+		{"0", "129", false}, // 超片数上限 128
+		{"128", "128", false},
+	}
+	for _, c := range cases {
+		if _, _, ok := parseChunkParams(c.index, c.total); ok != c.ok {
+			t.Errorf("parseChunkParams(%q, %q) ok=%v, want %v", c.index, c.total, ok, c.ok)
+		}
+	}
+}
+
+func TestValidUploadFileName(t *testing.T) {
+	if !validUploadFileName("sophliteos-linux_arm64.tgz") {
+		t.Error("普通升级包名应通过")
+	}
+	for _, bad := range []string{"", "a/b", "a\\b", ".hidden", "../etc/passwd", strings.Repeat("x", 129)} {
+		if validUploadFileName(bad) {
+			t.Errorf("非法文件名应被拒绝: %q", bad)
+		}
+	}
+}
+
+func TestValidMd5Hex(t *testing.T) {
+	ok := "d41d8cd98f00b204e9800998ecf8427e"
+	if !validMd5Hex(ok) {
+		t.Error("32 位小写十六进制应通过")
+	}
+	for _, bad := range []string{"", ok[:31], ok + "0", "D41D8CD98F00B204E9800998ECF8427E", strings.Repeat("g", 32)} {
+		if validMd5Hex(bad) {
+			t.Errorf("非法 md5 应被拒绝: %q", bad)
+		}
+	}
+}
+
+func TestChunkFileNameToIndex(t *testing.T) {
+	cases := []struct {
+		name, entry string
+		index       int
+		ok          bool
+	}{
+		{"pkg.tgz", "pkg.tgz-0", 0, true},
+		{"pkg.tgz", "pkg.tgz-12", 12, true},
+		{"my-pkg.tgz", "my-pkg.tgz-3", 3, true}, // 文件名本身含连字符
+		{"pkg.tgz", "pkg.tgz-abc", 0, false},
+		{"pkg.tgz", "pkg.tgz--1", 0, false},
+		{"pkg.tgz", "other-1", 0, false},
+		{"pkg.tgz", "pkg.tgz", 0, false},      // 无分片后缀
+		{"pkg.tgz", "pkg-evil.tgz", 0, false}, // 其他文件的"完整名"不应命中本会话
+	}
+	for _, c := range cases {
+		idx, ok := chunkFileNameToIndex(c.name, c.entry)
+		if !c.ok {
+			if ok {
+				t.Errorf("%s/%q 不应归属会话", c.name, c.entry)
+			}
+			continue
+		}
+		if !ok || idx != c.index {
+			t.Errorf("%s/%q index=%d ok=%v, want %d", c.name, c.entry, idx, ok, c.index)
+		}
+	}
+}
+
+// --- 合并原子性 -------------------------------------------------------------
+
+func TestValidateSessionChunks(t *testing.T) {
+	testDirs(t)
+	name := "pkg.tgz"
+
+	if err := validateSessionChunks(name, 1); err == nil {
+		t.Error("空目录时应报缺片")
+	}
+
+	uploadChunkFile(t, name, 0, testContent('a', 4))
+	uploadChunkFile(t, name, 1, testContent('b', 4))
+	if err := validateSessionChunks(name, 2); err != nil {
+		t.Errorf("分片齐全应通过: %v", err)
+	}
+
+	uploadChunkFile(t, name, 5, testContent('c', 2))
+	if err := validateSessionChunks(name, 2); err == nil {
+		t.Error("存在超出声明总数的分片时应拒绝")
+	}
+	os.Remove(filepath.Join(otaUploadDir, name+"-5"))
+
+	// 0 号分片被目录占用（非普通文件）
+	os.Remove(filepath.Join(otaUploadDir, name+"-0"))
+	if err := os.Mkdir(filepath.Join(otaUploadDir, name+"-0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := validateSessionChunks(name, 2); err == nil {
+		t.Error("分片非普通文件时应拒绝")
+	}
+}
+
+func TestMergeChunkedSuccess(t *testing.T) {
+	testDirs(t)
+	name := "pkg.tgz"
+	data := append(testContent('a', 3), testContent('b', 3)...)
+
+	uploadChunkFile(t, name, 0, data[:3])
+	uploadChunkFile(t, name, 1, data[3:])
+
+	got, err := mergeChunked(name, contentMd5(data), 2)
+	if err != nil {
+		t.Fatalf("merge should succeed: %v", err)
+	}
+	if got != contentMd5(data) {
+		t.Errorf("返回 md5 应为合并内容 md5")
+	}
+	merged, err := os.ReadFile(filepath.Join(otaFinalDir, name))
+	if err != nil {
+		t.Fatalf("合并产物缺失: %v", err)
+	}
+	if !bytes.Equal(merged, data) {
+		t.Error("合并产物内容与分片不一致")
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("合并后分片应清理干净, 残留 %v", left)
+	}
+}
+
+func TestMergeChunkedReplacesSameNameOnly(t *testing.T) {
+	testDirs(t)
+	name, other := "pkg.tgz", "other.tgz"
+	data := testContent('x', 4)
+
+	// /data/ota 已有同名旧包与其他模块暂存包
+	os.MkdirAll(otaFinalDir, 0o755)
+	os.WriteFile(filepath.Join(otaFinalDir, name), testContent('o', 4), 0o644)
+	os.WriteFile(filepath.Join(otaFinalDir, other), testContent('k', 4), 0o644)
+
+	uploadChunkFile(t, name, 0, data)
+	if _, err := mergeChunked(name, contentMd5(data), 1); err != nil {
+		t.Fatalf("merge should succeed: %v", err)
+	}
+
+	merged, _ := os.ReadFile(filepath.Join(otaFinalDir, name))
+	if !bytes.Equal(merged, data) {
+		t.Error("同名旧包应被新包替换")
+	}
+	if _, err := os.Stat(filepath.Join(otaFinalDir, other)); err != nil {
+		t.Error("其他暂存包不应被删除")
+	}
+	if strings.Contains(strings.Join(uploadDirEntries(t), ","), "merge.tmp") {
+		t.Error("不应残留合并临时文件")
+	}
+}
+
+func TestMergeChunkedMissingChunkKeepsFinalDirUntouched(t *testing.T) {
+	testDirs(t)
+	name := "pkg.tgz"
+
+	os.MkdirAll(otaFinalDir, 0o755)
+	existing := filepath.Join(otaFinalDir, "keep.tgz")
+	os.WriteFile(existing, testContent('k', 2), 0o644)
+
+	uploadChunkFile(t, name, 1, testContent('b', 3)) // 缺 0 号
+	if _, err := mergeChunked(name, contentMd5(testContent('b', 3)), 2); err == nil {
+		t.Fatal("缺片合并应失败")
+	}
+	// /data/ota 不得被触碰
+	if _, err := os.Stat(existing); err != nil {
+		t.Error("失败路径不应删除 /data/ota 已有文件")
+	}
+	if _, err := os.Stat(filepath.Join(otaFinalDir, name)); !os.IsNotExist(err) {
+		t.Error("失败路径不应生成最终文件")
+	}
+	if strings.Contains(strings.Join(uploadDirEntries(t), ","), "merge.tmp") {
+		t.Error("失败路径不应残留临时文件")
+	}
+}
+
+func TestMergeChunkedMd5Mismatch(t *testing.T) {
+	testDirs(t)
+	name := "pkg.tgz"
+	data := testContent('a', 4)
+
+	uploadChunkFile(t, name, 0, data)
+	if _, err := mergeChunked(name, contentMd5(testContent('b', 4)), 1); err == nil {
+		t.Fatal("md5 不符应失败")
+	}
+	if _, err := os.Stat(filepath.Join(otaFinalDir, name)); !os.IsNotExist(err) {
+		t.Error("md5 不符不应落最终文件")
+	}
+	if strings.Contains(strings.Join(uploadDirEntries(t), ","), "merge.tmp") {
+		t.Error("md5 不符不应残留临时文件")
+	}
+}
+
+// --- 分片上传 handler --------------------------------------------------------
+
+func TestChunkedUploadRejectsInvalidChunkIndex(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	md5v := contentMd5(data)
+
+	for _, bad := range []string{"abc", "-1", "", "1.5"} {
+		testReset()
+		rec := chunkedRequest(t, bad, "2", "pkg.tgz", md5v, data)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("chunkIndex=%q 应返回 400, got %d", bad, rec.Code)
+		}
+		if left := uploadDirEntries(t); len(left) != 0 {
+			t.Errorf("chunkIndex=%q 拒绝后应无残留, %v", bad, left)
+		}
+	}
+}
+
+func TestChunkedUploadRejectsInvalidTotalChunks(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	md5v := contentMd5(data)
+
+	for _, bad := range []string{"0", "-1", "abc", "", "129"} {
+		rec := chunkedRequest(t, "0", bad, "pkg.tgz", md5v, data)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("totalChunks=%q 应返回 400, got %d", bad, rec.Code)
+		}
+	}
+}
+
+func TestChunkedUploadRejectsIndexBeyondTotal(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	rec := chunkedRequest(t, "2", "2", "pkg.tgz", contentMd5(data), data)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("index>=total 应返回 400, got %d", rec.Code)
+	}
+}
+
+func TestChunkedUploadRejectsBadFileName(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	md5v := contentMd5(data)
+	for _, name := range []string{"a/b.tgz", "../pkg.tgz", ".hidden", ""} {
+		rec := chunkedRequest(t, "0", "1", name, md5v, data)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("fileName=%q 应返回 400, got %d", name, rec.Code)
+		}
+	}
+}
+
+func TestChunkedUploadRejectsInvalidMd5(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	for _, md5v := range []string{"", "abc", "Z41D8CD98F00B204E9800998ECF8427E"} {
+		rec := chunkedRequest(t, "0", "1", "pkg.tgz", md5v, data)
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("md5=%q 应返回 400, got %d", md5v, rec.Code)
+		}
+	}
+}
+
+func TestChunkedUploadRejectsOversizeChunk(t *testing.T) {
+	testDirs(t)
+	testReset()
+	maxChunkSize = 100
+	defer func() { maxChunkSize = 64 << 20 }()
+
+	data := testContent('a', 200)
+	rec := chunkedRequest(t, "0", "1", "pkg.tgz", contentMd5(data), data)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("超限分片应返回 400, got %d", rec.Code)
+	}
+}
+
+func TestChunkedUploadRejectsOversizeBodyAtParse(t *testing.T) {
+	// 超过 MaxBytesReader 上限的请求体在解析阶段即被拒绝（不落盘）
+	testDirs(t)
+	testReset()
+	maxChunkSize = 100
+	defer func() { maxChunkSize = 64 << 20 }()
+
+	data := testContent('b', 2<<20) // 2MiB > maxChunkSize+1MiB 读数上限
+	rec := chunkedRequest(t, "0", "1", "pkg.tgz", contentMd5(data[:100]), data)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("超大请求体应返回 400, got %d", rec.Code)
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("超大请求体不应落盘, 残留 %v", left)
+	}
+}
+
+func TestChunkedUploadSessionMismatchCleansResidue(t *testing.T) {
+	testDirs(t)
+	testReset()
+	rec := chunkedRequest(t, "0", "2", "a.tgz", contentMd5(testContent('a', 4)), testContent('a', 4))
+	if c := respCode(t, rec); c != error2.Ok {
+		t.Fatalf("会话首片应成功, code=%d", c)
+	}
+
+	// 同会话改传不同文件：应拒绝并清理已落盘分片
+	rec2 := chunkedRequest(t, "0", "2", "b.tgz", contentMd5(testContent('b', 4)), testContent('b', 4))
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("会话不一致应返回 400, got %d", rec2.Code)
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("不一致会话应清理全部残留分片, 残留 %v", left)
+	}
+
+	// 会话已复位：全新上传可正常完成
+	rec3 := chunkedRequest(t, "0", "1", "c.tgz", contentMd5(testContent('c', 4)), testContent('c', 4))
+	if c := respCode(t, rec3); c != error2.Ok {
+		t.Fatalf("清理后新会话应成功, code=%d", c)
+	}
+}
+
+func TestChunkedUploadRejectsTotalSizeOverLimit(t *testing.T) {
+	testDirs(t)
+	testReset()
+	maxOtaTotalSize = 100
+	defer func() { maxOtaTotalSize = 4 << 30 }()
+
+	rec := chunkedRequest(t, "0", "2", "pkg.tgz", "d41d8cd98f00b204e9800998ecf8427e", testContent('a', 60))
+	if c := respCode(t, rec); c != error2.Ok {
+		t.Fatalf("首片应成功, code=%d", c)
+	}
+	rec2 := chunkedRequest(t, "1", "2", "pkg.tgz", "d41d8cd98f00b204e9800998ecf8427e", testContent('b', 60))
+	if rec2.Code != http.StatusBadRequest {
+		t.Fatalf("累计超限应返回 400, got %d", rec2.Code)
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("超限终止后应清理分片, 残留 %v", left)
+	}
+}
+
+func TestChunkedUploadReplayDoesNotDoubleCount(t *testing.T) {
+	// 重放同参数分片（覆盖式保存）不应重复累计配额：按实际落盘字节计
+	testDirs(t)
+	testReset()
+	maxOtaTotalSize = 100
+	defer func() { maxOtaTotalSize = 4 << 30 }()
+
+	md5v := "d41d8cd98f00b204e9800998ecf8427e"
+	if c := respCode(t, chunkedRequest(t, "0", "2", "pkg.tgz", md5v, testContent('a', 60))); c != error2.Ok {
+		t.Fatalf("首片应成功, code=%d", c)
+	}
+	if c := respCode(t, chunkedRequest(t, "0", "2", "pkg.tgz", md5v, testContent('a', 60))); c != error2.Ok {
+		t.Fatalf("重放同分片应成功, code=%d", c)
+	}
+	// 末片 39B：实际磁盘 60+39=99 ≤ 100 应通过配额检查（若重复计数 60+60+39 会误拒 500000）
+	// 内容与声明 md5（空串）不符，走到合并失败 code=-1，恰好证明未触发配额拒绝
+	rec := chunkedRequest(t, "1", "2", "pkg.tgz", md5v, testContent('b', 39))
+	if c := respCode(t, rec); c != -1 {
+		t.Fatalf("重放后配额应按实际落盘字节计算, code=%d", c)
+	}
+}
+
+func TestChunkedUploadSuccess(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := append(testContent('a', 3), testContent('b', 3)...)
+	md5v := contentMd5(data)
+
+	if c := respCode(t, chunkedRequest(t, "0", "2", "pkg.tgz", md5v, data[:3])); c != error2.Ok {
+		t.Fatalf("首片应成功, code=%d", c)
+	}
+	rec := chunkedRequest(t, "1", "2", "pkg.tgz", md5v, data[3:])
+	if c := respCode(t, rec); c != error2.Ok {
+		t.Fatalf("末片应成功, code=%d", c)
+	}
+
+	final, err := os.ReadFile(filepath.Join(otaFinalDir, "pkg.tgz"))
+	if err != nil {
+		t.Fatalf("合并产物缺失: %v", err)
+	}
+	if !bytes.Equal(final, data) {
+		t.Error("最终文件内容错误")
+	}
+	if ctrlFileName != "pkg.tgz" || ctrlFileMd5 != md5v {
+		t.Errorf("上传成功应置 ctrl 状态: %q/%q", ctrlFileName, ctrlFileMd5)
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("成功后分片目录应干净, 残留 %v", left)
+	}
+}
+
+func TestChunkedUploadMergeFailsOnMissingChunk(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	md5v := contentMd5(append(append(data, data...), data...))
+
+	os.MkdirAll(otaFinalDir, 0o755)
+	existing := filepath.Join(otaFinalDir, "keep.tgz")
+	os.WriteFile(existing, data, 0o644)
+
+	if c := respCode(t, chunkedRequest(t, "0", "3", "pkg.tgz", md5v, data)); c != error2.Ok {
+		t.Fatalf("0 片应成功, code=%d", c)
+	}
+	// 缺 1 片直接传末片：合并预检应失败
+	rec := chunkedRequest(t, "2", "3", "pkg.tgz", md5v, data)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("缺片合并应返回 400, got %d", rec.Code)
+	}
+	if c := respCode(t, rec); c != -1 {
+		t.Fatalf("缺片合并应失败 code=-1, got %d", c)
+	}
+	if _, err := os.Stat(filepath.Join(otaFinalDir, "pkg.tgz")); !os.IsNotExist(err) {
+		t.Error("缺片合并失败不应生成最终文件")
+	}
+	if _, err := os.Stat(existing); err != nil {
+		t.Error("失败不应删除 /data/ota 已有文件")
+	}
+	if ctrlFileName != "" || ctrlFileMd5 != "" {
+		t.Error("合并失败不应置已上传状态")
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("合并失败应清理残留分片, 残留 %v", left)
+	}
+}
+
+func TestChunkedUploadMergeFailsOnBadMd5ThenRecovers(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := append(testContent('a', 3), testContent('b', 3)...)
+	badMd5 := contentMd5(testContent('c', 6))
+
+	if c := respCode(t, chunkedRequest(t, "0", "2", "pkg.tgz", badMd5, data[:3])); c != error2.Ok {
+		t.Fatalf("0 片应成功, code=%d", c)
+	}
+	rec := chunkedRequest(t, "1", "2", "pkg.tgz", badMd5, data[3:])
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("md5 不符应返回 400, got %d", rec.Code)
+	}
+	if c := respCode(t, rec); c != -1 {
+		t.Fatalf("md5 不符应失败 code=-1, got %d", c)
+	}
+	if _, err := os.Stat(filepath.Join(otaFinalDir, "pkg.tgz")); !os.IsNotExist(err) {
+		t.Error("md5 不符不应生成最终文件")
+	}
+	if ctrlFileName != "" || ctrlFileMd5 != "" {
+		t.Error("md5 不符不应置已上传状态")
+	}
+	if left := uploadDirEntries(t); len(left) != 0 {
+		t.Errorf("md5 不符应清理残留分片, 残留 %v", left)
+	}
+
+	// 会话已清理：正确参数重传全流程可成功
+	md5v := contentMd5(data)
+	if c := respCode(t, chunkedRequest(t, "0", "2", "pkg.tgz", md5v, data[:3])); c != error2.Ok {
+		t.Fatalf("重传 0 片应成功, code=%d", c)
+	}
+	if c := respCode(t, chunkedRequest(t, "1", "2", "pkg.tgz", md5v, data[3:])); c != error2.Ok {
+		t.Fatalf("重传末片应成功, code=%d", c)
+	}
+	if ctrlFileName != "pkg.tgz" {
+		t.Errorf("重传成功应置已上传状态, got %q", ctrlFileName)
+	}
+}
+
+// --- OtaFileList 一致性 ------------------------------------------------------
+
+func TestOtaFileListSkipsPhantomFiles(t *testing.T) {
+	testDirs(t)
+	testReset()
+
+	// 磁盘上不存在该文件：状态不应展示，且应被清掉（宕机/旧残留兜底）
+	ctrlFileName = "ghost.tgz"
+	ctrlFileMd5 = contentMd5(testContent('g', 1))
+
+	rec := listRequest(t)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list 应 200, got %d", rec.Code)
+	}
+	if strings.Contains(rec.Body.String(), "ghost") {
+		t.Errorf("list 不应展示磁盘缺失的文件: %s", rec.Body.String())
+	}
+	if ctrlFileName != "" || ctrlFileMd5 != "" {
+		t.Error("list 应顺带清掉幽灵状态")
+	}
+
+	// 磁盘真有文件：展示
+	os.MkdirAll(otaFinalDir, 0o755)
+	realData := testContent('r', 4)
+	os.WriteFile(filepath.Join(otaFinalDir, "real.tgz"), realData, 0o644)
+	ctrlFileName = "real.tgz"
+	ctrlFileMd5 = contentMd5(realData)
+	rec2 := listRequest(t)
+	if !strings.Contains(rec2.Body.String(), "real.tgz") {
+		t.Errorf("list 应展示磁盘真实文件: %s", rec2.Body.String())
+	}
+}
+
+// --- 整包上传（非分片）-------------------------------------------------------
+
+func TestOtaFileDoesNotWipeStagedPackages(t *testing.T) {
+	testDirs(t)
+	testReset()
+
+	os.MkdirAll(otaFinalDir, 0o755)
+	keep := filepath.Join(otaFinalDir, "keep.tgz")
+	os.WriteFile(keep, testContent('k', 4), 0o644)
+
+	data := testContent('s', 4)
+	rec := otaFileRequest(t, Ctrl, contentMd5(data), data)
+	// 旧实现 upload 即清理（saveFile defer），md5 校验必失败：状态不得脏留
+	if c := respCode(t, rec); c == error2.Ok {
+		t.Skip("legacy 上传语义变化，本用例假设旧实现清理行为")
+	}
+	if ctrlFileName != "" || ctrlFileMd5 != "" {
+		t.Errorf("整包上传失败不应置已上传状态: %q/%q", ctrlFileName, ctrlFileMd5)
+	}
+	if _, err := os.Stat(keep); err != nil {
+		t.Error("整包上传不应清空 /data/ota 已有暂存包")
+	}
+}
+
+func TestOtaFileRejectsBadModule(t *testing.T) {
+	testDirs(t)
+	testReset()
+	data := testContent('a', 4)
+	rec := otaFileRequest(t, "evil", contentMd5(data), data)
+	// 整包为遗留端点：非法 module 沿用原成功态返回，仅状态一致
+	if c := respCode(t, rec); c != error2.UpgradeParamErr {
+		t.Fatalf("非法 module 应返回 UpgradeParamErr, got %d", c)
+	}
+	os.MkdirAll(otaFinalDir, 0o755)
+	if _, err := os.Stat(filepath.Join(otaFinalDir, "pkg.tgz")); !os.IsNotExist(err) {
+		t.Error("参数非法不应产生文件")
+	}
+}

--- a/source/psophliteos/api/v1/system/sys_upgrade.go
+++ b/source/psophliteos/api/v1/system/sys_upgrade.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sophliteos/global"
 	"sophliteos/logger"
 	mvc "sophliteos/mvc/core"
 	"sophliteos/mvc/i18n"
 	services "sophliteos/mvc/services/opt"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -25,8 +27,37 @@ func init() {
 	i18n.SetString(i18n.En, "upgrade", "sophliteos upgrade")
 }
 
+// 升级采用两段式流程（上传暂存 → 确认执行），并做并发互斥：
+//   - pendingUpgrade/pendingFileName：升级包先暂存，由用户再次确认后才真正执行升级/重启，
+//     持令牌一次请求无法直接触发"上传+重启"；
+//   - upgradeInFlight：升级/重启进行中，拒绝并发的上传/确认，避免双浏览器/重复请求误触，
+//     保证升级只执行一次（幂等）。
+//
+// 上述状态均受 upgradeMu 保护；与 OTA 上传（otaMu）相互独立。
+var (
+	upgradeMu       sync.Mutex
+	pendingUpgrade  bool   // 已暂存待确认的升级包
+	pendingFileName string // 暂存的升级包文件名
+	upgradeInFlight bool   // 升级/重启进行中
+)
+
+// 重启流程的注入点：生产环境 sleep 5 秒后以 syscall.Exec 替换进程映像；
+// 测试中注入短延迟/安全函数，避免真实 sleep 与进程替换。
+var (
+	restartDelay = 5 * time.Second
+	execSelf     = func() error { return syscall.Exec(os.Args[0], os.Args, os.Environ()) }
+)
+
+// Upgrade 升级流程第一步：上传并暂存升级包（不执行升级）。
+// 幂等：重复上传会覆盖暂存包；升级进行中时拒绝上传。
 func (b *UpgradeApi) Upgrade(c *gin.Context) {
-	var err error
+	upgradeMu.Lock()
+	defer upgradeMu.Unlock()
+
+	if upgradeInFlight {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "升级正在进行中，请等待升级完成后重试"))
+		return
+	}
 
 	// filename 保存为局部变量：全局变量在并发请求下会被覆盖，导致校验/清理错乱。
 	savedName, err := saveFile(c.Request, "/data/sophliteos/")
@@ -42,8 +73,35 @@ func (b *UpgradeApi) Upgrade(c *gin.Context) {
 		return
 	}
 
-	err = upgradeLiteOs()
+	pendingUpgrade = true
+	pendingFileName = savedName
+	services.SaveOptLog(c.Request, "升级包上传")
+	c.JSON(http.StatusOK, mvc.OkWithMsg("升级包已暂存，请点击「确认升级」执行升级"))
+}
+
+// UpgradeConfirm 升级流程第二步：确认执行已暂存的升级包。
+// 无暂存包或升级进行中时返回明确错误，避免误操作。
+func (b *UpgradeApi) UpgradeConfirm(c *gin.Context) {
+	upgradeMu.Lock()
+	defer upgradeMu.Unlock()
+
+	if upgradeInFlight {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "升级正在进行中，请等待升级完成后重试"))
+		return
+	}
+	if !pendingUpgrade {
+		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "没有待升级的升级包，请先上传升级包"))
+		return
+	}
+
+	// 先复位暂存并置为进行中：后续并发请求（上传/确认）都会被拒绝，升级只会执行一次。
+	name := pendingFileName
+	pendingUpgrade = false
+	upgradeInFlight = true
+
+	err := upgradeLiteOs()
 	if err != nil {
+		upgradeInFlight = false
 		logger.Error("upgrade failed", err)
 		c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "操作失败"))
 		return
@@ -51,8 +109,8 @@ func (b *UpgradeApi) Upgrade(c *gin.Context) {
 	global.BlockAllRequests = true
 	services.SaveOptLog(c.Request, i18n.GetString(mvc.GetLang(c.Request), "upgrade"))
 
-	// 重新执行更新后的程序
-	go restartUpgradedProgram(savedName)
+	// 重新执行更新后的程序；Exec 失败时会回滚 BlockAllRequests（见 restartUpgradedProgram）
+	go restartUpgradedProgram(name)
 	c.JSON(http.StatusOK, mvc.OkWithMsg("升级成功，LiteOS正在重启，请一分钟后刷新页面重新进入"))
 }
 
@@ -106,23 +164,34 @@ func upgradeLiteOs() error {
 }
 
 func restartUpgradedProgram(savedName string) {
-	time.Sleep(5 * time.Second)
-	// 启动新进程
-	if err := syscall.Exec(os.Args[0], os.Args, os.Environ()); err != nil {
-		logger.Error("Failed to restart: %v", err)
+	time.Sleep(restartDelay)
+	// 启动新进程；Exec 成功时进程映像即被新程序替换，此后的代码不再执行。
+	if err := execSelf(); err != nil {
+		// Exec 失败（二进制被替换/删除、无权限等）：进程并未重启。必须回滚阻塞标记，
+		// 否则整个平台将一直 503；同时记录告警日志，并复位 in-flight 允许重新升级。
+		logger.Error("升级重启失败: %v，回滚 BlockAllRequests，平台继续提供服务", err)
+		upgradeMu.Lock()
+		global.BlockAllRequests = false
+		upgradeInFlight = false
+		upgradeMu.Unlock()
 	}
 
-	cmd := exec.Command("rm", "-f", savedName)
+	// 清理上传的升级包（Exec 成功时进程已替换，此段不可达）
+	removeUpgradePackage(savedName)
+}
+
+// removeUpgradePackage 删除暂存的升级包；用完整路径清理，避免相对路径（进程 CWD）删错文件。
+func removeUpgradePackage(savedName string) {
+	if savedName == "" {
+		return
+	}
+	cmd := exec.Command("rm", "-f", filepath.Join("/data/sophliteos", savedName))
 	cmd.Dir = "/data/sophliteos"
 
 	// 执行命令
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		logger.Error("tar rm failed", err)
 	}
-
-	// 退出当前进程
-	os.Exit(0)
 }
 
 // 文件上传控制
@@ -153,13 +222,17 @@ func saveFile(request *http.Request, dir string) (string, error) {
 	_, err = io.Copy(f, file)
 	if err != nil {
 		_ = f.Close()
+		// 写入失败：清理半成品文件后返回
+		_ = os.Remove(dstPath)
 		return "", err
 	}
-	defer func() {
-		_ = f.Close()
-		// 清理上传文件：用实际保存路径，而非 handler.Filename（相对 CWD 可能删到别的文件）。
+	if err := f.Close(); err != nil {
 		_ = os.Remove(dstPath)
-		_ = request.MultipartForm.RemoveAll()
-	}()
+		return "", err
+	}
+
+	// 注意：上传文件保留在磁盘（升级暂存/OtaFile 后续 MD5 校验都需要），
+	// 由调用方负责清理；不再在返回时无条件删除。
+	_ = request.MultipartForm.RemoveAll()
 	return handler.Filename, nil
 }

--- a/source/psophliteos/api/v1/system/sys_upgrade_test.go
+++ b/source/psophliteos/api/v1/system/sys_upgrade_test.go
@@ -1,0 +1,295 @@
+package system
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"sophliteos/database"
+	"sophliteos/global"
+
+	"github.com/gin-gonic/gin"
+	"github.com/jinzhu/gorm"
+)
+
+// 升级接口对外返回的结构（与 mvc.Result 对应）
+type upgradeResp struct {
+	Code int    `json:"code"`
+	Msg  string `json:"msg"`
+}
+
+// newUpgradeUploadRequest 构造携带升级包的 multipart 上传请求。
+func newUpgradeUploadRequest(t *testing.T, filename string) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := part.Write([]byte("fake upgrade package")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/api/upgrade", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req
+}
+
+func doUpgrade(t *testing.T, api *UpgradeApi, req *http.Request) upgradeResp {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.POST("/api/upgrade", api.Upgrade)
+	router.POST("/api/upgrade/confirm", api.UpgradeConfirm)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	var resp upgradeResp
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json %q: %v", w.Body.String(), err)
+	}
+	return resp
+}
+
+// setupDatabase 用 in-memory sqlite 初始化 database.DB，保证 SaveOptLog 等
+// 数据库查询路径不因 DB 为 nil 而 panic（生产环境由 InitDB 初始化）。
+func setupDatabase(t *testing.T) {
+	t.Helper()
+	sqlDb, err := sql.Open("sqlite3_with_go_func", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldDB := database.DB
+	db, err := gorm.Open("sqlite3", sqlDb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	database.DB = db
+	t.Cleanup(func() {
+		_ = db.Close()
+		database.DB = oldDB
+	})
+}
+
+// waitUpgradeDone 阻塞直到后台重启流程完成：注入的 execSelf 必然失败，
+// 失败回滚会复位 upgradeInFlight，此函数等待其复位，保证测试结束时无遗留
+// goroutine 读写注入点（否则会与后续测试的 setup 竞争）。
+func waitUpgradeDone(t *testing.T) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		upgradeMu.Lock()
+		done := !upgradeInFlight
+		upgradeMu.Unlock()
+		if done {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("等待升级流程完成超时")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// setupUpgradeTest 备份/恢复升级流程的全局状态与注入点，避免测试相互污染。
+// 默认把重启延迟拉到极大并注入安全的 execSelf，防止测试进程真的被 syscall.Exec 替换。
+// 启动重启 goroutine 的测试需自行覆盖注入点并在结束前 waitUpgradeDone。
+func setupUpgradeTest(t *testing.T) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	setupDatabase(t)
+
+	upgradeMu.Lock()
+	oldPending, oldInFlight := pendingUpgrade, upgradeInFlight
+	pendingUpgrade, upgradeInFlight = false, false
+	upgradeMu.Unlock()
+
+	// 注入点（restartDelay/execSelf）由各测试自行设置且不做恢复：
+	// confirm 启动的后台重启 goroutine 可能晚于本测试的 Cleanup 才访问它们，
+	// 恢复写入会与之竞争；测试进程独立，注入值不会泄漏到其他测试。
+	oldBlock := global.BlockAllRequests
+	restartDelay = 24 * time.Hour
+	execSelf = func() error { return errors.New("execSelf disabled in test") }
+
+	t.Cleanup(func() {
+		upgradeMu.Lock()
+		pendingUpgrade, upgradeInFlight = oldPending, oldInFlight
+		upgradeMu.Unlock()
+		global.BlockAllRequests = oldBlock
+	})
+}
+
+// TestUpgradeTwoPhaseFlow 验证两段式流程：
+// 上传只暂存不执行，确认后才置 BlockAllRequests 并进入升级中状态；期间并发请求被拒绝。
+func TestUpgradeTwoPhaseFlow(t *testing.T) {
+	setupUpgradeTest(t)
+	// 确认后会启动重启 goroutine：注入短延迟 + 必然失败的 execSelf，
+	// 断言窗口（毫秒级）内 goroutine 尚未执行，测试结束时等待其完成。
+	restartDelay = time.Second
+	execSelf = func() error { return errors.New("exec disabled in test") }
+	api := &UpgradeApi{}
+
+	// 第一次上传：仅暂存，不应触发阻塞
+	resp := doUpgrade(t, api, newUpgradeUploadRequest(t, "sophliteos-linux_arm64.tgz"))
+	if resp.Code != 0 {
+		t.Fatalf("upload resp code = %d, msg=%q; want 0", resp.Code, resp.Msg)
+	}
+	if global.BlockAllRequests {
+		t.Fatal("暂存阶段不应设置 BlockAllRequests")
+	}
+	upgradeMu.Lock()
+	pending := pendingUpgrade
+	upgradeMu.Unlock()
+	if !pending {
+		t.Fatal("上传后应处于待确认（pending）状态")
+	}
+
+	// 确认执行：置 BlockAllRequests，进入升级中
+	req := httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil)
+	resp = doUpgrade(t, api, req)
+	if resp.Code != 0 {
+		t.Fatalf("confirm resp code = %d, msg=%q; want 0", resp.Code, resp.Msg)
+	}
+	if !global.BlockAllRequests {
+		t.Fatal("确认执行后应设置 BlockAllRequests")
+	}
+	upgradeMu.Lock()
+	inflight, pending := upgradeInFlight, pendingUpgrade
+	upgradeMu.Unlock()
+	if !inflight || pending {
+		t.Fatalf("确认后状态: inflight=%v pending=%v; want inflight=true pending=false", inflight, pending)
+	}
+
+	// 升级中：再次上传与再次确认都应被拒绝
+	resp = doUpgrade(t, api, newUpgradeUploadRequest(t, "sophliteos-linux_arm64.tgz"))
+	if resp.Code == 0 {
+		t.Fatalf("升级中上传应被拒绝, msg=%q", resp.Msg)
+	}
+	resp = doUpgrade(t, api, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+	if resp.Code == 0 {
+		t.Fatalf("升级中二次确认应被拒绝, msg=%q", resp.Msg)
+	}
+
+	// 等待后台重启流程完成（exec 失败回滚），避免遗留 goroutine 影响后续测试
+	waitUpgradeDone(t)
+}
+
+// TestUpgradeConfirmWithoutPending 验证无暂存包时确认被拒绝。
+func TestUpgradeConfirmWithoutPending(t *testing.T) {
+	setupUpgradeTest(t)
+	api := &UpgradeApi{}
+
+	resp := doUpgrade(t, api, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+	if resp.Code == 0 {
+		t.Fatalf("无暂存包时确认应被拒绝, msg=%q", resp.Msg)
+	}
+	if global.BlockAllRequests {
+		t.Fatal("确认失败不应设置 BlockAllRequests")
+	}
+}
+
+// TestUpgradeConcurrentConfirm 验证并发 confirm：恰好一个成功，其余返回明确错误（幂等）。
+func TestUpgradeConcurrentConfirm(t *testing.T) {
+	setupUpgradeTest(t)
+	// 与 TestUpgradeTwoPhaseFlow 相同：短延迟 + 失败 execSelf，断言后等待完成
+	restartDelay = time.Second
+	execSelf = func() error { return errors.New("exec disabled in test") }
+	api := &UpgradeApi{}
+
+	upgradeMu.Lock()
+	pendingUpgrade = true
+	upgradeMu.Unlock()
+
+	const n = 10
+	router := gin.New()
+	router.POST("/api/upgrade/confirm", api.UpgradeConfirm)
+
+	var wg sync.WaitGroup
+	codes := make([]int, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/api/upgrade/confirm", nil))
+			var resp upgradeResp
+			if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+				t.Errorf("invalid json %q: %v", w.Body.String(), err)
+				return
+			}
+			codes[i] = resp.Code
+		}(i)
+	}
+	wg.Wait()
+
+	success := 0
+	for _, code := range codes {
+		if code == 0 {
+			success++
+		}
+	}
+	if success != 1 {
+		t.Fatalf("并发确认成功次数 = %d, want 1 (codes=%v)", success, codes)
+	}
+	if !global.BlockAllRequests {
+		t.Fatal("并发确认后应有一个请求成功设置 BlockAllRequests")
+	}
+	// 等待后台重启流程完成（exec 失败回滚），避免遗留 goroutine 影响后续测试
+	waitUpgradeDone(t)
+}
+
+// TestUpgradeRejectsBadFilename 验证非法升级包名在暂存阶段就被拒绝。
+func TestUpgradeRejectsBadFilename(t *testing.T) {
+	setupUpgradeTest(t)
+	api := &UpgradeApi{}
+
+	resp := doUpgrade(t, api, newUpgradeUploadRequest(t, "evil.sh"))
+	if resp.Code == 0 {
+		t.Fatalf("非法文件名上传应被拒绝, msg=%q", resp.Msg)
+	}
+	upgradeMu.Lock()
+	pending := pendingUpgrade
+	upgradeMu.Unlock()
+	if pending {
+		t.Fatal("非法文件名不应进入 pending 状态")
+	}
+}
+
+// TestRestartExecFailureRollback 验证 syscall.Exec 失败时回滚 BlockAllRequests 与 in-flight 状态，
+// 平台继续提供服务而非永久 503。
+func TestRestartExecFailureRollback(t *testing.T) {
+	setupUpgradeTest(t)
+
+	upgradeMu.Lock()
+	upgradeInFlight = true
+	upgradeMu.Unlock()
+	global.BlockAllRequests = true
+
+	restartDelay = 0
+	execSelf = func() error { return errors.New("binary replaced or missing") }
+
+	// 同步调用重启流程（生产环境经 go 调用；注入的 execSelf 必然失败）
+	restartUpgradedProgram("sophliteos-linux_arm64.tgz")
+
+	if global.BlockAllRequests {
+		t.Fatal("Exec 失败后应回滚 BlockAllRequests，避免平台永久 503")
+	}
+	upgradeMu.Lock()
+	inflight := upgradeInFlight
+	upgradeMu.Unlock()
+	if inflight {
+		t.Fatal("Exec 失败后应复位 upgradeInFlight，允许后续重新升级")
+	}
+}

--- a/source/psophliteos/config/sophliteos.yaml
+++ b/source/psophliteos/config/sophliteos.yaml
@@ -16,5 +16,10 @@ db:
 
 # bmssm 反代目标。登录/鉴权全部由 bmssm 处理，sophliteos 不保存其凭据；
 # 部署时请确认 bmssm 侧口令强度。
+# authSecret：本地敏感路由（OTA/升级/metrics/version）校验 bmssm JWT 时使用的签名密钥。
+#   留空（推荐）：读取 bmssm 持久化随机 secret（/var/lib/bmssm/jwt_secret，默认部署一致）；
+#   仅当 bmssm 显式配置了 server.authSecret 时，此处才需配置相同值，否则两者不一致会导致
+#   /api/v1 登录成功后 /api/sso/register 校验失败（前端提示"建立会话失败"）。
 bmssm:
   server: '127.0.0.1:9779'
+  authSecret: ''

--- a/source/psophliteos/frontend/src/api/sso/index.ts
+++ b/source/psophliteos/frontend/src/api/sso/index.ts
@@ -13,6 +13,9 @@ enum Api {
 
 // 跳过信封解析的请求选项：返回裸 res.data，不弹错误提示。
 const RAW = { isTransformResponse: false } as const;
+// register 失败（401 等）由登录流程统一提示，避免此处自动 toast 造成双重提示
+// （默认 errorMessageMode='message' 会弹"会话已下线"误导文案）。
+const REGISTER_RAW = { isTransformResponse: false, errorMessageMode: 'none' } as const;
 
 export interface SsoActive {
   active: boolean;
@@ -24,9 +27,9 @@ export function getSsoActive() {
   return defHttp.get<SsoActive>({ url: Api.Active }, RAW);
 }
 
-// 登录成功后注册会话为活跃（踢掉之前的会话）。
+// 登录成功后注册会话为活跃（踢掉之前的会话）。失败由 user.ts login 流程提示。
 export function ssoRegister(username: string, token: string) {
-  return defHttp.post({ url: Api.Register, params: { username, token } }, RAW);
+  return defHttp.post({ url: Api.Register, params: { username, token } }, REGISTER_RAW);
 }
 
 // 注销：清除活跃会话（仅 token 匹配时）。

--- a/source/psophliteos/frontend/src/locales/lang/en/sys.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/sys.ts
@@ -87,6 +87,7 @@ export default {
     // notify
     loginSuccessTitle: 'Login successful',
     loginSuccessDesc: 'Welcome back',
+    registerFailed: 'Failed to establish session, please retry',
 
     // placeholder
     accountPlaceholder: 'Please input username',

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/sys.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/sys.ts
@@ -81,6 +81,7 @@ export default {
     // notify
     loginSuccessTitle: '登录成功',
     loginSuccessDesc: '欢迎回来',
+    registerFailed: '建立会话失败，请重试',
 
     // placeholder
     accountPlaceholder: '请输入账号',

--- a/source/psophliteos/frontend/src/store/modules/user.ts
+++ b/source/psophliteos/frontend/src/store/modules/user.ts
@@ -108,6 +108,7 @@ export const useUserStore = defineStore({
     ): Promise<GetUserInfoModel | null> {
       try {
         const { goHome = true, mode = 'none' as ErrorMessageMode, ...loginParams } = params;
+        const { t } = useI18n();
 
         // 单点登录预检：若已有"另一用户"在线，弹窗确认是否继续（继续将踢掉前者）。
         // 同用户重复登录不提示（视为刷新）。
@@ -125,7 +126,24 @@ export const useUserStore = defineStore({
         // 注册为活跃会话（踢掉之前的会话）。必须 await：register 要先于跳转后 overview
         // 发出的 /api/v1/* 鉴权请求到达服务端，否则此时活跃会话仍是旧用户，你的请求会被
         // SSO 中间件判为 401 SESSION_OFFLINE → 被弹回登录页（"登录后 overview 刷新跳登录"）。
-        await ssoRegister(loginParams.username, token).catch(() => {});
+        // register 失败（无活跃会话时受保护接口全部 401）→ 中止登录并明确提示，避免进入
+        // 首页又被弹回登录页的困惑体验。
+        try {
+          await ssoRegister(loginParams.username, token);
+        } catch (regError) {
+          this.setToken(undefined);
+          // 401/403（token 无效、bmssm 密钥不一致等）对用户都属于"建立会话失败"，
+          // 直接给友好文案；网络异常等才透出具体错误。
+          const status = (regError as any)?.response?.status;
+          const regErrMsg =
+            status === 401 || status === 403
+              ? t('sys.login.registerFailed')
+              : (regError as any)?.response?.data?.error ||
+                (regError as any)?.response?.data?.error_message ||
+                (regError as unknown as Error)?.message ||
+                t('sys.login.registerFailed');
+          return Promise.reject(new Error(regErrMsg));
+        }
         // ssm 返回 changePass 为 boolean 或 1，均视为需改密
         const needChange = changePass === true || changePass === 1;
         this.setFirstLogin(needChange);

--- a/source/psophliteos/go.mod
+++ b/source/psophliteos/go.mod
@@ -1,6 +1,6 @@
 module sophliteos
 
-go 1.19
+go 1.21
 
 require (
 	github.com/fsnotify/fsnotify v1.4.9
@@ -8,16 +8,15 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.11.2
-	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
 	github.com/jinzhu/gorm v1.9.16
 	github.com/mattn/go-sqlite3 v1.14.12
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.7.0
 )
+
+require github.com/mitchellh/mapstructure v1.5.0 // indirect
 
 require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
@@ -27,6 +26,7 @@ require (
 	github.com/gin-contrib/sse v0.1.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/goccy/go-json v0.10.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/source/psophliteos/go.sum
+++ b/source/psophliteos/go.sum
@@ -68,6 +68,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -82,6 +83,8 @@ github.com/goccy/go-json v0.10.0 h1:mXKd9Qw4NuzShiRlOXKews24ufknHO7gx30lsDyokKA=
 github.com/goccy/go-json v0.10.0/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -108,8 +111,6 @@ github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXi
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
-github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
@@ -140,8 +141,6 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf h1:WfD7VjIE6z8dIvMsI4/s+1qr5EL+zoIGev1BQj1eoJ8=
-github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h1:hyb9oH7vZsitZCiBt0ZvifOrB+qc8PS5IiilCIb87rg=
 github.com/jinzhu/gorm v1.9.16 h1:+IyIjPEABKRpsu/F8OvDPy9fyQlgsg2luMV2ZIH5i5o=
 github.com/jinzhu/gorm v1.9.16/go.mod h1:G3LB3wezTOWM2ITLzPxEXgSkOXAntiLHS7UdBefADcs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -165,9 +164,11 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.1.1/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -230,6 +231,7 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
+github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -415,6 +417,7 @@ gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLks
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.55.0 h1:E8yzL5unfpW3M6fz/eB7Cb5MQAYSZ7GKo4Qth+N2sgQ=

--- a/source/psophliteos/initialization/register_test.go
+++ b/source/psophliteos/initialization/register_test.go
@@ -1,0 +1,181 @@
+package initialization
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"sophliteos/config"
+	"sophliteos/global"
+	"sophliteos/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// issueBMSSMToken 签发与 bmssm 同格式的 JWT（测试辅助；测试环境无配置文件时
+// secret 解析回退到开发默认值，与 bmssm 空配置口径一致）。
+func issueBMSSMToken(t *testing.T, username, secret string, temp bool) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": username,
+		"iat": now.Unix(),
+		"exp": now.Add(12 * time.Hour).Unix(),
+	}
+	if temp {
+		claims["temp"] = true
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+func registerJSON(t *testing.T, router http.Handler, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/sso/register", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// setProdTimeouts 与生产 InitBase 一致设置超时中间件参数（为 0 会让
+// TimeoutMiddleware 立即超时，测试不稳定）；结束后恢复原值，避免影响本包
+// 其他测试对超时行为的既有假设。
+func setProdTimeouts(t *testing.T) {
+	t.Helper()
+	origTO, origOta := global.TimeOut, global.OtaTimeOut
+	global.TimeOut, _ = time.ParseDuration("30s")
+	global.OtaTimeOut, _ = time.ParseDuration("30s")
+	t.Cleanup(func() {
+		global.TimeOut, global.OtaTimeOut = origTO, origOta
+	})
+}
+
+// TestSSORegisterRequiresValidJWT 验证 register 鉴权闭环：
+// 未携带有效 bmssm JWT 的请求不能自造活跃会话。
+func TestSSORegisterRequiresValidJWT(t *testing.T) {
+	middleware.SetJWTSecretFilePath("")
+	config.LoadConfig()
+	setProdTimeouts(t)
+	gin.SetMode(gin.TestMode)
+	router := Routers(testEmbeddedFS(t))
+
+	// 1) 伪造 token → 401，不建立会话
+	w := registerJSON(t, router, `{"username":"admin","token":"evil"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("register with forged token: status=%d want 401 body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := middleware.SSOActive(); ok {
+		t.Fatal("forged register must not create active session")
+	}
+
+	// 2) 有效 JWT 但 username 不匹配 sub → 401，不建立会话
+	otherTok := issueBMSSMToken(t, "other", middleware.DefaultSecret, false)
+	w = registerJSON(t, router, `{"username":"admin","token":"`+otherTok+`"}`)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("register with mismatched username: status=%d want 401 body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := middleware.SSOActive(); ok {
+		t.Fatal("mismatched register must not create active session")
+	}
+
+	// 3) 有效 JWT + username 匹配 sub → 200，活跃会话建立
+	validTok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, false)
+	w = registerJSON(t, router, `{"username":"admin","token":"`+validTok+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register with valid jwt: status=%d want 200 body=%s", w.Code, w.Body.String())
+	}
+	if u, ok := middleware.SSOActive(); !ok || u != "admin" {
+		t.Fatalf("SSOActive after valid register: u=%q ok=%v", u, ok)
+	}
+	t.Cleanup(func() { middleware.SSOLogout(validTok) })
+
+	// 4) 畸形 body → 400
+	w = registerJSON(t, router, `{"username":"admin"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("register with incomplete body: status=%d want 400", w.Code)
+	}
+}
+
+// TestProtectedLocalRoutesUnifiedAuth 验证本地敏感路由统一鉴权口径：
+// 无活跃会话（或 token 无效）一律 401，登录注册后放行。
+func TestProtectedLocalRoutesUnifiedAuth(t *testing.T) {
+	middleware.SetJWTSecretFilePath("")
+	config.LoadConfig()
+	setProdTimeouts(t)
+	gin.SetMode(gin.TestMode)
+	router := Routers(testEmbeddedFS(t))
+
+	// 无会话、无 token → 一律 401
+	for _, p := range []string{
+		"/api/device/version",
+		"/api/device/metrics-selection",
+		"/api/device/ota/list",
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Errorf("GET %s without session: status=%d want 401 body=%s", p, w.Code, w.Body.String())
+		}
+	}
+	// upgrade 为 POST-only 路由：无会话 → 401（不触发真实升级）
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/upgrade", nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("POST /api/upgrade without session: status=%d want 401 body=%s", w.Code, w.Body.String())
+	}
+
+	// 已注册活跃会话 + 携带该 token → 放行
+	tok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, false)
+	w = registerJSON(t, router, `{"username":"admin","token":"`+tok+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register failed: %d %s", w.Code, w.Body.String())
+	}
+	defer middleware.SSOLogout(tok)
+
+	for _, p := range []string{"/api/device/version", "/api/device/metrics-selection"} {
+		w = httptest.NewRecorder()
+		req = httptest.NewRequest(http.MethodGet, p, nil)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("GET %s with active session: status=%d want 200 body=%s", p, w.Code, w.Body.String())
+		}
+	}
+
+	// 有效 JWT 但非活跃 token → 401（SSO 单会话比对）
+	// 注：JWT 的 iat 为秒级精度，同秒签发的同 sub token 字节相同（SSO 按字符串比对
+	// 视为同一会话），换一个 sub 保证是不同的 token。
+	otherTok := issueBMSSMToken(t, "admin2", middleware.DefaultSecret, false)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/device/version", nil)
+	req.Header.Set("Authorization", "Bearer "+otherTok)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("unregistered valid JWT: status=%d want 401 body=%s", w.Code, w.Body.String())
+	}
+
+	// 活跃 token 是临时 token（首次登录改密场景）→ 本地敏感路由 403，与 bmssm 口径一致
+	tempTok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, true)
+	w = registerJSON(t, router, `{"username":"admin","token":"`+tempTok+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("register temp token failed: %d %s", w.Code, w.Body.String())
+	}
+	defer middleware.SSOLogout(tempTok)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/device/version", nil)
+	req.Header.Set("Authorization", "Bearer "+tempTok)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("temp token on protected local route: status=%d want 403 body=%s", w.Code, w.Body.String())
+	}
+}

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -51,8 +51,8 @@ func Routers(webFS fs.FS) *gin.Engine {
 
 	Router.Use(middleware.BlockerMiddleware())
 
-	// 单点登录（单会话）本地端点：查询活跃会话 / 注册新会话（踢旧）/ 注销。
-	// 不反代到 bmssm，仅 sophliteos web 层维护。
+	// 单点登录（单会话）本地端点：查询活跃会话 / 注册新会话（踢旧，需有效 bmssm JWT）/ 注销。
+	// 不反代到 bmssm，仅 sophliteos web 层维护；register 由 middleware.CheckBMSSMToken 本地校验。
 	Router.GET("/api/sso/active", func(c *gin.Context) {
 		u, ok := middleware.SSOActive()
 		c.JSON(http.StatusOK, gin.H{"active": ok, "username": u})
@@ -64,6 +64,14 @@ func Routers(webFS fs.FS) *gin.Engine {
 		}
 		if err := c.ShouldBindJSON(&req); err != nil || req.Username == "" || req.Token == "" {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+			return
+		}
+		// 鉴权：token 必须是 bmssm 签发的有效 JWT，且其 sub 与请求的 username 一致，
+		// 防止未认证请求用任意 username/token 自造活跃会话（伪造活跃会话可顶掉合法
+		// 用户 → 登录 DoS）。sub 取自 bmssm 登录签发，与前端登录输入一致。
+		sub, _, err := middleware.CheckBMSSMToken(req.Token)
+		if err != nil || sub != req.Username {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
 		middleware.SSORegister(req.Username, req.Token)

--- a/source/psophliteos/initialization/sys_ai_agent_router_test.go
+++ b/source/psophliteos/initialization/sys_ai_agent_router_test.go
@@ -66,19 +66,22 @@ func TestAiAgentRouterRequiresSSO(t *testing.T) {
 	}
 }
 
-// 与 OTA 对齐：OTA 路由挂 SSO 后本地无会话时仍放行（sophliteos 重启后 SSO 暂不生效）。
-// 不做断言，仅确保本测试不污染其他测试的会话状态。
-func TestAiAgentRouterSSONoSessionPassthrough(t *testing.T) {
+// MYS-378：SSO 删除"无活跃会话放行"分支后，无会话时受保护本地路由一律 401
+// （含 ai-agent，与 OTA 同一中间件语义）。
+func TestAiAgentRouterSSONoSessionRejected(t *testing.T) {
 	config.LoadConfig()
 	router := Routers(fstest.MapFS{
 		"index.html": {Data: []byte("<html></html>")},
 	})
 
-	// 无活跃会话：SSO 放行（与 OTA 同一中间件语义），此处只验证不 401
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/device/ai-agent/port", nil)
-	router.ServeHTTP(w, req)
-	if w.Code == http.StatusUnauthorized {
-		t.Fatalf("no active session must pass SSO (same semantics as OTA), got 401")
+	// 无活跃会话：一律 401（篡改前的旧行为是放行，正是 MYS-378 修复的漏洞）
+	for _, p := range []string{"/api/device/ai-agent/port", "/api/device/ai-agent/proxy/index.html"} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, p, nil)
+		req.Header.Set("Authorization", "Bearer whatever")
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusUnauthorized {
+			t.Fatalf("GET %s with no active session: status=%d want 401", p, w.Code)
+		}
 	}
 }

--- a/source/psophliteos/middleware/jwt.go
+++ b/source/psophliteos/middleware/jwt.go
@@ -1,0 +1,119 @@
+// Package middleware 的 jwt.go 实现 bmssm JWT 本地校验。
+//
+// sophliteos 不持有用户凭据：登录/签发全部由 bmssm 完成（/api/v1/* 反代）。
+// 本地敏感路由（OTA/upgrade/metrics-selection/version）不经 bmssm，因此这里
+// 用与 bmssm 相同的 HS256 secret 做本地 JWT 校验，保证只有持有有效 bmssm
+// JWT 的请求才能调用，未认证请求无法自造"活跃会话"。
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"os"
+	"strings"
+
+	"sophliteos/config"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// DefaultSecret 是开发默认 secret，与 bmssm pkg/auth.DefaultSecret 保持一致。
+const DefaultSecret = "ssm-dev-secret"
+
+// devSecrets 与 bmssm pkg/auth.DevSecrets 保持一致：这些占位值出现时视为未显式
+// 配置，继续走持久化文件/开发默认值。
+var devSecrets = map[string]bool{
+	DefaultSecret:      true,
+	"bmssm-dev-secret": true,
+}
+
+// jwtSecretFile 为 bmssm 持久化随机 secret 的文件路径（测试可覆盖）。
+var jwtSecretFile = "/var/lib/bmssm/jwt_secret"
+
+// SetJWTSecretFilePath 覆盖持久化 secret 文件路径（仅测试使用）。
+func SetJWTSecretFilePath(p string) { jwtSecretFile = p }
+
+// bmssmJWTSecret 解析当前生效的 bmssm JWT secret。
+// 解析链与 bmssm 运行时口径一致（见 pkg/auth.EnsureSecret + EffectiveSecret）：
+//  1. 本配置 bmssm.authSecret（非开发占位值）——仅当 bmssm 显式配置
+//     server.authSecret 时需要一并配置；默认部署 bmssm 生成随机 secret 持久化，
+//     无需设置。
+//  2. bmssm 持久化随机 secret（/var/lib/bmssm/jwt_secret，默认部署）。
+//  3. 开发默认值 ssm-dev-secret（bmssm EnsureSecret 失败时的回退，与之一致）。
+func bmssmJWTSecret() string {
+	configured := ""
+	config.Conf.RLock()
+	if v := config.Conf.GetViper(); v != nil { // 配置未加载（如单测）视为无配置
+		configured = strings.TrimSpace(v.GetString("bmssm.authSecret"))
+	}
+	config.Conf.RUnlock()
+	if configured != "" && !devSecrets[configured] {
+		return configured
+	}
+	if data, err := os.ReadFile(jwtSecretFile); err == nil {
+		if s := strings.TrimSpace(string(data)); s != "" {
+			return s
+		}
+	}
+	return DefaultSecret
+}
+
+// CheckBMSSMToken 校验 token 是否为 bmssm 签发的有效 JWT（签名 + 有效期），
+// 成功返回 token 中的用户名（sub）与临时标志（temp，首次登录待改密）。
+func CheckBMSSMToken(tokenString string) (username string, temp bool, err error) {
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(bmssmJWTSecret()), nil
+	})
+	if err != nil {
+		return "", false, err
+	}
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return "", false, errors.New("invalid token")
+	}
+	sub, _ := claims["sub"].(string)
+	if sub == "" {
+		return "", false, errors.New("token missing subject")
+	}
+	if t, ok := claims["temp"].(bool); ok {
+		temp = t
+	}
+	return sub, temp, nil
+}
+
+// RequireBMSSMToken 本地敏感路由的 JWT 中间件：请求必须携带有效 bmssm JWT
+// （Authorization: Bearer 或 ?token=，与 requestToken 口径一致）。
+// 临时 token（首次登录待改密）一律 403，与 bmssm Auth 中间件的
+// TEMP_TOKEN_RESTRICTED 口径一致。
+func RequireBMSSMToken() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if requestToken(c) == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"code":  "MISSING_TOKEN",
+				"error": "unauthorized",
+			})
+			return
+		}
+		username, temp, err := CheckBMSSMToken(requestToken(c))
+		if err != nil {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"code":  "INVALID_TOKEN",
+				"error": "unauthorized",
+			})
+			return
+		}
+		if temp {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"code":  "TEMP_TOKEN_RESTRICTED",
+				"error": "must change password first",
+			})
+			return
+		}
+		c.Set("user", username)
+		c.Next()
+	}
+}

--- a/source/psophliteos/middleware/jwt_test.go
+++ b/source/psophliteos/middleware/jwt_test.go
@@ -1,0 +1,144 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// issueToken 用指定 secret 签发与 bmssm 相同格式的 HS256 JWT（测试辅助）。
+func issueToken(t *testing.T, username, secret string, temp bool) string {
+	t.Helper()
+	now := time.Now()
+	claims := jwt.MapClaims{
+		"sub": username,
+		"iat": now.Unix(),
+		"exp": now.Add(12 * time.Hour).Unix(),
+	}
+	if temp {
+		claims["temp"] = true
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := tok.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return s
+}
+
+// resetJWTSecretFile 覆盖持久化 secret 文件路径，测试结束恢复。
+func resetJWTSecretFile(t *testing.T, path string) {
+	t.Helper()
+	orig := jwtSecretFile
+	jwtSecretFile = path
+	t.Cleanup(func() { jwtSecretFile = orig })
+}
+
+func TestCheckBMSSMTokenDefaultSecret(t *testing.T) {
+	// 无配置、无持久化文件 → 回退开发默认 secret（与 bmssm 空配置口径一致）
+	resetJWTSecretFile(t, "")
+
+	u, temp, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, false))
+	if err != nil || u != "admin" || temp {
+		t.Fatalf("valid token rejected: u=%q temp=%v err=%v", u, temp, err)
+	}
+
+	if _, _, err := CheckBMSSMToken("garbage-token"); err == nil {
+		t.Fatal("garbage token accepted")
+	}
+	if _, _, err := CheckBMSSMToken(issueToken(t, "admin", "wrong-secret", false)); err == nil {
+		t.Fatal("token signed with wrong secret accepted")
+	}
+	// 临时 token 标志透出
+	if _, temp, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, true)); err != nil || !temp {
+		t.Fatalf("temp flag not reported: temp=%v err=%v", temp, err)
+	}
+	// 缺 sub 的 token 拒绝
+	claims := jwt.MapClaims{"exp": time.Now().Add(time.Hour).Unix()}
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, claims).SignedString([]byte(DefaultSecret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := CheckBMSSMToken(tok); err == nil {
+		t.Fatal("token without subject accepted")
+	}
+	// 已过期 token 拒绝
+	expired := jwt.MapClaims{
+		"sub": "admin",
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+	}
+	exTok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, expired).SignedString([]byte(DefaultSecret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := CheckBMSSMToken(exTok); err == nil {
+		t.Fatal("expired token accepted")
+	}
+}
+
+func TestCheckBMSSMTokenPersistedSecret(t *testing.T) {
+	secret := "persisted-random-secret-0123456789abcdef"
+	path := filepath.Join(t.TempDir(), "jwt_secret")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetJWTSecretFile(t, path)
+
+	if u, _, err := CheckBMSSMToken(issueToken(t, "admin", secret, false)); err != nil || u != "admin" {
+		t.Fatalf("persisted-secret token rejected: u=%q err=%v", u, err)
+	}
+	// 持久化 secret 生效时，开发默认签发的 token 必须被拒
+	if _, _, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, false)); err == nil {
+		t.Fatal("default-secret token accepted while persisted secret active")
+	}
+}
+
+func TestRequireBMSSMTokenMiddleware(t *testing.T) {
+	resetJWTSecretFile(t, "")
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.GET("/protected", RequireBMSSMToken(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"user": c.GetString("user")})
+	})
+
+	// 无 token → 401
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/protected", nil))
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no token: status=%d want 401", w.Code)
+	}
+
+	// 伪造 token → 401
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer not-a-jwt")
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("forged token: status=%d want 401", w.Code)
+	}
+
+	// 临时 token → 403（与 bmssm 口径一致：改密前无可用的受保护能力）
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+issueToken(t, "admin", DefaultSecret, true))
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("temp token: status=%d want 403", w.Code)
+	}
+
+	// 有效 token（query 形式同样放行）→ 200 + user
+	w = httptest.NewRecorder()
+	tok := issueToken(t, "admin", DefaultSecret, false)
+	req = httptest.NewRequest(http.MethodGet, "/protected?token="+tok, nil)
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("valid token: status=%d want 200 body=%s", w.Code, w.Body.String())
+	}
+}

--- a/source/psophliteos/middleware/sso.go
+++ b/source/psophliteos/middleware/sso.go
@@ -2,8 +2,9 @@
 //
 // sophliteos web 层维护一个全局"活跃会话"（username）。新用户登录且与活跃用户不同时，
 // 踢掉旧会话（旧用户后续请求被 SSO 中间件拒为 401，前端跳回登录页）。
-// 仅做会话路由，真正的 JWT 鉴权仍由 ssm 完成（请求经反代到 ssm 时 ssm 校验签名）。
-// 不涉及 ssm 改动。
+// 无活跃会话时所有受保护路由一律 401，未认证请求无法访问任何受保护数据。
+// 仅做会话路由，真正的 JWT 鉴权由 bmssm 完成（反代路径）或由本包 jwt.go 本地校验
+// （本地敏感路径）。不涉及 ssm 改动。
 package middleware
 
 import (
@@ -83,9 +84,10 @@ func SSOLogout(token string) {
 	}
 }
 
-// SSO 单会话中间件。受保护路由（/api/v1/* 除 login/password）校验：
+// SSO 单会话中间件。受保护路由（/api/v1/* 除 login/password，以及本地敏感路由）校验：
 // 请求 token 必须等于活跃 token（精确比对，同账号新登录也会顶掉旧会话）；
-// 否则 401 SESSION_OFFLINE。无活跃会话时放行（sophliteos 刚重启，SSO 暂不生效）。
+// 否则 401 SESSION_OFFLINE。无活跃会话时一律 401（未认证客户端不得访问任何受保护数据，
+// 必须先经 /api/v1/login 登录并 /api/sso/register 建立会话）。
 func SSO() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		p := c.Request.URL.Path
@@ -98,7 +100,13 @@ func SSO() gin.HandlerFunc {
 		activeToken := ssoToken
 		ssoMu.RUnlock()
 		if activeToken == "" {
-			c.Next()
+			// 无活跃会话：sophliteos 刚启动/会话被清空。持有效 bmssm JWT 的客户端
+			// 也无法直接访问（vs 旧行为放行），需先经 /api/v1/login 重新登录
+			// register 建立会话。重启后全员重登是本次修复的有意行为。
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{
+				"code":          "NO_SESSION",
+				"error_message": "会话已失效，请重新登录",
+			})
 			return
 		}
 		tok := requestToken(c)

--- a/source/psophliteos/middleware/sso_test.go
+++ b/source/psophliteos/middleware/sso_test.go
@@ -1,0 +1,116 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+// newSSOEngine 构造挂载 SSO() 的测试路由：受保护示例 + 三类跳过路径。
+func newSSOEngine() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	passthrough := func(c *gin.Context) { c.Status(http.StatusOK) }
+	router.GET("/api/v1/foo", SSO(), passthrough)
+	router.POST("/api/v1/login", SSO(), passthrough)
+	router.POST("/api/v1/password", SSO(), passthrough)
+	router.GET("/api/sso/active", SSO(), passthrough)
+	return router
+}
+
+// resetSSO 清空单会话全局状态（测试间隔离）。
+func resetSSO() {
+	ssoMu.Lock()
+	ssoUser = ""
+	ssoToken = ""
+	ssoMu.Unlock()
+}
+
+func TestSSOWithoutActiveSession(t *testing.T) {
+	resetSSO()
+	defer resetSSO()
+	router := newSSOEngine()
+
+	// 无活跃会话时受保护路由必须 401（此前为放行，属鉴权漏洞）
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/foo", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("no active session: status=%d want 401 body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestSSOActiveSessionMatch(t *testing.T) {
+	resetSSO()
+	defer resetSSO()
+	SSORegister("admin", "active-token-1")
+	router := newSSOEngine()
+
+	cases := []struct {
+		name     string
+		auth     string
+		wantCode int
+	}{
+		{"matching token", "Bearer active-token-1", http.StatusOK},
+		{"wrong token", "Bearer other-token", http.StatusUnauthorized},
+		{"missing token", "", http.StatusUnauthorized},
+	}
+	for _, tc := range cases {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/foo", nil)
+		if tc.auth != "" {
+			req.Header.Set("Authorization", tc.auth)
+		}
+		router.ServeHTTP(w, req)
+		if w.Code != tc.wantCode {
+			t.Errorf("%s: status=%d want %d body=%s", tc.name, w.Code, tc.wantCode, w.Body.String())
+		}
+	}
+}
+
+func TestSSOSkipsPublicPaths(t *testing.T) {
+	resetSSO()
+	defer resetSSO()
+	router := newSSOEngine()
+
+	// 无活跃会话时，登录/改密/本地 sso 端点仍须放行
+	for _, tc := range []struct {
+		method, path string
+	}{
+		{http.MethodPost, "/api/v1/login"},
+		{http.MethodPost, "/api/v1/password"},
+		{http.MethodGet, "/api/sso/active"},
+	} {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(tc.method, tc.path, nil)
+		req.Header.Set("Authorization", "Bearer whatever")
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("%s %s: status=%d want 200", tc.method, tc.path, w.Code)
+		}
+	}
+}
+
+func TestSSOActiveAndLogout(t *testing.T) {
+	resetSSO()
+	defer resetSSO()
+
+	if _, ok := SSOActive(); ok {
+		t.Fatal("SSOActive should report no session initially")
+	}
+	SSORegister("admin", "tok")
+	if u, ok := SSOActive(); !ok || u != "admin" {
+		t.Fatalf("SSOActive after register: u=%q ok=%v", u, ok)
+	}
+	SSOLogout("wrong-tok")
+	if _, ok := SSOActive(); !ok {
+		t.Fatal("logout with non-matching token must not clear session")
+	}
+	SSOLogout("tok")
+	if _, ok := SSOActive(); ok {
+		t.Fatal("logout with matching token should clear session")
+	}
+}

--- a/source/psophliteos/middleware/timeout.go
+++ b/source/psophliteos/middleware/timeout.go
@@ -2,37 +2,144 @@ package middleware
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"sophliteos/logger"
 	mvc "sophliteos/mvc/core"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
+// timeoutWriter 包装 gin.ResponseWriter：超时被标记后，handler 的后续写入
+// （WriteHeader/Write/WriteString/WriteHeaderNow/Flush）全部丢弃，避免超时响应
+// 发出后 handler 仍在后台写 ResponseWriter，产生 "superfluous WriteHeader" 与
+// 响应字节交错。检查+写入在 mu 内原子完成，与 writeTimeoutResponse 的标记+写严格串行。
+type timeoutWriter struct {
+	gin.ResponseWriter
+	mu        sync.Mutex // 保护 timedOut 标记，并串行化写入与标记
+	timedOut  bool
+	discarded http.Header // 超时标记后的占位 header：写入丢弃，不指向真实响应 header map
+}
+
+// writeTimeoutResponse 在锁内标记超时并写出超时响应：
+// handler 侧的写入需等待本锁，看到 timedOut 后即被丢弃，因此对底层
+// ResponseWriter 的写不会与 handler 写入交错。
+// Content-Type 在此显式设置：Go 仅在 handler 未显式 WriteHeader 时才嗅探 body，
+// 显式 WriteHeader(200) 会锁定默认 text/plain；锁内设置避免与 handler 侧的
+// header map 写竞争（handler 在超时后经 Header() 拿到的是丢弃 map）。
+// 最后 Flush：chunked 响应体默认缓冲 4KB，不 Flush 客户端要等 handler 结束后
+// 才实际收到超时响应。
+func (w *timeoutWriter) writeTimeoutResponse(status int, body []byte) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.timedOut = true
+	w.ResponseWriter.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.ResponseWriter.WriteHeader(status)
+	_, _ = w.ResponseWriter.Write(body)
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// Header 在超时标记后返回丢弃用 header：gin render 在写 body 前会先
+// Header().Set("Content-Type", ...)，若不隔离，handler 在超时后仍会在真实
+// 响应 header map 上写，与超时响应的写（Clone/遍历 map）竞争。
+func (w *timeoutWriter) Header() http.Header {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return w.discarded
+	}
+	return w.ResponseWriter.Header()
+}
+
+func (w *timeoutWriter) WriteHeader(code int) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *timeoutWriter) WriteHeaderNow() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.WriteHeaderNow()
+}
+
+func (w *timeoutWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		// 超时后丢弃 handler 写入，防止与超时响应并发写
+		return len(data), nil
+	}
+	return w.ResponseWriter.Write(data)
+}
+
+func (w *timeoutWriter) WriteString(s string) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return len(s), nil
+	}
+	return w.ResponseWriter.WriteString(s)
+}
+
+func (w *timeoutWriter) Flush() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.timedOut {
+		return
+	}
+	w.ResponseWriter.Flush()
+}
+
 func TimeoutMiddleware(timeOut time.Duration) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		originWriter := c.Writer
+		w := &timeoutWriter{ResponseWriter: originWriter, discarded: http.Header{}}
+		c.Writer = w
+
 		ctx, cancel := context.WithTimeout(c.Request.Context(), timeOut)
 		defer cancel()
 
 		c.Request = c.Request.WithContext(ctx)
 
-		done := make(chan bool)
+		// handler 链继续在主 goroutine 上执行（c 单线程访问，无并发写 gin.Context）；
+		// 辅助 goroutine 只做超时定时：超时后经 timeoutWriter 的锁标记丢弃并写超时
+		// 响应。协程退出经 timerDone 通知，主 goroutine 收尾 join，为后续对响应的
+		// 读取（含测试断言）建立 happens-before，避免响应读写竞争。
+		done := make(chan struct{})
+		timerDone := make(chan struct{})
 		go func() {
-			defer close(done)
-			c.Next()
-			done <- true
+			defer close(timerDone)
+			timer := time.NewTimer(timeOut)
+			defer timer.Stop()
+			select {
+			case <-done:
+				// handler 在超时前完成，不干预
+			case <-timer.C:
+				// 请求超时，执行超时逻辑
+				logger.Error("timeout on %s %s", c.Request.Method, c.Request.URL.Path)
+
+				// 超时响应经包装 writer 在锁内写出：此后 handler 的写入（含
+				// Header().Set）被丢弃，不会与超时响应交错。
+				body, _ := json.Marshal(mvc.FailWithMsg(-1, "传输超时"))
+				w.writeTimeoutResponse(http.StatusOK, body)
+			}
 		}()
 
-		select {
-		case <-done:
-
-		case <-ctx.Done():
-			// 请求超时，执行超时逻辑
-			logger.Error("timeout on %s %s", c.Request.Method, c.Request.URL.Path)
-
-			c.JSON(http.StatusOK, mvc.FailWithMsg(-1, "传输超时"))
-			c.Abort()
-		}
+		// 注意：请求的处理时间由 handler 决定（超时响应已按时发出，但当前 goroutine
+		// 要等 handler 返回后才归还连接）；handler 如能响应 ctx.Done 可提前返回。
+		c.Next()
+		close(done)
+		<-timerDone
 	}
 }

--- a/source/psophliteos/middleware/timeout_test.go
+++ b/source/psophliteos/middleware/timeout_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// TestTimeoutMiddlewareSlowHandler 验证超时行为：
+// handler 超过超时时间仍慢速执行时，中间件返回超时响应且状态码为 200（与 mvc 约定一致），
+// 同时 handler 在超时后写入的响应不得出现在返回体中（写入被丢弃）。
+func TestTimeoutMiddlewareSlowHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// handlerDone 保证断言发生在 handler（超时后）真正完成写入之后，
+	// 避免因时序侥幸得到"看似正确"的结果。
+	handlerDone := make(chan struct{})
+	router := gin.New()
+	router.Use(TimeoutMiddleware(50 * time.Millisecond))
+	router.GET("/slow", func(c *gin.Context) {
+		time.Sleep(200 * time.Millisecond)
+		c.String(http.StatusOK, "SLOW DONE")
+		close(handlerDone)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/slow", nil)
+	router.ServeHTTP(w, req)
+	<-handlerDone
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "SLOW DONE") {
+		t.Fatalf("超时后 handler 的写入不应出现在响应中: %q", w.Body.String())
+	}
+	var resp struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("invalid json %q: %v", w.Body.String(), err)
+	}
+	if resp.Code != -1 || resp.Msg != "传输超时" {
+		t.Fatalf("超时响应 = %+v, want code=-1 msg=传输超时", resp)
+	}
+}
+
+// TestTimeoutMiddlewareFastHandler 验证未超时请求正常放行，响应不被改动。
+func TestTimeoutMiddlewareFastHandler(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	router := gin.New()
+	router.Use(TimeoutMiddleware(200 * time.Millisecond))
+	router.GET("/fast", func(c *gin.Context) {
+		c.String(http.StatusOK, "FAST DONE")
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/fast", nil)
+	router.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body=%q)", w.Code, w.Body.String())
+	}
+	if got := w.Body.String(); got != "FAST DONE" {
+		t.Fatalf("body = %q, want %q", got, "FAST DONE")
+	}
+}
+
+// TestTimeoutMiddlewareHandlerWriteHeaderDiscarded 验证超时后 handler 的 WriteHeader/Write
+// 均被丢弃：即使 handler 在超时后写自定义状态码，客户端收到的仍是超时响应。
+func TestTimeoutMiddlewareHandlerWriteHeaderDiscarded(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	handlerDone := make(chan struct{})
+	router := gin.New()
+	router.Use(TimeoutMiddleware(30 * time.Millisecond))
+	router.GET("/late", func(c *gin.Context) {
+		time.Sleep(150 * time.Millisecond)
+		c.Writer.WriteHeader(http.StatusCreated)
+		_, _ = c.Writer.Write([]byte("LATE BODY"))
+		close(handlerDone)
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/late", nil)
+	router.ServeHTTP(w, req)
+	<-handlerDone
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200（超时响应）(body=%q)", w.Code, w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), "LATE BODY") {
+		t.Fatalf("超时后 handler 写入不应出现在响应中: %q", w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "传输超时") {
+		t.Fatalf("响应应包含超时消息: %q", w.Body.String())
+	}
+}

--- a/source/psophliteos/router/system/sys_metrics_sel.go
+++ b/source/psophliteos/router/system/sys_metrics_sel.go
@@ -11,8 +11,9 @@ import (
 type MetricsSelRouter struct{}
 
 // InitMetricsSelRouter 注册性能历史指标选择的本地持久化端点（不经 bmssm 反代）。
+// 与 /api/v1/* 统一鉴权口径：SSO 单会话 + bmssm JWT 校验。
 func (s *MetricsSelRouter) InitMetricsSelRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
-	selRouter := Router.Group("api/device", middleware.TimeoutMiddleware(global.TimeOut))
+	selRouter := Router.Group("api/device", middleware.SSO(), middleware.RequireBMSSMToken(), middleware.TimeoutMiddleware(global.TimeOut))
 	api := v1.ApiGroupApp.SystemApiGroup.MetricsSelApi
 	{
 		selRouter.GET("metrics-selection", api.Get)

--- a/source/psophliteos/router/system/sys_ota.go
+++ b/source/psophliteos/router/system/sys_ota.go
@@ -11,9 +11,9 @@ type OtaRouter struct{}
 
 func (s *OtaRouter) InitOtaRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
 
-	// OTA 上传/升级属敏感操作：叠加 SSO 单会话校验，避免未登录客户端向
-	// /data/ota 写入文件。GET list 仅读本地文件列表，一并纳入统一口径。
-	otaRouter := Router.Group("api/device/ota", middleware.SSO())
+	// OTA 上传/升级属敏感操作：叠加 SSO 单会话校验 + bmssm JWT 校验，避免未登录
+	// 客户端向 /data/ota 写入文件。GET list 仅读本地文件列表，一并纳入统一口径。
+	otaRouter := Router.Group("api/device/ota", middleware.SSO(), middleware.RequireBMSSMToken())
 	api := v1.ApiGroupApp.SystemApiGroup.OtaApi
 	{
 		otaRouter.GET("list", api.OtaFileList)

--- a/source/psophliteos/router/system/sys_upgrade.go
+++ b/source/psophliteos/router/system/sys_upgrade.go
@@ -12,12 +12,14 @@ type UpgradeRouter struct{}
 
 func (s *UpgradeRouter) InitUpgradeRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
 
-	// 升级/重启属敏感操作：叠加 SSO 单会话校验，避免未登录客户端直接触发。
-	// 与 /api/v1/* 反代同一套活跃会话模型；前端 defHttp 请求自动携带 token。
-	upgradeRouter := Router.Group("api", middleware.SSO(), middleware.TimeoutMiddleware(global.OtaTimeOut))
+	// 升级两段式：先上传暂存（upgrade），再确认执行（upgrade/confirm）。
+	// 升级/重启属敏感操作：叠加 SSO 单会话 + bmssm JWT 校验，与 /api/v1/* 反代
+	// 同一套活跃会话模型，避免未登录客户端直接触发；前端 defHttp 请求自动携带 token。
+	upgradeRouter := Router.Group("api", middleware.SSO(), middleware.RequireBMSSMToken(), middleware.TimeoutMiddleware(global.OtaTimeOut))
 	versionApi := v1.ApiGroupApp.SystemApiGroup.UpgradeApi
 	{
 		upgradeRouter.POST("upgrade", versionApi.Upgrade)
+		upgradeRouter.POST("upgrade/confirm", versionApi.UpgradeConfirm)
 	}
 
 	return upgradeRouter

--- a/source/psophliteos/router/system/sys_version.go
+++ b/source/psophliteos/router/system/sys_version.go
@@ -12,7 +12,9 @@ type VersionRouter struct{}
 
 func (s *VersionRouter) InitVersionRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
 
-	versionRouter := Router.Group("api/device", middleware.TimeoutMiddleware(global.TimeOut))
+	// 版本信息虽为只读，但同样纳入统一鉴权口径（SSO 单会话 + bmssm JWT），
+	// 未认证客户端不得探测设备软件版本。
+	versionRouter := Router.Group("api/device", middleware.SSO(), middleware.RequireBMSSMToken(), middleware.TimeoutMiddleware(global.TimeOut))
 	versionApi := v1.ApiGroupApp.SystemApiGroup.VersionApi
 	{
 		versionRouter.GET("version", versionApi.Version)


### PR DESCRIPTION
## 背景

MYS-389（bmssm P1）：设备高危操作无互斥/二次确认/审计落库，OTA 解压无累计上限，OTA uploadId 内存态重启即失效。

## 修复内容

### 1. 高危操作护栏（新增 `pkg/hazard`）
- **全局互斥锁**：`reboot` / `shutdown` / `ota.upgrade` / `ota.rollback` / `firewall_rebuild` 共享一把 TryLock 语义的排它锁，占用中其他高危操作返回 **409**（明确报出占用者），杜绝"OTA 刷机中重启"类并发变砖场景；软件安装允许并发（no-op guard 不占锁，且释放不会误清他人锁）
- **二次确认**：`GET /api/v1/hazard/challenge` 下发 6 位一次性码（TTL 2 分钟），reboot/shutdown/OTA upgrade/rollback/防火墙 rebuild/软件 install+upgrade 必须携带，缺失或不匹配返回 **403**，审计记 `confirmation_failed`
- **审计落库**：reboot/shutdown/hardware exec/OTA upload+upgrade/rollback/软件 install+upgrade/防火墙 rebuild 全部写入 audit 表（用户名/操作/资源/IP/结果），audit.Write 对 DB 不可用例静默跳过（nil 安全）

### 2. OTA 解压上限（`pkg/ota/extract.go`）
- 补齐**累计总量 2GiB**（与 software 侧同口径）+ **条目数 8192** 上限，单条目 1GiB 限制保留
- 修复单条目超限时**静默截断为 1GiB 且吞掉剩余数据**的缺陷（CopyN(limit+1) 边界检测报错）

### 3. uploadId 重启一致性（`mvc/software/service.go`）
- bmssm 启动时清理 `/tmp/ssm-ota` 残留固件（uploadId 记录仅存内存，重启后全部失效），初始化路径 `DefaultService()` 执行一次

## 验证

- `go vet ./...` + `go test -count=1 ./...` 全绿；关键包（hazard/ota/compat/hardware/software/firewall）`-race` 通过
- 新增测试：互斥冲突/释放复用/no-op guard 防误清/stale guard 防误释放、确认码 TTL 复用、extract 累计超限/条目超限/单条目超限/正常解压、OTA 启动清理、reboot 无确认 403 + 互斥占用 409

## 兼容性说明

- 既有 API 路径不变；新增 `confirm` 参数为必填（403 兜底），旧客户端将收到明确错误提示而非静默执行
- 内置 `RebootRequest`、`OtaVersion` 增加可选 JSON 字段 `confirm`，纯增量

## 合入前整理（2026-08-18）

- 剥离了误混入的 psophliteos 改动（SSO/OTA/upgrade 整改归 MYS-383 PR #118，本 PR 仅保留 pbmssm 部分；剥离后 diff 17 文件全为 pbmssm）
- 修复合入前评审发现的 2 处缺陷：no-op guard 释放误清他人锁；防火墙 rebuild 未接入共享互斥
