### PR TITLE
fix(psophliteos): 防火墙意图操作接入 hazard challenge 二次确认 + 文件管理目录隐藏删除 (MYS-446)

### DIFF
--- a/source/psophliteos/frontend/src/api/maintenance/firewall.ts
+++ b/source/psophliteos/frontend/src/api/maintenance/firewall.ts
@@ -4,15 +4,19 @@ export interface EnvIssue { check: string; message: string; fix_cmd: string; }
 export interface EnvResult { ok: boolean; issues: EnvIssue[]; }
 export interface StatusResult { environment: EnvResult; protectPorts: number[]; }
 export interface Intent { id?: number; type: string; params: string; enabled: boolean; }
+export interface HazardChallenge { code: string; expiresInSecs: number; }
 
 enum Api {
   Status = '/v1/firewall/status',
   Intent = '/v1/firewall/intent',
   Rebuild = '/v1/firewall/rebuild',
+  Challenge = '/v1/hazard/challenge',
 }
 
 export const getStatus = () => defHttp.get<StatusResult>({ url: Api.Status }, { errorMessageMode: 'none' });
 export const getIntents = () => defHttp.get<Intent[]>({ url: Api.Intent });
 export const addIntent = (params: Intent) => defHttp.post({ url: Api.Intent, params });
 export const deleteIntent = (id: number) => defHttp.delete({ url: `${Api.Intent}/${id}` });
-export const rebuildFirewall = () => defHttp.post({ url: Api.Rebuild });
+// 高危操作二次确认（MYS-389）：rebuild 前须先取一次性确认码，再携带 confirm 调用。
+export const getHazardChallenge = () => defHttp.get<HazardChallenge>({ url: Api.Challenge });
+export const rebuildFirewall = (confirm: string) => defHttp.post({ url: Api.Rebuild, params: { confirm } });

--- a/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
@@ -180,5 +180,11 @@ export default {
     disabledOk: 'Disabled',
     toggleFail: 'Toggle failed',
     reset: 'Reset',
+    portAllow: 'Port Allow',
+    portDeny: 'Port Deny',
+    highRiskConfirmTitle: 'High-risk operation confirmation',
+    highRiskConfirmContent: 'Confirmation code: {code} (valid for {secs}s). This high-risk operation takes effect immediately. Please confirm.',
+    challengeFail: 'Failed to fetch confirmation code',
+    actionFail: 'Operation failed',
   },
 };

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
@@ -185,5 +185,11 @@ export default {
     disabledOk: '已禁用',
     toggleFail: '切换失败',
     reset: '重置',
+    portAllow: '端口放行',
+    portDeny: '端口拒绝',
+    highRiskConfirmTitle: '高危操作二次确认',
+    highRiskConfirmContent: '二次确认码：{code}（{secs} 秒内有效）。高危操作将立即生效，请确认执行。',
+    challengeFail: '获取二次确认码失败',
+    actionFail: '操作失败',
   },
 };

--- a/source/psophliteos/frontend/src/views/maintenance/filemanage/index.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/filemanage/index.vue
@@ -89,7 +89,9 @@
               <a-button size="small" @click="openChown(record)">{{
                 t('maintenance.fileManage.chown')
               }}</a-button>
+              <!-- 后端（MYS-390）明确拒绝删除目录（仅文件可删）：目录行不显示删除按钮 -->
               <a-popconfirm
+                v-if="!record.isDir"
                 :title="t('maintenance.fileManage.deleteConfirm')"
                 @confirm="removeFile(record)"
               >

--- a/source/psophliteos/frontend/src/views/maintenance/firewall/Intent.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/firewall/Intent.vue
@@ -53,8 +53,9 @@
 </template>
 
 <script lang="ts" setup>
