### PR TITLE
fix(bmssm): P2 一般问题清理：文件管理只读清单+符号链接解析/metrics 敏感 label/审计权限/docker tail 上限/compat 死代码 (MYS-390)

### DIFF
--- a/source/pbmssm/initialization/init.go
+++ b/source/pbmssm/initialization/init.go
@@ -86,8 +86,6 @@ func InitBase() {
 	// 每 updateIntervalSeconds 秒采集硬件指标→更新 sophon_* gauge→/metrics 暴露。
 	metrics.StartCollection(conf, metrics.DeviceLabels{
 		DeviceID:  "0",
-		Model:     global.DeviceTypeEx,
-		Serial:    global.DeviceSnEx,
 		ChipType:  global.ModuleType,
 		BoardType: global.ModuleTypeEx,
 	})

--- a/source/pbmssm/mvc/compat/controller.go
+++ b/source/pbmssm/mvc/compat/controller.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"syscall"
 	"time"
 
 	"bytes"
@@ -95,7 +96,7 @@ func (ctrl *Controller) requireHazardGuard(c *gin.Context, holder, action, resou
 	return guard, true
 }
 
-// getSecret 从配置获取 JWT secret。
+// getSecret 从配置获取 JWT secret（TerminalWS query token 校验等使用）。
 func getSecret() string {
 	conf := &config.Conf
 	conf.RLock()
@@ -105,51 +106,6 @@ func getSecret() string {
 		secret = auth.DefaultSecret
 	}
 	return secret
-}
-
-// ---------------------------------------------------------------
-// Login
-// ---------------------------------------------------------------
-
-// Login POST /api/v1/login（compat 形态）
-// 与 user.Controller.Login 一致：默认密码登录返回临时 token + changePass=true。
-func (ctrl *Controller) Login(c *gin.Context) {
-	var req LoginRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
-		return
-	}
-
-	user, err := ctrl.userSvc.Login(req.UserName, req.Password)
-	if err != nil {
-		c.JSON(http.StatusUnauthorized, response.Fail(err.Error()))
-		return
-	}
-
-	temp := req.Password == getDefaultPassword()
-	tokenStr, _, err := auth.IssueToken(user.Username, getSecret(), temp)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, response.Fail("failed to issue token"))
-		return
-	}
-
-	c.JSON(http.StatusOK, response.OK(SystemLoginResponse{
-		Token:      tokenStr,
-		Role:       user.Role,
-		ChangePass: temp,
-	}))
-}
-
-// getDefaultPassword 从配置读取默认密码（用于判定是否需强制改密）。
-func getDefaultPassword() string {
-	conf := &config.Conf
-	conf.RLock()
-	defer conf.RUnlock()
-	p := conf.GetViper().GetString("server.defaultPassword")
-	if p == "" {
-		p = "admin"
-	}
-	return p
 }
 
 // ---------------------------------------------------------------
@@ -293,33 +249,8 @@ func (ctrl *Controller) DeleteNAT(c *gin.Context) {
 // 重启 / 关机
 // ---------------------------------------------------------------
 
-// Reboot POST /bitmain/v1/ssm/hardware/devices/reset
-// 复用 hardware.HardwareService 的 Rebooter（生产用 osRebooter）。
-func (ctrl *Controller) Reboot(c *gin.Context) {
-	var req struct {
-		CoreOpe
-		Confirm string `json:"confirm"`
-	}
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
-		return
-	}
-
-	// MYS-389：二次确认 + 高危互斥 + 审计
-	guard, ok := ctrl.requireHazardGuard(c, "reboot", "reboot", "hardware", req.Confirm)
-	if !ok {
-		return
-	}
-	defer guard.Release()
-
-	if err := ctrl.hwSvc.Reboot(0); err != nil {
-		ctrl.auditWrite(c, uname(c), "reboot", "hardware", "failed")
-		c.JSON(http.StatusInternalServerError, response.Fail(err.Error()))
-		return
-	}
-	ctrl.auditWrite(c, uname(c), "reboot", "hardware", "success")
-	c.JSON(http.StatusOK, response.OK(nil))
-}
+// 重启走已挂载的 hwCtrl.Reboot（router admin 组 /hardware/reboot，
+// 含 MYS-389 二次确认+高危互斥），compat 未挂载的 Reboot 已删除。
 
 // uname 从 gin context 取用户名（middleware.Auth 注入）。
 func uname(c *gin.Context) string {
@@ -404,17 +335,63 @@ func (ctrl *Controller) GetSubscription(c *gin.Context) {
 // 设备配置
 // ---------------------------------------------------------------
 
-// SetBasic POST /bitmain/v1/ssm/software/device/configure/basic
+// SetBasic POST /api/v1/device/configure/basic
+// 真实实现（MYS-390，不再静默假成功）：
+//   - 修改系统 hostname（运行时 + /etc/hostname 持久化），失败如实报 500
+//   - 持久化 server.deviceName 到配置（GetCtrlBasic 的 deviceName 读取源）
+//
+// deviceType 不落盘：设备型号由全局设备信息决定，不允许用户改写。
 func (ctrl *Controller) SetBasic(c *gin.Context) {
 	var req BasicSettings
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, response.Fail("invalid request body"))
 		return
 	}
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		c.JSON(http.StatusBadRequest, response.Fail("deviceName is required"))
+		return
+	}
+	if !hostnameRe.MatchString(name) {
+		c.JSON(http.StatusBadRequest, response.Fail("invalid deviceName: only letters, digits, '-' and '.' allowed"))
+		return
+	}
 
