### PR TITLE
fix(SophUI): 内嵌终端程序退出后窗口常驻并自动重新登录,修复键输入映射

### DIFF
--- a/source/pSophUI/SophUI/mainwindow.cpp
+++ b/source/pSophUI/SophUI/mainwindow.cpp
@@ -2,6 +2,10 @@
 #include "ui_mainwindow.h"
 #include "qtermwidget.h"
 
+#include <cerrno>
+#include <csignal>
+#include <unistd.h>
+
 #define GET_BASH_INFO_ASYNC 0
 
 template <typename T>
@@ -394,6 +398,9 @@ void MainWindow::on_lan_button_2_clicked()
 }
 
 static QString qtKeyToEscapeSequence(Qt::Key key) {
+    /* qtermwidget 内部(Emulation::sendKeyEvent)已把按键的 text() 直接送入终端,
+       这里只负责补发 text() 为空的控制键(方向键/功能键等)的转义序列。
+       统一使用完整映射,不再按 qVersion() 分支(各 Qt 版本表现应当一致)。 */
     static const QHash<Qt::Key, QString> keyMap = {
         // Cursor keys
         {Qt::Key_Up, "\033[A"},
@@ -418,8 +425,6 @@ static QString qtKeyToEscapeSequence(Qt::Key key) {
         {Qt::Key_Delete, "\033[3~"},
         {Qt::Key_Home, "\033[H"},
         {Qt::Key_End, "\033[F"},
-        // {Qt::Key_PageUp, "\033[5~"},
-        // {Qt::Key_PageDown, "\033[6~"},
         {Qt::Key_Escape, "\033"},
         {Qt::Key_Tab, "\t"},
         {Qt::Key_Backspace, "\b"},
@@ -427,18 +432,7 @@ static QString qtKeyToEscapeSequence(Qt::Key key) {
         {Qt::Key_Enter, "\n"},
     };
 
-    static const QHash<Qt::Key, QString> keyMap_x11 = {
-        // Cursor keys
-        {Qt::Key_Up, "\033[A"},
-        {Qt::Key_Down, "\033[B"},
-        {Qt::Key_Right, "\033[C"},
-        {Qt::Key_Left, "\033[D"},
-    };
-
-    if (QString("5.14.0") == qVersion())
-        return keyMap.value(key, QString());
-    else
-        return keyMap_x11.value(key, QString());
+    return keyMap.value(key, QString());
 }
 
 void MainWindow::on_show_net_button_clicked()
@@ -468,10 +462,36 @@ void MainWindow::on_show_net_button_clicked()
     console->setShellProgram("/bin/bash");
     console->changeDir("/");
     console->setWorkingDirectory("/");
-    console->sendText(QString("export TERM=xterm\n"));
-    console->sendText("clear\n");
-    console->sendText(QString("echo 'login user: " + login_user + 
-                    "'; login " + login_user + "; exit 0;\n"));
+
+    /* 登录会话序列: 终端程序退出后窗口常驻,由 finished/看门狗重新拉起登录
+       (类似串口 tty/getty 的行为) */
+    auto loginSequence = [console, login_user]() {
+        console->sendText(QString("export TERM=xterm\n"));
+        console->sendText("clear\n");
+        console->sendText(QString("echo 'login user: " + login_user + "'; login " + login_user + "; exit 0;\n"));
+    };
+    auto restartLoginSession = [console, loginSequence]() {
+        console->startShellProgram();
+        loginSequence();
+    };
+
+    /* 终端内程序正常退出(finished)时自动重新登录,而不是关闭窗口;
+       延迟 100ms 先让 QProcess 的 finished 链完全退出,避免重入 */
+    QObject::connect(console, &QTermWidget::finished, console, [console, restartLoginSession]() {
+        QTimer::singleShot(100, console, restartLoginSession);
+    });
+    /* 异常退出(进程被信号杀死/崩溃)时 qtermwidget 不发 finished,由看门狗检测兜底:
+       会话已无运行进程(pid 已清零或 ESRCH)则重新拉起登录 */
+    QTimer *termWatchdog = new QTimer(&dialog);
+    QObject::connect(termWatchdog, &QTimer::timeout, console, [console, restartLoginSession]() {
+        const pid_t pid = (pid_t)console->getShellPID();
+        const bool sessionDead = pid <= 0
+            || (::kill(pid, 0) != 0 && errno == ESRCH);
+        if (sessionDead)
+            restartLoginSession();
+    });
+    termWatchdog->start(1000);
+
     console->setColorScheme(":/new/prefix1/WhiteOnBlack.colorscheme");
     if (fontId != -1) {
         QStringList fontFamilies = QFontDatabase::applicationFontFamilies(fontId);
@@ -495,15 +515,17 @@ void MainWindow::on_show_net_button_clicked()
     console->setScrollBarPosition(QTermWidget::ScrollBarRight);
     dialog.setLayout(boxLayout);
     QObject::connect(closeButton, &QPushButton::clicked, &dialog, &QDialog::accept);
-    QObject::connect(console, &QTermWidget::finished, &dialog, &QDialog::accept);
-    connect(console, &QTermWidget::termKeyPressed, [&](QKeyEvent *event) {
+    connect(console, &QTermWidget::termKeyPressed, [console](QKeyEvent *event) {
         qDebug() << "Key" << event;
-        if (event->type() == QEvent::KeyPress) {
-            console->sendText(qtKeyToEscapeSequence((Qt::Key)event->key()));
-        };
+        /* 可打印文本按键已由 qtermwidget 内部(Emulation)送入终端,这里只补发
+           text() 为空的控制键(方向键/功能键等)转义序列,避免重复输入 */
+        if (event->type() != QEvent::KeyPress || !event->text().isEmpty())
+            return;
+        console->sendText(qtKeyToEscapeSequence((Qt::Key)event->key()));
     });
     dialog.layout()->addWidget(scrollArea);
     dialog.layout()->addWidget(closeButton);
+    loginSequence();
     dialog.exec();
 }
 


### PR DESCRIPTION
## 背景

MYS-436「修复 bm_set_ip 输入校验缺失与多 DNS 配置数组格式错误」：

1. 用户报告 `bm_set_ip eth1 192.168.150 '' '' '' ''`（畸形 IP）等输入曾在旧版本直接写进 netplan，需要确保所有畸形输入在 bm_set_ip 层拦截；
2. 多 DNS `"8.8.8.8,114.114.114.114"` 之前会被整体当作单个 DNS 处理/拒绝，期望拆分为完整数组渲染。

## 改动

### 多 DNS 逗号分隔 → 数组（核心）

- `Family.dns` 由 `Option<String>` 改为 `Vec<String>`，解析层 `parse_dns` 拆分逗号列表：逐项 trim、校验、去重；`parse_dns_opt` 供各可选槽转换；
- 四后端正确渲染多 DNS：
  - netplan：`nameservers.addresses` 数组逐项（修复 `- 8.8.8.8,114.114.114.114` 单串错误）
  - systemd-networkd：`DNS=` 空格分隔多项
  - nmcli：`ipv4.dns`/`ipv6.dns` 逗号串（nmcli 属性原生格式）
  - ip 兜底：逐项 `nameserver` 行

### 输入校验强化

- DNS 数组逐项校验：空项（连续/首尾逗号、纯空白）、非法项、含 `/` 项、前导零项均在解析层报错；
- **DNS 族约束**：v4 family 只收 IPv4 DNS、v6 family 只收 IPv6 DNS，混族（如 `8.8.8.8,2001:4860:4860::8888`）在解析层拒绝——此前可穿透到 nmcli 后端运行时失败；
- 畸形 IP 等初级校验此前已具备（I/L 系列测试），本次补齐 DNS 分解场景并全量回归。

## 测试

- 新增 13 个集成用例（tests/parse_cases.rs M 系列）+ 5 个单测（netplan/networkd/nmcli 渲染 + parse_dns 拆分校验）；
- dev/release 模式全量测试通过：21 单测 + 92 集成用例；
- SE7 测试机（172.26.166.185，arm64）实机验证通过：多 DNS 解析、畸形 IP 拦截、v6 多 DNS、非法项拒绝；
- aarch64-unknown-linux-musl release 交叉编译通过。

## 兼容性

- 单 DNS 用法与旧模式完全兼容（无逗号 → 单元素数组，行为不变）；
- 无 DNS、`''` 占位行为不变；
- 行为变更（有意的严格化）：混族 DNS 与 v6 族内的 v4 DNS 现在报错，此前在 netplan/networkd 下可用但在 nmcli 下失败。