-  import { ref } from 'vue';
-  import { Card, Select, Switch, message } from 'ant-design-vue';
+  import { ref, h } from 'vue';
+  import { Card, Select, Switch, Modal, message } from 'ant-design-vue';
+  import { ExclamationCircleOutlined } from '@ant-design/icons-vue';
   import { BasicTable, useTable, TableAction } from '/@/components/Table';
   import { BasicForm, useForm } from '/@/components/Form/index';
   import { useI18n } from '/@/hooks/web/useI18n';
@@ -68,7 +69,9 @@
     addIntent,
     deleteIntent,
     rebuildFirewall,
+    getHazardChallenge,
     type Intent,
+    type HazardChallenge,
   } from '/@/api/maintenance/firewall';
 
   const ACard = Card;
@@ -109,18 +112,102 @@
     return JSON.stringify(values);
   }
 
+  // describeIntent 生成待执行操作的描述文本（确认弹窗展示）。
+  function describeIntent(type: string, raw: any, enabled?: boolean): string {
+    const names: Record<string, string> = {
+      port_allow: t('maintenance.firewall.portAllow'),
+      port_deny: t('maintenance.firewall.portDeny'),
+      rate_limit: '速率限制',
+      ip_whitelist: 'IP 白名单',
+      ip_blacklist: 'IP 黑名单',
+      icmp: 'ICMP',
+    };
+    let desc = names[type] || type;
+    if (typeof raw === 'string') {
+      try {
+        raw = JSON.parse(raw);
+      } catch {
+        /* keep raw */
+      }
+    }
+    if (raw && typeof raw === 'object') {
+      desc += `: ${raw.port ?? ''} ${raw.proto ?? ''} ${raw.src ?? ''}`.trim();
+    }
+    if (typeof enabled === 'boolean') {
+      desc += enabled ? '（启用）' : '（禁用）';
+    }
+    return desc;
+  }
+
+  // confirmHighRisk MYS-389 二次确认：取一次性确认码 → 弹确认框展示码 → 用户确认后执行。
+  async function confirmHighRisk(desc: string, doIt: (confirm: string) => Promise<void>): Promise<boolean> {
+    let ch: HazardChallenge;
+    try {
+      ch = await getHazardChallenge();
+    } catch (e: any) {
+      message.error(e?.message || t('maintenance.firewall.challengeFail'));
+      return false;
+    }
+    return await new Promise<boolean>((resolve) => {
+      Modal.confirm({
+        title: t('maintenance.firewall.highRiskConfirmTitle'),
+        icon: h(ExclamationCircleOutlined),
+        width: 480,
+        content: () =>
+          h('div', [
+            h('p', { style: { 'font-weight': 550 } }, desc),
+            h(
+              'p',
+              { style: { color: '#fa8c16', margin: '8px 0 4px', 'font-size': '13px' } },
+              t('maintenance.firewall.highRiskConfirmContent', {
+                code: ch.code,
+                secs: ch.expiresInSecs ?? 120,
+              }),
+            ),
+          ]),
+        onOk: async () => {
+          try {
+            await doIt(ch.code);
+            resolve(true);
+          } catch (e: any) {
+            message.error(e?.response?.data?.error_message || e?.message || t('maintenance.firewall.actionFail'));
+            resolve(false);
+          }
+        },
+        onCancel: () => resolve(false),
+      });
+    });
+  }
+
+  // rebuildWithConfirm 携带确认码重建防火墙；码过期（403）时自动重新取码重试一次，
+  // 保证与用户已确认的操作语义一致，避免因取码到执行间隔超时导致规则残留。
+  async function rebuildWithConfirm(initialCode: string): Promise<void> {
+    try {
+      await rebuildFirewall(initialCode);
+    } catch (e: any) {
+      const msg = e?.response?.data?.error_message || e?.message || '';
+      if (msg.includes('confirmation required')) {
+        const ch2 = await getHazardChallenge();
+        await rebuildFirewall(ch2?.code || '');
+        return;
+      }
+      throw e;
+    }
+  }
+
   async function handleAdd() {
     try {
       const values = await validate();
       adding.value = true;
-      await addIntent({
-        type: currentPreset.value,
-        params: buildParams(values),
-        enabled: true,
+      const type = currentPreset.value;
+      const ok = await confirmHighRisk(`${t('maintenance.firewall.add')}: ${describeIntent(type, values)}`, async (confirm) => {
+        await addIntent({ type, params: buildParams(values), enabled: true });
+        await rebuildWithConfirm(confirm);
       });
-      await rebuildFirewall();
-      message.success(t('maintenance.firewall.addOk'));
-      await resetFields();
+      if (ok) {
+        message.success(t('maintenance.firewall.addOk'));
+        await resetFields();
+      }
       reload();
     } catch (e: any) {
       if (e?.message) message.error(e.message);
@@ -135,10 +222,14 @@
 
   async function handleToggle(record: Intent, checked: boolean) {
     try {
-      await addIntent({ ...record, enabled: checked });
-      await rebuildFirewall();
-      message.success(checked ? t('maintenance.firewall.enabledOk') : t('maintenance.firewall.disabledOk'));
-      reload();
+      const ok = await confirmHighRisk(describeIntent(record.type, record.params, checked), async (confirm) => {
+        await addIntent({ ...record, enabled: checked });
+        await rebuildWithConfirm(confirm);
+      });
+      if (ok) {
+        message.success(checked ? t('maintenance.firewall.enabledOk') : t('maintenance.firewall.disabledOk'));
+      }
+      reload(); // 取消时回滚开关显示
     } catch (e: any) {
       message.error(e?.message || t('maintenance.firewall.toggleFail'));
       reload();
@@ -147,13 +238,13 @@
 
   async function handleDelete(record: Intent) {
     if (!record.id) return;
-    try {
+    const ok = await confirmHighRisk(t('maintenance.firewall.delete') + ': ' + describeIntent(record.type, record.params, record.enabled), async (confirm) => {
       await deleteIntent(record.id);
-      await rebuildFirewall();
+      await rebuildWithConfirm(confirm);
+    });
+    if (ok) {
       message.success(t('maintenance.firewall.deleteOk'));
-      reload();
-    } catch (e: any) {
-      message.error(e?.message || t('maintenance.firewall.deleteFail'));
     }
+    reload();
   }
 </script>


### PR DESCRIPTION
## 背景

bmssm 2.2.0（MYS-389 高危操作二次确认）要求防火墙 rebuild 携带 `/api/v1/hazard/challenge` 一次性确认码；前端未实现该流程，导致添加/删除/开关防火墙意图时 rebuild 恒 403（confirmation required），规则无法生效且残留 DB。MYS-445 真机测试发现并记录。

## 改动

- `api/maintenance/firewall.ts`：新增 `getHazardChallenge()`；`rebuildFirewall(confirm)` 携带确认码
- `views/maintenance/firewall/Intent.vue`：添加/切换/删除意图前取码，弹「高危操作二次确认」对话框展示操作描述 + 确认码（120s 有效），确认后执行意图变更 + rebuild；确认码过期（403）自动重新取码重试一次，避免规则残留
- `views/maintenance/filemanage/index.vue`：目录行隐藏「删除」按钮（后端明确拒删目录，仅文件可删）
- `locales`：新增二次确认相关 i18n（zh-CN/en）

## 验证（172.26.166.185 真机）

- 添加端口放行 8081：二次确认弹窗（码 E55EJA）→ 确认 → rebuild success → iptables 落地 `bmssm-fw-intent 2`
- 删除 8081/8080：popconfirm → 高危二次确认（码 FEVM6C/XBCYB4）→ 确认 → rebuild success → 规则清除、iptables 干净
- 审计：3 条 `firewall_rebuild success`（修复前为 `confirmation_failed`）
- 前端 pnpm/vite 构建通过