-	// 降级：不做真 hostname 修改，返回成功 SsmResult
-	_ = req
+	// 1) 系统 hostname（失败如实报错；此时配置未动，保持状态一致）
+	if err := hostnameSetter(name); err != nil {
+		c.JSON(http.StatusInternalServerError, response.Fail("set hostname: "+err.Error()))
+		return
+	}
+
+	// 2) 配置持久化（GetCtrlBasic 的 deviceName 读取源），
+	// WriteConfig 失败降级为仅内存更新（与 SetAlarm 同模式：主机名已生效）
+	config.Conf.Lock()
+	defer config.Conf.Unlock()
+	v := config.Conf.GetViper()
+	v.Set("server.deviceName", name)
+	if err := v.WriteConfig(); err != nil {
+		logger.Warn("SetBasic WriteConfig failed (in-memory only): %v", err)
+	}
 	c.JSON(http.StatusOK, response.OK(nil))
+}
+
+// hostnameRe 限定 deviceName 为合法 hostname：字母/数字开头结尾，中间含
+// 字母数字、'-'、'.'，最长 63。
+var hostnameRe = regexp.MustCompile(`^[A-Za-z0-9]([A-Za-z0-9.-]{0,61}[A-Za-z0-9])?$`)
+
+// hostnameSetter 修改系统 hostname（包级变量，测试注入 fake 替换）。
+var hostnameSetter = realSetHostname
+
+// realSetHostname 运行时设置 hostname 并持久化到 /etc/hostname。
+func realSetHostname(name string) error {
+	if err := syscall.Sethostname([]byte(name)); err != nil {
+		return err
+	}
+	// 持久化失败不阻断：运行时已生效，仅告警
+	if err := os.WriteFile("/etc/hostname", []byte(name+"\n"), 0o644); err != nil {
+		logger.Warn("SetBasic persist /etc/hostname failed (runtime hostname applied): %v", err)
+	}
+	return nil
 }
 
 // SetAlarm POST /api/v1/device/configure/alarm
