### PR TITLE
fix(psophliteos): AI-Agent 反向代理移除 SSO 鉴权（设备内部自用）(MYS-379)

### DIFF
--- a/source/psophliteos/api/v1/system/sys_ai_agent.go
+++ b/source/psophliteos/api/v1/system/sys_ai_agent.go
@@ -22,7 +22,7 @@ import (
 // AiAgentApi AI Agent 功能：picoclaw web 端口探测与转发、本地模型样例。
 // LLM/VLM API 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（sophliteos 不再刷新 picoclaw）。
 //
-// MYS-379 安全加固：路由已叠加 SSO（见 router/system/sys_ai_agent.go）。本层：
+// MYS-379 安全加固（本层）：端点属设备内部自用、不经 ssm 反代，鉴权不做（见 router 层）；
 //   - 探测目标身份校验：部署锚定（设备已安装 sophpicoclaw）+ 候选端口白名单 + HTTP 探针；
 //   - 探测结果缓存（ok 30s / miss 5s）：消除每请求 4 次探测的资源消耗、
 //     探测与代理间的 TOCTOU 竞态，以及端口扫描式反馈；

--- a/source/psophliteos/initialization/sys_ai_agent_router_test.go
+++ b/source/psophliteos/initialization/sys_ai_agent_router_test.go
@@ -7,81 +7,33 @@ import (
 	"testing/fstest"
 
 	"sophliteos/config"
-	"sophliteos/middleware"
 )
 
-// MYS-379：/api/device/ai-agent/* 必须与 OTA 一致挂 SSO —— 有活跃会话时，
-// 无/错误 token 的请求一律 401 SESSION_OFFLINE；携带活跃 token 才放行到 handler。
-func TestAiAgentRouterRequiresSSO(t *testing.T) {
+// MYS-379 后续（用户裁定）：AI-Agent 端点属设备内部自用，不设 SSO 鉴权（跟随变更见
+// router/system/sys_ai_agent.go）。此处仅验证端点路由本身可用（port 返回业务响应而非
+// NotImplemented/404），SSO 拦截用例随鉴权移除而删除。
+func TestAiAgentRouterEndpointsReachable(t *testing.T) {
 	config.LoadConfig()
 	router := Routers(fstest.MapFS{ // 无真实前端 dist 也可建路由
 		"index.html": {Data: []byte("<html></html>")},
 	})
 
-	// 模拟 ssm 登录注入活跃会话
-	middleware.SSORegister("tester", "session-token-abc")
-	defer middleware.SSOLogout("session-token-abc")
-
-	cases := []struct {
-		name   string
-		method string
-		path   string
-		auth   string // Authorization 头；空表示不带
-		want   int
-	}{
-		{"port no token → 401", http.MethodGet, "/api/device/ai-agent/port", "", http.StatusUnauthorized},
-		{"port wrong token → 401", http.MethodGet, "/api/device/ai-agent/port", "Bearer wrong-token", http.StatusUnauthorized},
-		{"proxy no token → 401", http.MethodGet, "/api/device/ai-agent/proxy/index.html", "", http.StatusUnauthorized},
-		{"proxy wrong token → 401", http.MethodPost, "/api/device/ai-agent/proxy/api/chat", "Bearer wrong-token", http.StatusUnauthorized},
-		{"port query token mismatch → 401", http.MethodGet, "/api/device/ai-agent/port?token=wrong", "", http.StatusUnauthorized},
-	}
-	for _, tc := range cases {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(tc.method, tc.path, nil)
-		if tc.auth != "" {
-			req.Header.Set("Authorization", tc.auth)
-		}
-		router.ServeHTTP(w, req)
-		if w.Code != tc.want {
-			t.Errorf("%s: status = %d, want %d (body=%q)", tc.name, w.Code, tc.want, w.Body.String())
-		}
-	}
-
-	// 携带活跃 token → 放行到 handler（测试机无 picoclaw 时仍是业务响应而非 401）
 	for _, tc := range []struct {
 		name   string
 		method string
 		path   string
 	}{
-		{"port valid token → pass SSO", http.MethodGet, "/api/device/ai-agent/port"},
-		{"proxy valid token → pass SSO", http.MethodGet, "/api/device/ai-agent/proxy/index.html"},
+		{"port", http.MethodGet, "/api/device/ai-agent/port"},
+		{"proxy", http.MethodGet, "/api/device/ai-agent/proxy/index.html"},
 	} {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest(tc.method, tc.path, nil)
-		req.Header.Set("Authorization", "Bearer session-token-abc")
 		router.ServeHTTP(w, req)
-		if w.Code == http.StatusUnauthorized {
-			t.Errorf("%s: valid session token must pass SSO, got 401", tc.name)
+		if w.Code == http.StatusNotFound {
+			t.Fatalf("%s: route must be registered, got 404", tc.name)
 		}
-	}
-}
-
-// MYS-378：SSO 删除"无活跃会话放行"分支后，无会话时受保护本地路由一律 401
-// （含 ai-agent，与 OTA 同一中间件语义）。
-func TestAiAgentRouterSSONoSessionRejected(t *testing.T) {
-	config.LoadConfig()
-	router := Routers(fstest.MapFS{
-		"index.html": {Data: []byte("<html></html>")},
-	})
-
-	// 无活跃会话：一律 401（篡改前的旧行为是放行，正是 MYS-378 修复的漏洞）
-	for _, p := range []string{"/api/device/ai-agent/port", "/api/device/ai-agent/proxy/index.html"} {
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodGet, p, nil)
-		req.Header.Set("Authorization", "Bearer whatever")
-		router.ServeHTTP(w, req)
-		if w.Code != http.StatusUnauthorized {
-			t.Fatalf("GET %s with no active session: status=%d want 401", p, w.Code)
+		if w.Code == http.StatusUnauthorized {
+			t.Fatalf("%s: endpoint must not require SSO, got 401", tc.name)
 		}
 	}
 }

--- a/source/psophliteos/router/system/sys_ai_agent.go
+++ b/source/psophliteos/router/system/sys_ai_agent.go
@@ -13,10 +13,10 @@ type AiAgentRouter struct{}
 // InitAiAgentRouter 注册 AI Agent 本地端点（不经 bmssm 反代）。
 // LLM/VLM 配置由 bmssm 的 /api/v1/llm-proxy/config 管理（经 /api/v1/* 反代），
 // 此处仅保留 picoclaw 端口探测、本地模型样例与页面转发。
-// MYS-379：AI Agent 本地端点是 AI 助手页面/内部 API（聊天记录、Agent 控制）的
-// 直达入口，此前无任何鉴权；与 OTA 一致叠加 SSO 单会话校验。
+// 鉴权：AI-Agent 端点属设备内部自用（同一设备内部服务/受信任访问，不经 ssm 反代），
+// 不设 SSO；MYS-379 的代理目标身份校验/路径白名单/探测缓存等加固保留（见 api 层）。
 func (s *AiAgentRouter) InitAiAgentRouter(Router *gin.RouterGroup) (R gin.IRoutes) {
-	agentRouter := Router.Group("api/device/ai-agent", middleware.SSO(), middleware.TimeoutMiddleware(global.TimeOut))
+	agentRouter := Router.Group("api/device/ai-agent", middleware.TimeoutMiddleware(global.TimeOut))
 	api := v1.ApiGroupApp.SystemApiGroup.AiAgentApi
 	{
 		agentRouter.GET("port", api.Port)


### PR DESCRIPTION
## 背景

MYS-379 修复（PR #106，已合入 main）为 `/api/device/ai-agent/*` 叠加了 SSO 鉴权。
用户裁定：该端点属设备**内部自用**（不经 ssm 反代，供设备内部服务/受信任访问），
不需要加鉴权。本 PR 移除 SSO，保留 MYS-379 其余加固。

## 改动

1. `router/system/sys_ai_agent.go`：`api/device/ai-agent` 路由组移除 `middleware.SSO()`，
   恢复为仅 `TimeoutMiddleware`（与修复前一致）
2. `initialization/sys_ai_agent_router_test.go`：删除 SSO 401 拦截用例（验证的行为已撤销），
   改为验证端点可达（非 404/401）
3. `api/v1/system/sys_ai_agent.go`：文件头注释同步（SSO 已不在本端点）

**保留不动**（非鉴权类加固，不影响内部自用访问）：
- 代理目标身份校验（部署锚定 + 候选端口白名单 + HTTP 探针禁重定向）
- 路径/方法白名单（入口页/静态资源/`/api/*`/`/ws*`，拒绝穿越与 CONNECT/TRACE）
- 探测缓存（ok 30s / miss 5s），消除 TOCTOU 与每请求 4 次探测
- 失败不回显探测细节

如这些加固也需一并回滚，请告知，可在此 PR 或新 PR 处理。

## 验证

- `go build ./...` / `go vet ./...` 通过
- `go test ./...` 全绿（api/v1/system 探测/白名单/代理用例、initialization 路由用例）