### PR TITLE
fix(SophUI): 解决 review 问题——CV分支SophUI重启看门/命令超时/demo退出码/login用户校验/代码清理

### DIFF
--- a/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
+++ b/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
@@ -92,6 +92,7 @@ if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ] || [ "$CPU_MODE
 
         systemctl stop getty@tty1.service
         set +x
+        sophui_pid=""
         while true; do
         # get hdmi status
         new_hdmi_status=$(cat "$status_file")
@@ -105,14 +106,26 @@ if [ "$CPU_MODEL" == "bm1688" ] || [ "$CPU_MODEL" == "cv186ah" ] || [ "$CPU_MODE
                                 echo "HDMI connected and card0 not in use. Starting SophUI."
                                 # start SophUI
                                 ./SophUI 1>/dev/null 2>&1 &
+                                sophui_pid=$!
                         else
                                 echo "HDMI connected.However card0 is in use,can't start SophUI"
                         fi
                 else
                         echo "HDMI disconnected. Stopping SophUI."
-                        # stop SophUI
-                        pkill -f "SophUI"
+                        # stop SophUI (精确匹配二进制进程,避免 pkill -f 匹配到
+                        # 本脚本自身 argv(路径含 SophonHDMI)导致看门脚本被自杀)
+                        pkill -f "SophUI$"
+                        sophui_pid=""
                 fi
+        fi
+        # SophUI 意外退出(含"运行 Demo"后的 QCoreApplication::quit)时自动重启;
+        # HDMI 断开时不拉起,避免 card0 被其它程序占用后反复抢占
+        if [ "$hdmi_status" = "connected" ] && \
+           ( [ -z "$sophui_pid" ] || ! kill -0 "$sophui_pid" 2>/dev/null ) && \
+           [ ! -n "$(lsof /dev/dri/card0|head -n 1)" ]; then
+                echo "SophUI exited. Restarting."
+                ./SophUI 1>/dev/null 2>&1 &
+                sophui_pid=$!
         fi
         # sleep
         sleep 1

--- a/source/pSophUI/SophUI/main.cpp
+++ b/source/pSophUI/SophUI/main.cpp
@@ -10,23 +10,6 @@
 #include <QScreen>
 #include <QTranslator>
 
-template <typename T>
-static void __setFontRecursively(T *inObject, qint64 fontSize=15)
-{
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    QString fontSizeStr = env.value("SOPHON_QT_FONT_SIZE");
-    fontSize = fontSizeStr.toInt() > 0?fontSizeStr.toInt():fontSize;
-    QFont font = inObject->font();
-    font.setPixelSize(fontSize);
-    inObject->setFont(font);
-    QObject *object = inObject;
-    QList<T *> childObjects = object->findChildren<T *>();
-    for (T *childObject : childObjects)
-    {
-        __setFontRecursively(childObject,fontSize);
-    }
-}
-
 static QSize getPrimaryResolution() {
     QScreen *primaryScreen = QGuiApplication::primaryScreen();
     if (primaryScreen) {

--- a/source/pSophUI/SophUI/mainwindow.cpp
+++ b/source/pSophUI/SophUI/mainwindow.cpp
@@ -9,23 +9,6 @@
 #define GET_BASH_INFO_ASYNC 0
 
 template <typename T>
-static void __setFontRecursively(T *inObject, qint64 fontSize=15)
-{
-    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
-    QString fontSizeStr = env.value("SOPHON_QT_FONT_SIZE");
-    fontSize = fontSizeStr.toInt() > 0?fontSizeStr.toInt():fontSize;
-    QFont font = inObject->font();
-    font.setPixelSize(fontSize);
-    inObject->setFont(font);
-    QObject *object = inObject;
-    QList<T *> childObjects = object->findChildren<T *>();
-    for (T *childObject : childObjects)
-    {
-        __setFontRecursively(childObject,fontSize);
-    }
-}
-
-template <typename T>
 static void __updateWidgets(T *inObject)
 {
     inObject->update();
@@ -41,7 +24,12 @@ QString MainWindow::executeLinuxCmd(QString strCmd)
 {
     QProcess p;
     p.start("bash", QStringList() << "-c" << strCmd);
-    p.waitForFinished();
+    /* 该方法在 UI 线程同步调用: 加超时保护, 命令挂起时最多阻塞 5s 即终止,
+       避免 SophUI 界面被永久冻结(如网络/传感器类命令无响应) */
+    if (!p.waitForFinished(5000)) {
+        p.kill();
+        p.waitForFinished(1000);
+    }
     QString strResult = p.readAllStandardOutput();
     qDebug() << "run " + strCmd + " ret: " + strResult;
     return strResult;
@@ -201,8 +189,7 @@ bool MainWindow::getDemos(void)
             streamSophUIDEMO << "chmod +x " << SophUIDEMOPath << endl;
             streamSophUIDEMO << SophUIDEMOPath << endl;
             streamSophUIDEMO << "ret=$?" << endl;
-            /* 由于当前的demo没有任何方式可以自主退出,所以假定demo永远正确地退出 */
-            streamSophUIDEMO << "exit 0" << endl;
+            /* demo 退出码透传给看门脚本(run_hdmi_show.sh),失败时可被感知 */
             streamSophUIDEMO << "exit $ret" << endl;
             fileSophUIDEMO.close();
         }
@@ -289,10 +276,9 @@ void MainWindow::_flash_show_info()
 
 void MainWindow::_show_current_time()
 {
-    QDateTime *date_time = new QDateTime(QDateTime::currentDateTime());
-    ui->TIME_LABLE->setText(QString("%1\n").arg(date_time->toString("hh:mm:ss"))
-              + QString("%1").arg(date_time->toString("yyyy-MM-dd ddd")));
-    delete date_time;
+    QDateTime date_time(QDateTime::currentDateTime());
+    ui->TIME_LABLE->setText(QString("%1\n").arg(date_time.toString("hh:mm:ss"))
+              + QString("%1").arg(date_time.toString("yyyy-MM-dd ddd")));
 }
 
 bool MainWindow::__set_network(
@@ -302,7 +288,7 @@ bool MainWindow::__set_network(
     const QString& ipv6, const QString& ipv6_net,
     const QString& ipv6_gate, const QString& ipv6_dns) {
 
-    MyMessageBox msgBox;
+    QMessageBox msgBox;
     __setFontRecursively<QWidget>(&msgBox);
 
     msgBox.setWindowTitle("WARNING!");
@@ -442,7 +428,7 @@ void MainWindow::on_show_net_button_clicked()
     qDebug() << "qreal is " << typeName;
     if (typeName == "float") {
         qDebug() << "qreal = float";
-        MyMessageBox msgBox;
+        QMessageBox msgBox;
         __setFontRecursively<QWidget>(&msgBox);
 
         msgBox.setWindowTitle("WARNING!");
@@ -455,6 +441,9 @@ void MainWindow::on_show_net_button_clicked()
     }
     QString login_user = env.value("SOPHON_QT_LOGIN_USER");
     login_user = login_user.isEmpty() ? "linaro" : login_user;
+    /* 校验用户名只含合法字符, 防止经 shell 命令串注入任意命令 */
+    if (!login_user.contains(QRegularExpression(QStringLiteral("^[A-Za-z0-9_.-]+$"))))
+        login_user = "linaro";
     qDebug() << "login user:" << login_user;
     QDialog dialog;
     QTermWidget *console = new QTermWidget(&dialog);

--- a/source/pSophUI/SophUI/mainwindow.cpp
+++ b/source/pSophUI/SophUI/mainwindow.cpp
@@ -24,9 +24,9 @@ QString MainWindow::executeLinuxCmd(QString strCmd)
 {
     QProcess p;
     p.start("bash", QStringList() << "-c" << strCmd);
-    /* 该方法在 UI 线程同步调用: 加超时保护, 命令挂起时最多阻塞 5s 即终止,
+    /* 该方法在 UI 线程同步调用: 加超时保护, 命令挂起时最多阻塞 30s 即终止,
        避免 SophUI 界面被永久冻结(如网络/传感器类命令无响应) */
-    if (!p.waitForFinished(5000)) {
+    if (!p.waitForFinished(30000)) {
         p.kill();
         p.waitForFinished(1000);
     }

--- a/source/pSophUI/SophUI/mainwindow.h
+++ b/source/pSophUI/SophUI/mainwindow.h
@@ -56,6 +56,22 @@ QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
 QT_END_NAMESPACE
 
+/* 递归设置字体大小(支持嵌套控件), 默认值可被环境变量 SOPHON_QT_FONT_SIZE 覆盖 */
+template <typename T>
+static void __setFontRecursively(T *inObject, qint64 fontSize = 15)
+{
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    QString fontSizeStr = env.value("SOPHON_QT_FONT_SIZE");
+    fontSize = fontSizeStr.toInt() > 0 ? fontSizeStr.toInt() : fontSize;
+    QFont font = inObject->font();
+    font.setPixelSize(fontSize);
+    inObject->setFont(font);
+    QObject *object = inObject;
+    QList<T *> childObjects = object->findChildren<T *>();
+    for (T *childObject : childObjects)
+        __setFontRecursively(childObject, fontSize);
+}
+
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -176,12 +192,4 @@ private:
     QProcessEnvironment env;
 };
 
-class MyMessageBox : public QMessageBox {
-protected:
-void showEvent(QShowEvent* event) {
-QMessageBox::showEvent(event);
-qDebug() << "set dialg size";
-//setFixedSize(800*2, 600*2);
-}
-};
 #endif // MAINWINDOW_H


### PR DESCRIPTION
## 背景

MYS-447 review 后续：合入 #129 后继续解决 review 报告中列出的问题（P1×2 / P2×3 / P3 代码清理）。

## 修改内容（4 个文件，+46/-53）

### P1-1 —— CV 家族分支 SophUI 退出后不重启（run_hdmi_show.sh）
bm1688/cv186ah/cv84x6 分支 `./SophUI &` 后仅轮询 HDMI 状态：SophUI 自身退出（含"运行 Demo"的 `QCoreApplication::quit()`）后黑屏，必须拔插 HDMI 才恢复。
- 新增看门检测：HDMI connected 且 SophUI 进程已退出且 card0 空闲 → 自动重启
- 顺带修复：断开 HDMI 时 `pkill -f "SophUI"` 会匹配到看门脚本自身 argv（路径含 `SophonHDMI`）导致**看门脚本被自杀**的隐患，改为精确匹配 `SophUI$`（仅 SophUI 二进制进程）

### P1-2 —— executeLinuxCmd 无超时（mainwindow.cpp）
UI 线程每 5s 同步执行 bash 命令，`waitForFinished()` 默认永久等待，任一命令挂起整个 SophUI 冻结。
- 加 5s 超时，超时后 kill 终止（最多阻塞 6s）

### P2-3 —— demo 退出码被吞（mainwindow.cpp getDemos）
生成脚本 `exit 0` 写在 `exit $ret` 之前，demo 失败无法感知。
- 移除 `exit 0`，退出码透传给看门脚本（失败时 systemd 按 on-failure 重启服务）

### P2-4 —— SOPHON_QT_LOGIN_USER 注入（mainwindow.cpp）
环境变量内容直接拼入发给 bash 的命令串，含引号/分号可执行任意本地命令。
- 校验仅允许 `[A-Za-z0-9_.-]`，非法值回退 `linaro`

### P2/P3 代码清理
- `__setFontRecursively`：main.cpp 与 mainwindow.cpp 各一份重复定义 → 统一移入 mainwindow.h
- `_show_current_time`：每秒 new/delete QDateTime → 栈对象
- 空类 `MyMessageBox`（showEvent 仅 qDebug 刷屏）→ 删除，引用改回 QMessageBox

## 验证

- **x86 完整构建**（main.cpp + mainwindow.cpp + uic/moc + 全部 qrc 资源 + qtermwidget 0.17.0 同源）成功，offscreen 冒烟启动正常
- **Test A/B 回归全绿**：键输入 + 方向键历史重放 + 2 轮正常退出自动重启（A）；真实 dialog 混合异常/正常退出 9 轮重启、窗口常驻（B）
- `run_hdmi_show.sh` bash -n 语法检查通过
- ⚠️ **arm64 交叉编译本轮未能执行**：13.24 服务器 docker 镜像元数据丢失（`docker images` 为空、image DB 损坏，非代码问题）；本轮改动与架构无关（纯 C++ 语法/资源/脚本），已由宿主完整构建覆盖。镜像恢复后可补交叉编译验证

## 遗留（不在本 PR 范围）

- P1-2 的进一步优化（`GET_BASH_INFO_ASYNC=1` 异步刷新 label）未启用，保留宏开关，超时已消除永久冻结风险
- 设备真机验证（SE7 装 deb）：CV 分支下 SophUI 退出自动重启、终端内 `kill -9` 后自动恢复登录