@@ -630,8 +607,9 @@ func (ctrl *Controller) GetWorkflow(c *gin.Context) {
 // ---------------------------------------------------------------
 
 // SCP POST /bitmain/v1/ssm/hardware/devices/scp
+// 未实现：如实返回 501 Not Implemented，杜绝调用方误以为操作成功（MYS-390）。
 func (ctrl *Controller) SCP(c *gin.Context) {
-	c.JSON(http.StatusOK, response.Fail("scp not supported"))
+	c.JSON(http.StatusNotImplemented, response.Fail("scp not supported"))
 }
 
 // Exec POST /bitmain/v1/ssm/hardware/devices/exec

--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -3,6 +3,7 @@ package compat
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
@@ -512,10 +513,16 @@ func TestCompatSubscribeFlow(t *testing.T) {
 }
 
 // ---------------------------------------------------------------
-// 设备配置降级测试
+// 设备配置测试
 // ---------------------------------------------------------------
 
+// TestCompatSetBasic 真实实现：持久化 deviceName 到配置 + 调用 hostname 设置。
 func TestCompatSetBasic(t *testing.T) {
+	// hostname setter 注入 fake（单测环境无 CAP_SYS_ADMIN，不能真改 hostname）
+	var gotName string
+	hostnameSetter = func(name string) error { gotName = name; return nil }
+	t.Cleanup(func() { hostnameSetter = realSetHostname })
+
 	r := setupCompatTest(t)
 	token := getNormalToken(t, r)
 
@@ -529,9 +536,66 @@ func TestCompatSetBasic(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	if w.Code != http.StatusOK {
-		t.Fatalf("set basic: expected 200, got %d", w.Code)
+		t.Fatalf("set basic: expected 200, got %d body=%s", w.Code, w.Body.String())
 	}
 	assertSsmOK(t, w.Body.Bytes(), "set basic")
+
+	if gotName != "my-device" {
+		t.Errorf("hostnameSetter called with %q, want my-device", gotName)
+	}
+	// 配置已持久化（GetCtrlBasic 的 deviceName 读取源）
+	config.Conf.RLock()
+	cfgName := config.Conf.GetViper().GetString("server.deviceName")
+	config.Conf.RUnlock()
+	if cfgName != "my-device" {
+		t.Errorf("config server.deviceName = %q, want my-device", cfgName)
+	}
+}
+
+// TestCompatSetBasicInvalidName 非法 deviceName 拒绝（400，不改配置不改 hostname）。
+func TestCompatSetBasicInvalidName(t *testing.T) {
+	var called bool
+	hostnameSetter = func(name string) error { called = true; return nil }
+	t.Cleanup(func() { hostnameSetter = realSetHostname })
+
+	r := setupCompatTest(t)
+	token := getNormalToken(t, r)
+
+	for _, bad := range []string{"", "bad name!", "a/b", "-leading"} {
+		body, _ := json.Marshal(BasicSettings{Name: bad, Type: "SE8"})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/device/configure/basic", bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("name %q: expected 400, got %d", bad, w.Code)
+		}
+	}
+	if called {
+		t.Error("hostnameSetter must not be called for invalid names")
+	}
+}
+
+// TestCompatSetBasicHostnameError hostname 设置失败如实报错（不再假成功）。
+func TestCompatSetBasicHostnameError(t *testing.T) {
+	hostnameSetter = func(name string) error { return errors.New("operation not permitted") }
+	t.Cleanup(func() { hostnameSetter = realSetHostname })
+
+	r := setupCompatTest(t)
+	token := getNormalToken(t, r)
+
+	body, _ := json.Marshal(BasicSettings{Name: "ok-name", Type: "SE8"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/device/configure/basic", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("set basic with hostname error: expected 500, got %d", w.Code)
+	}
+	assertSsmErr(t, w.Body.Bytes(), "set basic hostname error")
 }
 
 func TestCompatSetAlarm(t *testing.T) {
@@ -862,6 +926,10 @@ func TestCompatSCP(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+token)
 	r.ServeHTTP(w, req)
 
+	// 未实现：如实返回 501（MYS-390），杜绝调用方误以为成功
+	if w.Code != http.StatusNotImplemented {
+		t.Errorf("scp: expected 501, got %d", w.Code)
+	}
 	resp := assertSsmErr(t, w.Body.Bytes(), "scp")
 	if resp.ErrorMessage != "scp not supported" {
 		t.Errorf("scp: error_message = %q", resp.ErrorMessage)

--- a/source/pbmssm/mvc/compat/types.go
+++ b/source/pbmssm/mvc/compat/types.go
@@ -14,12 +14,6 @@ import "bmssm/pkg/metrics"
 // 请求类型
 // ---------------------------------------------------------------
 
-// LoginRequest 登录请求（对应 bmssm ReqLogin/sophliteos LoginRequest）。
-type LoginRequest struct {
-	UserName string `json:"userName"`
-	Password string `json:"password"`
-}
-
 // IPSettings IP 设置请求（字段名对齐 sophliteos 前端：ipType/subnetMask + ipv6*）。
 //   - IPType 1=静态 2=DHCP；IPv6Type 0=不配置 1=静态 2=DHCP（与 IPv4 独立）
 //   - Mask/Prefix6 为 CIDR 或点分掩码，透传给 bm_set_ip
@@ -93,13 +87,6 @@ type OtaVersion struct {
 // ---------------------------------------------------------------
 // 响应类型
 // ---------------------------------------------------------------
-
-// SystemLoginResponse 系统登录响应（对应 bmssm RespLogin/sophliteos SystemLoginResponse）。
-type SystemLoginResponse struct {
-	Token      string `json:"token"`
-	Role       string `json:"role"`
-	ChangePass bool   `json:"changePass,omitempty"`
-}
 
 // Ip IP 信息（对应 sophliteos Ip）。
 type Ip struct {

--- a/source/pbmssm/mvc/docker/service.go
+++ b/source/pbmssm/mvc/docker/service.go
@@ -3,6 +3,7 @@ package docker
 import (
 	"bytes"
 	"fmt"
+	"strconv"
 	"sync"
 
 	dockerclient "github.com/fsouza/go-dockerclient"
@@ -149,7 +150,24 @@ func (s *DockerService) RemoveImage(id string) error {
 	return s.client.RemoveImage(id)
 }
 
-// GetLogs 获取容器日志。
+// maxLogTailLines docker 日志 tail 上限：日志经 bytes.Buffer 整读进内存，
+// 限制行数防止 tail=all 时内存暴涨（MYS-390）。
+const maxLogTailLines = 5000
+
+// normalizeTail 将 docker log tail 参数钳制到 [1, maxLogTailLines]。
+// "all"/空/非法值按 maxLogTailLines 处理。
+func normalizeTail(tail string) string {
+	n, err := strconv.Atoi(tail)
+	if err != nil || n <= 0 {
+		return strconv.Itoa(maxLogTailLines)
+	}
+	if n > maxLogTailLines {
+		return strconv.Itoa(maxLogTailLines)
+	}
+	return tail
+}
+
+// GetLogs 获取容器日志。tail 强制钳制在 maxLogTailLines 内。
 func (s *DockerService) GetLogs(name string, tail string, since int64) (string, error) {
 	if !s.IsAvailable() {
 		return "", errUnavailable
@@ -160,7 +178,7 @@ func (s *DockerService) GetLogs(name string, tail string, since int64) (string, 
 		Container:    name,
 		OutputStream: &buf,
 		ErrorStream:  &buf,
-		Tail:         tail,
+		Tail:         normalizeTail(tail),
 		Since:        since,
 		Stdout:       true,
 		Stderr:       true,

--- a/source/pbmssm/mvc/docker/service_test.go
+++ b/source/pbmssm/mvc/docker/service_test.go
@@ -2,6 +2,7 @@ package docker
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 	"time"
 
@@ -17,14 +18,16 @@ type fakeDockerClient struct {
 	images     []dockerclient.APIImages
 	logs       map[string]string // container name -> log text
 
+	lastTail string // 最近一次 Logs 请求的 Tail 参数（断言钳制用）
+
 	// 错误注入
-	listContainersErr error
-	startContainerErr error
-	stopContainerErr  error
+	listContainersErr  error
+	startContainerErr  error
+	stopContainerErr   error
 	removeContainerErr error
-	listImagesErr     error
-	removeImageErr    error
-	logsErr           error
+	listImagesErr      error
+	removeImageErr     error
+	logsErr            error
 }
 
 func newFakeDockerClient() *fakeDockerClient {
@@ -120,6 +123,7 @@ func (f *fakeDockerClient) RemoveImage(name string) error {
 }
 
 func (f *fakeDockerClient) Logs(opts dockerclient.LogsOptions) error {
+	f.lastTail = opts.Tail
 	if f.logsErr != nil {
 		return f.logsErr
 	}
@@ -319,6 +323,33 @@ func TestServiceGetLogs(t *testing.T) {
 	}
 	if logs == "" {
 		t.Fatal("expected non-empty logs")
+	}
+}
+
+// TestServiceGetLogsTailClamped tail=all / 超大值被钳制到 maxLogTailLines，
+// 防 tail=all 时日志整体读入内存（MYS-390）。
+func TestServiceGetLogsTailClamped(t *testing.T) {
+	fake := newFakeDockerClient()
+	fake.logs["nginx"] = "log line\n"
+	svc := NewDockerServiceWithClient(fake)
+
+	cases := []struct{ in, want string }{
+		{"100", "100"},
+		{"all", "5000"},
+		{"", "5000"},
+		{"999999", "5000"},
+		{"abc", "5000"},
+	}
+	for _, tc := range cases {
+		if _, err := svc.GetLogs("nginx", tc.in, 0); err != nil {
+			t.Fatalf("GetLogs(%q): %v", tc.in, err)
+		}
+		if fake.lastTail != tc.want {
+			t.Errorf("GetLogs tail=%q: forwarded tail=%q, want %q", tc.in, fake.lastTail, tc.want)
+		}
+	}
+	if got := strconv.Itoa(maxLogTailLines); got != "5000" {
+		t.Errorf("maxLogTailLines=%d, want 5000", maxLogTailLines)
 	}
 }
 

--- a/source/pbmssm/mvc/filemanage/service.go
+++ b/source/pbmssm/mvc/filemanage/service.go
@@ -15,8 +15,13 @@ import (
 // maxContentSize 小文件文本查看上限 1MB。
 const maxContentSize = 1 << 20
 
-// blockedPrefixes 被禁止访问的路径前缀（/proc /sys /dev）。
+// blockedPrefixes 被禁止访问的路径前缀（/proc /sys /dev）。读与写均禁止。
 var blockedPrefixes = []string{"/proc", "/sys", "/dev"}
+
+// readonlyPrefixes 关键系统目录前缀：写操作（增/删/改/移动/上传）一律禁止，
+// 防止 admin 误操作（如 chmod/chown/覆盖 /etc 配置文件）导致设备不可用。
+// 读操作（列表/查看/下载）不受限，便于查看配置文件核对状态。
+var readonlyPrefixes = []string{"/etc", "/boot", "/var", "/opt", "/usr", "/bin", "/sbin", "/lib", "/lib64", "/run"}
 
 type Service struct{}
 
@@ -34,7 +39,8 @@ func HomeDir() string {
 	return "/root"
 }
 
-// ResolvePath 规范化并校验路径。空 path 返回家目录；转绝对路径并 Clean；
+// ResolvePath 规范化并校验路径。空 path 返回家目录；转绝对路径并解析符号链接
+// （对路径上最深已存在部分做 EvalSymlinks，防 blocklist 被 symlink 绕过）；
 // 禁止访问 /proc /sys /dev 前缀。
 func ResolvePath(path string) (string, error) {
 	if strings.TrimSpace(path) == "" {
@@ -44,12 +50,61 @@ func ResolvePath(path string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve path: %w", err)
 	}
+	real, err := resolveReal(abs)
+	if err != nil {
+		return "", err
+	}
 	for _, p := range blockedPrefixes {
-		if abs == p || strings.HasPrefix(abs, p+"/") {
+		if real == p || strings.HasPrefix(real, p+"/") {
 			return "", fmt.Errorf("access to %s is not allowed", p)
 		}
 	}
+	return real, nil
+}
+
+// ResolveWritePath 校验写操作路径：在 ResolvePath 基础上，禁止落在
+// 关键系统目录（readonlyPrefixes）内，防误操作破坏设备系统文件。
+func ResolveWritePath(path string) (string, error) {
+	abs, err := ResolvePath(path)
+	if err != nil {
+		return "", err
+	}
+	for _, p := range readonlyPrefixes {
+		if abs == p || strings.HasPrefix(abs, p+"/") {
+			return "", fmt.Errorf("write access to %s is not allowed", p)
+		}
+	}
 	return abs, nil
+}
+
+// resolveReal 对 abs 上最深已存在部分做符号链接解引用，返回归一化真实路径；
+// 不存在的尾部段保持原样拼接（写操作目标可能尚未创建）。
+// 例如 /root/link->/etc 的 /root/link/passwd 解析为 /etc/passwd；
+// 新建目标 /root/newdir 时 /root 存在则原样返回 /root/newdir。
+// 已知限制：检查与后续操作之间存在 TOCTOU 竞态（检查后 symlink 可能被替换），
+// admin-only 工具可接受；如需更强保证可用 openat2(RESOLVE_NO_SYMLINKS)。
+func resolveReal(abs string) (string, error) {
+	rest := abs
+	var tail []string
+	for {
+		resolved, err := filepath.EvalSymlinks(rest)
+		if err == nil {
+			if len(tail) == 0 {
+				return resolved, nil
+			}
+			return filepath.Join(append([]string{resolved}, tail...)...), nil
+		}
+		// 仅"不存在"（ENOENT/ENOTDIR）向上回溯父段；权限等错误直接返回
+		if !errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("resolve path %q: %w", abs, err)
+		}
+		parent := filepath.Dir(rest)
+		if parent == rest {
+			return "", fmt.Errorf("resolve path %q: %w", abs, err)
+		}
+		tail = append([]string{filepath.Base(rest)}, tail...)
+		rest = parent
+	}
 }
 
 // List 列目录。返回绝对目录路径与每个条目的 FileInfo（含属主/组名）。
@@ -101,9 +156,9 @@ func (s *Service) ReadContent(path string) (string, error) {
 }
 
 // Mkdir 递归创建目录（mkdir -p）。拒绝在根目录下创建一级目录（/xxx），
-// 防止污染系统根；二级及以下（如 /root/newdir）允许。
+// 防止污染系统根；二级及以下（如 /root/newdir）允许；关键系统目录内拒绝。
 func (s *Service) Mkdir(path string) error {
-	abs, err := ResolvePath(path)
+	abs, err := ResolveWritePath(path)
 	if err != nil {
 		return err
 	}
@@ -117,22 +172,22 @@ func (s *Service) Mkdir(path string) error {
 	return os.MkdirAll(abs, 0o755)
 }
 
-// Rename 重命名/移动。
+// Rename 重命名/移动。源与目标均不得落在关键系统目录内。
 func (s *Service) Rename(oldPath, newPath string) error {
-	oldAbs, err := ResolvePath(oldPath)
+	oldAbs, err := ResolveWritePath(oldPath)
 	if err != nil {
 		return err
 	}
-	newAbs, err := ResolvePath(newPath)
+	newAbs, err := ResolveWritePath(newPath)
 	if err != nil {
 		return err
 	}
 	return os.Rename(oldAbs, newAbs)
 }
 
-// Chmod 修改权限。mode 为八进制权限串，形如 "0755" 或 "755"。
+// Chmod 修改权限。mode 为八进制权限串，形如 "0755" 或 "755"。关键系统目录内拒绝。
 func (s *Service) Chmod(path, mode string) error {
-	abs, err := ResolvePath(path)
+	abs, err := ResolveWritePath(path)
 	if err != nil {
 		return err
 	}
@@ -148,9 +203,9 @@ func (s *Service) Chmod(path, mode string) error {
 	return os.Chmod(abs, os.FileMode(n))
 }
 
-// Chown 修改所有权。需 root 权限执行。
+// Chown 修改所有权。需 root 权限执行。关键系统目录内拒绝。
 func (s *Service) Chown(path, owner, group string) error {
-	abs, err := ResolvePath(path)
+	abs, err := ResolveWritePath(path)
 	if err != nil {
 		return err
 	}
@@ -177,8 +232,9 @@ func (s *Service) Chown(path, owner, group string) error {
 //   - 只删文件，拒绝删除目录（IsDir 直接报错）
 //   - 不递归：用 os.Remove（非 os.RemoveAll），目录/非空路径会失败
 //   - 拒删根、根下一级目录（depth<=1）
+//   - 关键系统目录内拒绝
 func (s *Service) Delete(path string) error {
-	abs, err := ResolvePath(path)
+	abs, err := ResolveWritePath(path)
 	if err != nil {
 		return err
 	}
@@ -227,9 +283,9 @@ func (s *Service) DownloadName(path string) (name string, size int64, err error)
 }
 
 // SaveUpload 将 reader 内容流式写入 dir/<filename>。支持大文件。
-// 仅取基名，禁止路径穿越（如 ../etc/passwd）。
+// 仅取基名，禁止路径穿越（如 ../etc/passwd）；目标目录不得在关键系统目录内。
 func (s *Service) SaveUpload(dir, filename string, r io.Reader) (string, int64, error) {
-	abs, err := ResolvePath(dir)
+	abs, err := ResolveWritePath(dir)
 	if err != nil {
 		return "", 0, err
 	}

--- a/source/pbmssm/mvc/filemanage/service_test.go
+++ b/source/pbmssm/mvc/filemanage/service_test.go
@@ -1,0 +1,86 @@
+package filemanage
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestResolvePathSymlinkBypass symlink 指向被禁前缀时读路径也拒绝（blocklist 不可绕过）。
+func TestResolvePathSymlinkBypass(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "proc-link")
+	if err := os.Symlink("/proc", link); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ResolvePath(filepath.Join(link, "cpuinfo")); err == nil {
+		t.Fatal("expected refusal for symlink into /proc")
+	}
+}
+
+// TestResolvePathReadAllowed 读操作允许访问关键系统目录（/etc）。
+func TestResolvePathReadAllowed(t *testing.T) {
+	if !isUnder(filepath.Clean("/etc"), readonlyPrefixes) {
+		t.Fatal("/etc not in readonly list?")
+	}
+	p, err := ResolvePath("/etc/hostname")
+	if err != nil {
+		t.Fatalf("read /etc should be allowed: %v", err)
+	}
+	if !strings.HasPrefix(p, "/etc/") {
+		t.Fatalf("resolved=%q, want /etc/hostname", p)
+	}
+}
+
+// TestResolveWritePathReadonly 写操作拒绝关键系统目录。
+func TestResolveWritePathReadonly(t *testing.T) {
+	for _, p := range readonlyPrefixes {
+		// /etc 下文件可能不存在（如 /etc/not-exist），前缀检查在 stat 之前，仍应拒绝
+		if _, err := ResolveWritePath(filepath.Join(p, "x")); err == nil {
+			t.Errorf("write to %s/x should be refused", p)
+		}
+		if _, err := ResolveWritePath(p); err == nil {
+			t.Errorf("write to %s itself should be refused", p)
+		}
+	}
+	// readonly 前缀下不存在路径的父段解析（/var/log/custom/child 中 /var/log/custom 不存在）
+	if _, err := ResolveWritePath("/var/log/custom/child"); err == nil {
+		t.Errorf("write to /var/log/custom/child should be refused")
+	}
+}
+
+// TestResolveWritePathSymlinkBypass 通过 writable 目录下 symlink 指向 /etc 的写路径拒绝。
+func TestResolveWritePathSymlinkBypass(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "etc-link")
+	if err := os.Symlink("/etc", link); err != nil {
+		t.Fatal(err)
+	}
+	// 删除/etc 内文件：/tmp/x/etc-link/passwd 归一化到 /etc/passwd → 拒绝
+	if _, err := ResolveWritePath(filepath.Join(link, "passwd")); err == nil {
+		t.Fatal("expected refusal for symlink write into /etc")
+	}
+}
+
+// TestResolveWritePathNonExistentParent 新建路径（父目录存在）正常解析。
+func TestResolveWritePathNonExistentParent(t *testing.T) {
+	dir := t.TempDir()
+	p, err := ResolveWritePath(filepath.Join(dir, "new", "dir"))
+	if err != nil {
+		t.Fatalf("new dir under temp dir should be allowed: %v", err)
+	}
+	if !strings.HasPrefix(p, dir) {
+		t.Fatalf("resolved=%q, want prefix %q", p, dir)
+	}
+}
+
+// isUnder 判断 abs 是否位于 readonly 列表任一前缀下（测试辅助，镜像生产逻辑）。
+func isUnder(abs string, list []string) bool {
+	for _, p := range list {
+		if abs == p || strings.HasPrefix(abs, p+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/source/pbmssm/pkg/metrics/prometheus.go
+++ b/source/pbmssm/pkg/metrics/prometheus.go
@@ -7,20 +7,20 @@ import (
 
 const namespace = "sophon"
 
-var defaultLabels = []string{"device_id", "model", "serial", "chip_type", "board_type"}
+// defaultLabels 指标标签。serial/model 属设备敏感信息，/metrics 公开抓取
+// （Prometheus scrape 不带 Authorization 头），不暴露给未授权内网用户（MYS-390）。
+var defaultLabels = []string{"device_id", "chip_type", "board_type"}
 
-// DeviceLabels Prometheus 标签值（对齐 Rust exporter 的 5 元组标签）。
+// DeviceLabels Prometheus 标签值（去敏感 label 后的 3 元组）。
 type DeviceLabels struct {
 	DeviceID  string
-	Model     string
-	Serial    string
 	ChipType  string
 	BoardType string
 }
 
 // labelsForDevice 将 DeviceLabels 转换为 Prometheus label values 切片。
 func labelsForDevice(d DeviceLabels) []string {
-	return []string{d.DeviceID, d.Model, d.Serial, d.ChipType, d.BoardType}
+	return []string{d.DeviceID, d.ChipType, d.BoardType}
 }
 
 // MetricsRegistry 持有全部 24 个 Prometheus gauge（对齐 Rust exporter 指标集）。

--- a/source/pbmssm/pkg/metrics/prometheus_test.go
+++ b/source/pbmssm/pkg/metrics/prometheus_test.go
@@ -60,7 +60,7 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 		}
 	})
 	dev := DeviceLabels{
-		DeviceID: "0", Model: "SE5", Serial: "SN123",
+		DeviceID: "0",
 		ChipType: "BM1684", BoardType: "0x10",
 	}
 	hw := &HardwareMetrics{
@@ -103,8 +103,14 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 		t.Fatal("no metrics in sophon_cpu_usage_percent")
 	}
 	labels := mf.Metric[0].GetLabel()
-	if len(labels) != 5 {
-		t.Errorf("expected 5 labels, got %d", len(labels))
+	if len(labels) != 3 {
+		t.Errorf("expected 3 labels, got %d", len(labels))
+	}
+	// 敏感 label（serial/model）不得出现在 /metrics 暴露的指标中（MYS-390）
+	for _, l := range labels {
+		if l.GetName() == "serial" || l.GetName() == "model" {
+			t.Errorf("sensitive label %q must not be exposed", l.GetName())
+		}
 	}
 
 	r.Reset()
@@ -117,9 +123,9 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 }
 
 func TestLabelsForDevice(t *testing.T) {
-	d := DeviceLabels{DeviceID: "0", Model: "SE7", Serial: "ABC", ChipType: "BM1684X", BoardType: "3"}
+	d := DeviceLabels{DeviceID: "0", ChipType: "BM1684X", BoardType: "3"}
 	got := labelsForDevice(d)
-	if len(got) != 5 || got[0] != "0" || got[3] != "BM1684X" {
-		t.Errorf("labelsForDevice = %v, want [0 SE7 ABC BM1684X 3]", got)
+	if len(got) != 3 || got[0] != "0" || got[1] != "BM1684X" || got[2] != "3" {
+		t.Errorf("labelsForDevice = %v, want [0 BM1684X 3]", got)
 	}
 }

--- a/source/pbmssm/router/router.go
+++ b/source/pbmssm/router/router.go
@@ -93,9 +93,6 @@ func Register(r *gin.Engine) {
 		// 高危操作二次确认码（MYS-389）：任何 reboot/shutdown/OTA/install 前先取码
 		api.GET("/hazard/challenge", hwCtrl.Challenge)
 
-		// 审计日志
-		api.GET("/audit", auditCtrl.ListLogs)
-
 		// 系统日志下载（流式 tar.gz: /var/log/kern* + syslog*）
 		api.GET("/logs/download", logsCtrl.DownloadLogs)
 
@@ -210,6 +207,10 @@ func Register(r *gin.Engine) {
 		// 告警订阅（写）
 		admin.POST("/software/notify/subscribe", compatCtrl.SubscribeAlarm)
 		admin.POST("/software/notify/unsubscribe", compatCtrl.UnsubscribeAlarm)
+
+		// 审计日志（含全部用户登录 IP/操作记录）：并入 admin 组，
+		// 普通 user 不可查看他人操作痕迹（MYS-390）
+		admin.GET("/audit", auditCtrl.ListLogs)
 
 		// 文件管理（读 + 写均需 admin：涉及设备敏感文件）
 		// 注：download 保留在公开区（<a download> 需 query token 鉴权），见 public 段。


### PR DESCRIPTION
## 背景

MYS-390：bmssm P2 一般问题清理（MYS-377 审查发现，5 个修复点）。非安全关键，但影响健壮性与信息暴露面。

## 修复内容

1. **文件管理只读清单 + 符号链接解析**（`mvc/filemanage/service.go`）
   - 新增 `readonlyPrefixes`（/etc /boot /var /opt /usr /bin /sbin /lib /lib64 /run），写操作（Mkdir/Rename/Chmod/Chown/Delete/SaveUpload）统一走新增 `ResolveWritePath` 拒绝写入，防 admin 误操作让设备不可用
   - `ResolvePath` 新增符号链接解析（`resolveReal`：对最深已存在前缀做 EvalSymlinks），blocklist 不可再被 symlink 绕过（如 /root/link→/etc 的写路径归一化后被拦截）
   - 读操作（列表/查看/下载）不受限，便于查看配置文件

2. **/metrics 移除敏感 label**（`pkg/metrics/prometheus.go`）
   - `defaultLabels` 从 5 元组（device_id/model/serial/chip_type/board_type）精简为 3 元组（device_id/chip_type/board_type），serial/model 不再暴露给未授权内网用户
   - ⚠️ 行为变更：依赖 model/serial 标签的监控 dashboard 需相应调整（若内网监控消费方需要这些维度，请告知，可另议仅内网 ACL 方案）

3. **审计日志列表并入 admin 组**（`router/router.go`）
   - `GET /api/v1/audit`（含全部用户登录 IP/操作记录）从仅 Auth 组移入 admin 组（Auth+RequireAdmin），普通 user 不再可查看他人操作痕迹

4. **docker GetLogs 强制 tail 上限**（`mvc/docker/service.go`）
   - tail 参数钳制到 [1,5000]，`all`/空/非法值按 5000 处理，杜绝 tail=all 时日志整体读入内存

5. **兼容层死代码清理 + SetBasic 真实实现**（`mvc/compat/`）
   - 删除从未挂路由的 `compat.Login`/`compat.Reboot`（及 `LoginRequest`/`SystemLoginResponse` 类型）；重启正路走已挂载的 `hwCtrl.Reboot`
   - `SCP` 从 HTTP 200+Fail 改为明确 **501 Not Implemented**，杜绝调用方误判
   - `SetBasic`（前端设备信息修改入口）从"直接返回成功"改为真实实现：`syscall.Sethostname` + /etc/hostname 持久化 + `server.deviceName` 配置写入，失败如实报 500，不再静默假成功

## 测试

- `go build ./...` / `go vet ./...` 通过
- `go test ./...` 全量通过（33 包），新增/更新测试：
  - filemanage：symlink 绕过回归（读/写）、readonly 前缀拒绝、不存在父段解析
  - metrics：label 数 3 + serial/model 不得出现
  - docker：tail 钳制 5 种输入断言（fake 记录透传 Tail）
  - compat：SetBasic 成功/非法名/主机名失败三路径、SCP 501
- 构建脚本 `build-bmssm.sh`（x86）通过，产物正常

## 兼容性说明

- 文件管理读接口返回解析后的真实路径（前端展示路径可能变化）
- /metrics 标签集变化（见上）；其余接口响应信封结构不变
