### PR TITLE
fix(bmssm): llm-proxy 对内转发不再校验 key/限流

### DIFF
--- a/source/pbmssm/mvc/llmproxy/server.go
+++ b/source/pbmssm/mvc/llmproxy/server.go
@@ -156,8 +156,8 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 
 // handleChatCompletions POST /v1/chat/completions —— OpenAI 兼容转发。
 // 流程（图片描述化，防止含图历史进入 VLM 导致推理质量下滑）：
-//  1. 转发 key 校验（MYS-171 放宽）：仅配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
-//     未配置 / 未携带 / 不匹配均放行，不强制拦截。
+//  1. 转发 key 校验：对内（默认仅监听 127.0.0.1 回环）服务不做入站 key 校验与限流——
+//     本机组件凭操作系统访问边界信任；ForwardKey 仅作旧 picoclaw 链路的兼容配置保留。
 //  2. 遍历所有 messages 的 content：
 //     - 文本块 → 保留
 //     - 图片块（image_url/image）→ 提取图片数据 → 哈希查缓存：
@@ -169,14 +169,9 @@ func handleModels(w http.ResponseWriter, r *http.Request) {
 func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	cfg := currentConfig()
 
-	// 1. 转发 key 校验（MYS-171：放宽策略，不做强制拦截）。
-	//    仅当配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
-	//    key 未配置 / 请求未携带 / 不匹配均放行。18080 为内部回环代理，
-	//    仅本机可信进程（reasonix 等）调用，不做安全加固。
-	if cfg.ForwardKey != "" && !validForwardKey(r, cfg.ForwardKey) {
-		logger.Warn("llm proxy: forward key mismatch (config set, request key absent or wrong)")
-	}
-
+	// 1. 转发 key 校验：对内（默认仅监听 127.0.0.1 回环）服务不做入站 key 校验与限流——
+	//    本机组件凭操作系统访问边界信任；ForwardKey 仅作旧 picoclaw 链路的兼容配置保留。
+	//    （18080 为内部回环代理，仅本机可信进程调用，不做安全加固。）
 	body, err := io.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
@@ -207,16 +202,6 @@ func handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	// 4. 透传响应
 	w.WriteHeader(statusCode)
 	_, _ = w.Write(respBody)
-}
-
-// validForwardKey 校验请求携带的转发 key 与配置一致（Bearer <key>）。
-func validForwardKey(r *http.Request, want string) bool {
-	h := r.Header.Get("Authorization")
-	if !strings.HasPrefix(h, "Bearer ") {
-		return false
-	}
-	got := strings.TrimSpace(strings.TrimPrefix(h, "Bearer "))
-	return got != "" && got == want
 }
 
 // describeImagesInRequest 遍历所有 message，把图片块替换为文本描述块。

--- a/source/pbmssm/mvc/llmproxy/server_test.go
+++ b/source/pbmssm/mvc/llmproxy/server_test.go
@@ -106,8 +106,8 @@ func TestServiceLoadWhenDBEmpty(t *testing.T) {
 	}
 }
 
-// TestForwardKeyRelaxed 验证 MYS-171 放宽后的 key 策略：
-// 配置了 ForwardKey 时，无 key / 错误 key 均不再 401（放行到上游）。
+// TestForwardKeyRelaxed 锁定对内不校验 key 的行为（防回归）：
+// 即使配置了 ForwardKey，无 key / 错误 key / 匹配 key 一律放行到上游。
 func TestForwardKeyRelaxed(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()
@@ -156,7 +156,7 @@ func TestForwardKeyRelaxed(t *testing.T) {
 	}
 }
 
-// TestForwardKeyUnset 验证未配置 ForwardKey 时同样放行（不要求鉴权）。
+// TestForwardKeyUnset 验证未配置 ForwardKey 时同样放行（对内不要求鉴权）。
 func TestForwardKeyUnset(t *testing.T) {
 	db := setupTestDB(t)
 	defer db.Close()

--- a/source/pbmssm/mvc/llmproxy/types.go
+++ b/source/pbmssm/mvc/llmproxy/types.go
@@ -5,8 +5,9 @@
 // 代理检测请求中是否含 image_url 分流到 VLM / LLM 配置的上游，
 // 请求带非空 model 则保留，否则替换为对应配置的模型名后转发到上游 api_base。
 //
-// 入站 key 校验（MYS-171 放宽）：仅配置了 ForwardKey 且请求携带匹配 key 时视为已鉴权；
-// 未配置 / 未携带 / 不匹配均放行，不强制拦截。转发时用 bmssm 内部存储的上游 key。
+// 入站策略：对内（默认仅监听 127.0.0.1 回环）不做 key 校验与限流——本机组件
+// 凭操作系统访问边界信任，转发时用 bmssm 内部存储的上游 key。ForwardKey 仅作
+// 旧 picoclaw 链路的兼容配置保留（不再参与入站鉴权）。
 package llmproxy
 
 import (


### PR DESCRIPTION
## 背景

llm-proxy 是对内转发服务（默认仅监听 `127.0.0.1` 回环，供本机 PicoClaw / reasonix 等组件调用），
入站不应做 key 校验与限流——本机组件凭操作系统访问边界信任。

## 改动

- **删除入站 key 校验残留**：`handleChatCompletions` 中 MYS-171 放宽后仅剩的 `ForwardKey` 软校验
  （配置了 key 且请求不匹配时打 WARN 日志）与 `validForwardKey` 函数一并移除
- **ForwardKey 保留为兼容配置**：管理接口（生成/重置/写入 picoclaw devproxy.key）流程不变，
  仅不再参与入站鉴权
- **限流核查**：转发端点（18080，原生 http server）经核查从未挂限流中间件，无需移除；
  bmssm 主服务 API 面的全局 `RateLimit(100, 10ms)` 属管理面防 DoS，不在本改动范围

## 测试

- `go build ./...`、`go vet`、gofmt 干净
- `go test ./...` 全量通过；`TestForwardKeyRelaxed` / `TestForwardKeyUnset` 防回归测试
  保留（断言行为不变：带 key / 无 key / 错 key 一律放行到上游）

🤖 Generated with [Claude Code](https://claude.com/claude-code)