### PR TITLE
fix(bmssm): OTA 刷机/回滚窗口全程持 hazard 互斥锁，刷机中 reboot/shutdown 返回 409 (MYS-451)

### DIFF
--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -772,6 +772,61 @@ func TestCompatRollback(t *testing.T) {
 	}
 }
 
+// TestCompatHazardBlockDuringFlashWindow 覆盖 MYS-451：OTA 刷机窗口
+// （引擎持 HazardHolderFlash 互斥锁）内，upgrade / rollback / shutdown
+// 请求一律 409（TryAcquire 冲突）且不实际执行——reboot/shutdown 在锁被占时
+// 直接短路（绝不真正关机）；窗口结束（锁释放）后 upgrade 恢复 200。
+func TestCompatHazardBlockDuringFlashWindow(t *testing.T) {
+	r := setupCompatTest(t)
+	token := getNormalToken(t, r)
+
+	guard, err := hazard.HazardOps.TryAcquire(ota.HazardHolderFlash)
+	if err != nil {
+		t.Fatalf("acquire flash window for test: %v", err)
+	}
+	t.Cleanup(guard.Release)
+
+	postSsm := func(path string, payload interface{}) *httptest.ResponseRecorder {
+		body, _ := json.Marshal(payload)
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, path, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// 刷机窗口内：upgrade / rollback / shutdown → 409（不实际执行）
+	// 注意 confirm 码要在每个请求体内现取：NewConfirmCode 会覆盖全局码，
+	// 先取后发的码会因被下一次生成替换而失效（403）。
+	for _, path := range []string{"/api/v1/ota/upgrade", "/api/v1/ota/rollback"} {
+		w := postSsm(path, OtaVersion{Product: "SE7", FileName: "fw.tgz", Confirm: hazard.NewConfirmCode()})
+		if w.Code != http.StatusConflict {
+			t.Errorf("%s during flash window = %d, want 409, body=%s", path, w.Code, w.Body.String())
+		} else if !strings.Contains(w.Body.String(), ota.HazardHolderFlash) {
+			t.Errorf("%s 409 body should mention holder %q, got %s", path, ota.HazardHolderFlash, w.Body.String())
+		}
+	}
+	w := postSsm("/api/v1/hardware/shutdown", map[string]interface{}{"id": 1, "confirm": hazard.NewConfirmCode()})
+	if w.Code != http.StatusConflict {
+		t.Errorf("shutdown during flash window = %d, want 409, body=%s", w.Code, w.Body.String())
+	} else if !strings.Contains(w.Body.String(), ota.HazardHolderFlash) {
+		t.Errorf("shutdown 409 body should mention holder %q, got %s", ota.HazardHolderFlash, w.Body.String())
+	}
+
+	// 窗口结束（flow 终态、锁释放）→ upgrade 恢复 200 "add workflow success"
+	guard.Release()
+	body, _ := json.Marshal(OtaVersion{Product: "SE7", FileName: "fw.tgz", Confirm: hazard.NewConfirmCode()})
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("upgrade after flash window = %d, want 200, body=%s", w.Code, w.Body.String())
+	}
+}
+
 // ---------------------------------------------------------------
 // OTA 端到端：上传 → 升级 → 列表/查询
 // ---------------------------------------------------------------

--- a/source/pbmssm/mvc/hardware/controller_test.go
+++ b/source/pbmssm/mvc/hardware/controller_test.go
@@ -13,6 +13,7 @@ import (
 	"bmssm/middleware"
 	"bmssm/pkg/auth"
 	"bmssm/pkg/hazard"
+	"bmssm/pkg/ota"
 	"bmssm/pkg/response"
 )
 
@@ -196,6 +197,60 @@ func TestRebootBlockedByActiveHazardOp409(t *testing.T) {
 	}
 	if rb.calls.Load() != 0 {
 		t.Fatalf("reboot must not run while hazard op active, calls=%d", rb.calls.Load())
+	}
+}
+
+// TestRebootBlockedDuringFlashWindowAndFreeAfter 覆盖 MYS-451 F2 用户可见契约：
+// worker 持锁（模拟 OTA 刷机窗口，holder 与 ota 引擎 handleFlash 一致）→
+// /hardware/reboot → 409 且 fake rebooter 未被调用（不实际执行 /sbin/reboot）；
+// 窗口结束（flow 终态、锁释放）→ 再次 reboot → 200 且正常执行。
+func TestRebootBlockedDuringFlashWindowAndFreeAfter(t *testing.T) {
+	setupHardwareTest(t)
+	fr := newFakeFileReader()
+	rb := &fakeRebooter{}
+	svc := NewService(&fakeCmdRunner{}, fr, rb)
+	ctrl := NewController(svc)
+
+	r := gin.New()
+	api := r.Group("/api/v1")
+	api.Use(middleware.Auth())
+	api.POST("/hardware/reboot", ctrl.Reboot)
+	token := makeAuthToken(t)
+
+	// 模拟刷机中：占用全局高危互斥锁（与 ota.Engine.handleFlash 的持有者一致）
+	guard, err := hazard.HazardOps.TryAcquire(ota.HazardHolderFlash)
+	if err != nil {
+		t.Fatalf("acquire flash window for test: %v", err)
+	}
+	t.Cleanup(guard.Release)
+
+	postReboot := func() *httptest.ResponseRecorder {
+		body, _ := json.Marshal(RebootRequest{Delay: 0, Confirm: hazard.NewConfirmCode()})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/hardware/reboot", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	// 刷机窗口内：409（TryAcquire 冲突），且不实际执行重启
+	w := postReboot()
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 while flash window open, got %d body=%s", w.Code, w.Body.String())
+	}
+	if rb.calls.Load() != 0 {
+		t.Fatalf("reboot must not run during flash window, calls=%d", rb.calls.Load())
+	}
+
+	// 窗口结束（flow 终态后引擎释放锁）→ reboot 正常 200 并执行
+	guard.Release()
+	w2 := postReboot()
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200 after flash window closed, got %d body=%s", w2.Code, w2.Body.String())
+	}
+	if rb.calls.Load() != 1 {
+		t.Fatalf("expected 1 reboot call after window closed, got %d", rb.calls.Load())
 	}
 }
 

--- a/source/pbmssm/pkg/ota/hazardlock.go
+++ b/source/pbmssm/pkg/ota/hazardlock.go
@@ -1,0 +1,37 @@
+package ota
+
+import (
+	"bmssm/logger"
+	"bmssm/pkg/hazard"
+)
+
+// HazardHolderFlash 是 OTA 刷机/回滚窗口在高危互斥锁上的占用者标识（MYS-451）。
+// 窗口 = flow 开始执行（handleFlash 非干跑入口）→ 该 flow 到达终态（Success/Fail）。
+// 持有期间任何 reboot/shutdown/OTA/等其他危险操作的 TryAcquire 一律冲突
+// （HTTP 层表现为 409），且不会实际执行 reboot/shutdown。
+// 锁为内存态：刷机终了设备本就会重启，进程随重启复位属预期；
+// 要防的是重启前刷机窗口内的并发 reboot/shutdown 指令。
+const HazardHolderFlash = "ota.flash"
+
+// acquireFlashGuard 尝试占用全局高危互斥锁（holder 见 HazardHolderFlash），
+// 成功则记入 flow.guard，随 flow 拷贝流转直到释放点。被占用返回错误，
+// 调用方（handleFlash）应将 flow 标为 Fail——快速拒绝并发刷机，不排队不等待。
+func (e *Engine) acquireFlashGuard(flow *Workflow) error {
+	guard, err := hazard.HazardOps.TryAcquire(HazardHolderFlash)
+	if err != nil {
+		logger.Warn("ota: flash blocked by hazardous op: wf=%s err=%v", flow.WorkflowID, err)
+		return err
+	}
+	flow.guard = guard
+	return nil
+}
+
+// releaseFlashGuard 释放 flow 携带的刷机互斥锁（幂等，可安全重复调用）。
+// 未持锁（dryRun 或直接调用 runSOC 的测试路径）时为空操作。
+func releaseFlashGuard(flow *Workflow) {
+	if flow.guard == nil {
+		return
+	}
+	flow.guard.Release()
+	flow.guard = nil
+}

--- a/source/pbmssm/pkg/ota/hazardlock_test.go
+++ b/source/pbmssm/pkg/ota/hazardlock_test.go
@@ -1,0 +1,248 @@
+package ota
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"bmssm/pkg/hazard"
+)
+
+// ---------------------------------------------------------------
+// MYS-451：刷机/回滚窗口全程持 hazard 互斥锁
+//
+// 契约：flow 从 handleFlash 入口（非 dryRun）开始持锁（holder=HazardHolderFlash），
+// 直到该 flow 到达终态（Success/Fail）才释放。窗口内任何 reboot/shutdown/
+// 其他 OTA/软件安装等危险操作 → TryAcquire 冲突（HTTP 层表现为 409）。
+// ---------------------------------------------------------------
+
+// waitHazardFree 轮询直到互斥锁可获取——断言 flow 终态后锁已释放。
+func waitHazardFree(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		g, err := hazard.HazardOps.TryAcquire("reboot")
+		if err == nil {
+			g.Release()
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("hazard lock still held after timeout (expected release at flow terminal)")
+}
+
+// blockingRunner 可按命令名阻塞 runner，精确控制刷机/重启窗口的时序。
+// blockOn(name) 注册信号量：命令首次执行时关闭 entered，等待 release 放行。
+type blockingRunner struct {
+	mu      sync.Mutex
+	calls   []string
+	entered map[string]chan struct{}
+	release map[string]chan struct{}
+}
+
+func newBlockingRunner() *blockingRunner {
+	return &blockingRunner{
+		entered: map[string]chan struct{}{},
+		release: map[string]chan struct{}{},
+	}
+}
+
+// blockOn 让指定命令在首次执行时阻塞；返回 entered（已执行）与 release（放行）。
+func (r *blockingRunner) blockOn(name string) (<-chan struct{}, chan struct{}) {
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	r.mu.Lock()
+	r.entered[name] = entered
+	r.release[name] = release
+	r.mu.Unlock()
+	return entered, release
+}
+
+func (r *blockingRunner) run(name string, args ...string) (string, string, error) {
+	r.mu.Lock()
+	r.calls = append(r.calls, name)
+	entered := r.entered[name]
+	release := r.release[name]
+	r.mu.Unlock()
+	if entered != nil {
+		close(entered)
+		<-release
+	}
+	return "ok", "", nil
+}
+
+// ---------------------------------------------------------------
+// 用例 1：SOC 刷机窗口持锁 → 终态释放
+// ---------------------------------------------------------------
+
+// TestFlashWindowHoldsHazardLock 覆盖：
+//  1. SOC 刷机中（flow Running、worker 已持锁）→ reboot / 再次 upgrade 的
+//     TryAcquire 均被拒，冲突错误点名持有者 HazardHolderFlash
+//  2. flow 到达终态（success 标志出现，pollSOC 判定）→ 锁释放 → reboot 可正常申请
+func TestFlashWindowHoldsHazardLock(t *testing.T) {
+	e, _, flags, _ := newTestEngine(t, false)
+	e.paths.SOCOTADir = t.TempDir()
+	e.paths.SOCWorkRoot = t.TempDir()
+	e.Start()
+	defer e.Stop()
+	t.Cleanup(hazard.HazardOps.Release) // 兜底：断言失败也不把锁泄漏给后续用例
+
+	createOTAFixture(t, e.paths.SOCOTADir, "fw.tgz", map[string]string{"md5.txt": "x\n"})
+	// 无 success/error 标志 → flow 保持 Running（ota.sh 异步执行中）
+	flags.mark(false, false)
+
+	flow := Workflow{Product: "SE7", FileName: "fw.tgz"}
+	if err := e.EnqueueFlow(&flow); err != nil {
+		t.Fatalf("EnqueueFlow: %v", err)
+	}
+	// 进入 Running 前 handleFlash 已 TryAcquire 持锁（锁先于状态写入，无竞态）
+	waitForStatus(t, e, flow.WorkflowID, StatusRunning, 3*time.Second)
+
+	// 刷机窗口内：reboot / shutdown / 再次 OTA 等危险操作一律被拒（TryAcquire 冲突）
+	if _, err := hazard.HazardOps.TryAcquire("reboot"); err == nil {
+		t.Fatal("reboot should be blocked while flash window open")
+	} else if !strings.Contains(err.Error(), HazardHolderFlash) {
+		t.Errorf("conflict error should name holder %q, got: %v", HazardHolderFlash, err)
+	}
+	if _, err := hazard.HazardOps.TryAcquire("ota.upgrade"); err == nil {
+		t.Fatal("another upgrade should be blocked while flash window open")
+	}
+
+	// 刷机终态（success 标志出现）→ pollSOC 判定终态并释放锁
+	flags.mark(true, false)
+	waitForStatus(t, e, flow.WorkflowID, StatusSuccess, 3*time.Second)
+	waitHazardFree(t, 3*time.Second)
+
+	// 窗口关闭后 reboot 可正常申请（HTTP 层即 200）
+	guard, err := hazard.HazardOps.TryAcquire("reboot")
+	if err != nil {
+		t.Fatalf("reboot should be acquirable after flow terminal: %v", err)
+	}
+	guard.Release()
+}
+
+// ---------------------------------------------------------------
+// 用例 2：刷机中（Running）→ 新的 upgrade/rollback 流被快速拒绝
+// ---------------------------------------------------------------
+
+// TestSecondFlowRejectedWhileFlashRunning 覆盖：
+// 已有 Running/刷机中的流持锁时，新 upgrade/rollback 流到执行点
+// （controller 入队已放行的场景）TryAcquire 失败 → 快速标 Fail，不并发刷机。
+func TestSecondFlowRejectedWhileFlashRunning(t *testing.T) {
+	e, _, flags, _ := newTestEngine(t, false)
+	e.paths.SOCOTADir = t.TempDir()
+	e.paths.SOCWorkRoot = t.TempDir()
+	e.Start()
+	defer e.Stop()
+	t.Cleanup(hazard.HazardOps.Release)
+
+	createOTAFixture(t, e.paths.SOCOTADir, "fw.tgz", map[string]string{"md5.txt": "x\n"})
+	flags.mark(false, false)
+
+	// flow A：SOC 刷机中（持锁）
+	a := Workflow{Product: "SE7", FileName: "fw.tgz", Name: "flash-A"}
+	if err := e.EnqueueFlow(&a); err != nil {
+		t.Fatalf("EnqueueFlow A: %v", err)
+	}
+	waitForStatus(t, e, a.WorkflowID, StatusRunning, 3*time.Second)
+
+	// flow B：另一个升级，到执行点时锁仍在 → StatusFail，Info 点名 ota.flash
+	b := Workflow{Product: "SE7", FileName: "fw.tgz", Name: "flash-B"}
+	if err := e.EnqueueFlow(&b); err != nil {
+		t.Fatalf("EnqueueFlow B: %v", err)
+	}
+	waitForStatus(t, e, b.WorkflowID, StatusFail, 3*time.Second)
+	wf, _ := e.Query(b.WorkflowID)
+	if !strings.Contains(wf.Info, HazardHolderFlash) {
+		t.Errorf("flow B Info = %q, want mention %q", wf.Info, HazardHolderFlash)
+	}
+
+	// flow C：回滚同理被拒
+	c := Workflow{Product: "SC5", FileName: "fw.bin", Type: TypeRollback, Name: "rb-C"}
+	if err := e.EnqueueFlow(&c); err != nil {
+		t.Fatalf("EnqueueFlow C: %v", err)
+	}
+	waitForStatus(t, e, c.WorkflowID, StatusFail, 3*time.Second)
+
+	// A 终态后锁释放，后续 flow 恢复执行（这里 A 走 SOC success 终态）
+	flags.mark(true, false)
+	waitForStatus(t, e, a.WorkflowID, StatusSuccess, 3*time.Second)
+	waitHazardFree(t, 3*time.Second)
+}
+
+// ---------------------------------------------------------------
+// 用例 3：PCIE/多节点路径 —— 锁经 reboot 步骤保持到 flow 终态
+// ---------------------------------------------------------------
+
+// TestPCIEFlashWindowHoldsLockThroughRebootStep 覆盖 advanceToReboot 重新入队
+// 的锁延续：刷机成功后 lock 不释放，reboot 步骤（doReboot 的 shutdown）执行期间
+// 仍被持有；shutdown 返回后（flow 终态）才释放。
+func TestPCIEFlashWindowHoldsLockThroughRebootStep(t *testing.T) {
+	e, _, _, _ := newTestEngine(t, false)
+	br := newBlockingRunner()
+	e.runner = br.run
+	e.Start()
+	defer e.Stop()
+	t.Cleanup(hazard.HazardOps.Release)
+
+	// 卡住 doReboot 的最后一步 shutdown，制造"reboot 步骤执行中"的观测窗口
+	entered, release := br.blockOn("shutdown")
+	// 兜底：断言失败也要放行 worker，否则 e.Stop() 会死锁（worker 阻塞在 runner 上）
+	var releaseOnce sync.Once
+	releaseNow := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseNow)
+
+	flow := Workflow{Product: "SC5", ModuleName: "a53", FileName: "fw.bin", Type: TypeUpgrade}
+	if err := e.EnqueueFlow(&flow); err != nil {
+		t.Fatalf("EnqueueFlow: %v", err)
+	}
+
+	// 等到 shutdown 命令正在执行（刷机已完成、reboot 步骤进行中）：锁必须仍被持有
+	select {
+	case <-entered:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for shutdown command during reboot step")
+	}
+	if _, err := hazard.HazardOps.TryAcquire("reboot"); err == nil {
+		t.Fatal("reboot should be blocked while reboot step executing")
+	} else if !strings.Contains(err.Error(), HazardHolderFlash) {
+		t.Errorf("conflict error should name holder %q, got: %v", HazardHolderFlash, err)
+	}
+
+	// 放行 shutdown → doReboot 返回 → flow 终态 → 锁释放
+	releaseNow()
+	waitHazardFree(t, 3*time.Second)
+}
+
+// ---------------------------------------------------------------
+// 用例 4：回滚窗口同样持锁
+// ---------------------------------------------------------------
+
+// TestRollbackWindowHoldsHazardLock 回滚（SOC Rollback 类型）刷机窗口持锁、
+// 终态释放，与升级同语义。
+func TestRollbackWindowHoldsHazardLock(t *testing.T) {
+	e, _, flags, _ := newTestEngine(t, false)
+	e.paths.SOCOTADir = t.TempDir()
+	e.paths.SOCWorkRoot = t.TempDir()
+	e.Start()
+	defer e.Stop()
+	t.Cleanup(hazard.HazardOps.Release)
+
+	createOTAFixture(t, e.paths.SOCOTADir, "fw.tgz", map[string]string{"md5.txt": "x\n"})
+	flags.mark(false, false)
+
+	flow := Workflow{Product: "SE7", FileName: "fw.tgz", Type: TypeRollback}
+	if err := e.EnqueueFlow(&flow); err != nil {
+		t.Fatalf("EnqueueFlow: %v", err)
+	}
+	waitForStatus(t, e, flow.WorkflowID, StatusRunning, 3*time.Second)
+
+	if _, err := hazard.HazardOps.TryAcquire("shutdown"); err == nil {
+		t.Fatal("shutdown should be blocked while rollback window open")
+	}
+
+	flags.mark(true, false)
+	waitForStatus(t, e, flow.WorkflowID, StatusSuccess, 3*time.Second)
+	waitHazardFree(t, 3*time.Second)
+}

--- a/source/pbmssm/pkg/ota/hazardlock_test.go
+++ b/source/pbmssm/pkg/ota/hazardlock_test.go
@@ -183,15 +183,18 @@ func TestPCIEFlashWindowHoldsLockThroughRebootStep(t *testing.T) {
 	br := newBlockingRunner()
 	e.runner = br.run
 	e.Start()
+	// 注意：必须用 defer 而非 t.Cleanup 注册放行——t.Fatal 时先跑 defer 后跑
+	// Cleanup，defer e.Stop() 会阻塞等待 worker（worker 卡在被阻塞的 runner 上），
+	// 造成整个测试二进制挂起而非干净失败。defer 按 LIFO 执行：releaseNow 后注册
+	// 先于 e.Stop() 运行，先放行 worker 再停止引擎。
 	defer e.Stop()
-	t.Cleanup(hazard.HazardOps.Release)
-
 	// 卡住 doReboot 的最后一步 shutdown，制造"reboot 步骤执行中"的观测窗口
 	entered, release := br.blockOn("shutdown")
-	// 兜底：断言失败也要放行 worker，否则 e.Stop() 会死锁（worker 阻塞在 runner 上）
+	// 兜底：任何断言失败都要放行 worker，否则 e.Stop() 死锁
 	var releaseOnce sync.Once
 	releaseNow := func() { releaseOnce.Do(func() { close(release) }) }
-	t.Cleanup(releaseNow)
+	defer releaseNow()
+	t.Cleanup(hazard.HazardOps.Release)
 
 	flow := Workflow{Product: "SC5", ModuleName: "a53", FileName: "fw.bin", Type: TypeUpgrade}
 	if err := e.EnqueueFlow(&flow); err != nil {

--- a/source/pbmssm/pkg/ota/helpers_test.go
+++ b/source/pbmssm/pkg/ota/helpers_test.go
@@ -45,7 +45,10 @@ func (r *recordingRunner) calls_() []runnerCall {
 
 // fakeFlags 内存 flag 检查器，按 PathConfig 的标志路径比对，可预设 success/error。
 // 用指针接收者，便于用例在运行中翻转标志（模拟 ota.sh 写入 /dev/shm 标志）。
+// 字段经 mu 保护：poll 协程（Exists/ReadTail/ReadPanicLine）与翻转标志的测试
+// 协程并发访问，不保护会被 -race 抓到。
 type fakeFlags struct {
+	mu        sync.Mutex
 	success   bool
 	error     bool
 	logTail   string
@@ -53,7 +56,17 @@ type fakeFlags struct {
 	paths     PathConfig
 }
 
+// mark 线程安全地更新 success/error 标志（测试协程调用，模拟 ota.sh 写入标志）。
+func (f *fakeFlags) mark(success, error bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.success = success
+	f.error = error
+}
+
 func (f *fakeFlags) Exists(path string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if path == f.paths.SuccessFlag {
 		return f.success
 	}
@@ -64,6 +77,8 @@ func (f *fakeFlags) Exists(path string) bool {
 }
 
 func (f *fakeFlags) ReadTail(path string, n int) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if path == f.paths.ShellLog {
 		return f.logTail
 	}
@@ -71,6 +86,8 @@ func (f *fakeFlags) ReadTail(path string, n int) string {
 }
 
 func (f *fakeFlags) ReadPanicLine(path string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if path == f.paths.ShellLog {
 		return f.panicLine
 	}

--- a/source/pbmssm/pkg/ota/soc.go
+++ b/source/pbmssm/pkg/ota/soc.go
@@ -94,17 +94,22 @@ func (e *Engine) pollOnce(flow Workflow) (status int, info string, done bool) {
 }
 
 // pollSOC 轮询 StatusSOC 直到终态或 quit，更新 DB。ota.sh 自带 reboot，无需重启步骤。
+// MYS-451：终态判定同一处释放刷机互斥锁（flow.guard，随 handleFlash→runSOC→pollSOC
+// 传递）——SOC 刷机窗口以 success/error 标志为终点；quit（引擎退出/进程重启）同样释放，
+// 避免把内存锁泄漏给后续流程（如测试间隔离）。
 func (e *Engine) pollSOC(flow Workflow) {
 	ticker := time.NewTicker(e.pollInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-e.quit:
+			releaseFlashGuard(&flow)
 			return
 		case <-ticker.C:
 			st, info, done := e.pollOnce(flow)
 			if done {
 				e.updateStatus(flow.ID, st, info)
+				releaseFlashGuard(&flow)
 				return
 			}
 		}

--- a/source/pbmssm/pkg/ota/soc_test.go
+++ b/source/pbmssm/pkg/ota/soc_test.go
@@ -181,8 +181,7 @@ func TestRunSOCRunnerFails(t *testing.T) {
 
 func TestStatusSOCNoneRunning(t *testing.T) {
 	e, _, flags, _ := newTestEngine(t, false)
-	flags.success = false
-	flags.error = false
+	flags.mark(false, false)
 	st, _ := e.StatusSOC()
 	if st != StatusRunning {
 		t.Errorf("status = %d, want %d (Running)", st, StatusRunning)
@@ -191,7 +190,7 @@ func TestStatusSOCNoneRunning(t *testing.T) {
 
 func TestStatusSOCSuccess(t *testing.T) {
 	e, _, flags, _ := newTestEngine(t, false)
-	flags.success = true
+	flags.mark(true, false)
 	st, info := e.StatusSOC()
 	if st != StatusSuccess {
 		t.Errorf("status = %d, want %d", st, StatusSuccess)
@@ -203,7 +202,7 @@ func TestStatusSOCSuccess(t *testing.T) {
 
 func TestStatusSOCFail(t *testing.T) {
 	e, _, flags, _ := newTestEngine(t, false)
-	flags.error = true
+	flags.mark(false, true)
 	flags.panicLine = "LAST_PART_NOT_FLASH mode, check last part start [28602368] != [49573888]"
 	st, info := e.StatusSOC()
 	if st != StatusFail {
@@ -323,7 +322,7 @@ func TestRunSOCFlowSuccess(t *testing.T) {
 		"md5.txt":       "deadbeef boot.img\n",
 	})
 	// 预置 success 标志，pollOnce 首次即命中
-	flags.success = true
+	flags.mark(true, false)
 
 	flow := Workflow{Product: "SE7", FileName: "fw.tgz"}
 	if err := e.EnqueueFlow(&flow); err != nil {
@@ -352,7 +351,7 @@ func TestRunSOCFlowFail(t *testing.T) {
 
 	createOTAFixture(t, e.paths.SOCOTADir, "fw.tgz", map[string]string{"md5.txt": "x\n"})
 	// 预置 error 标志，poll 命中 Fail
-	flags.error = true
+	flags.mark(false, true)
 	flags.panicLine = "ota failed: gpt corrupt"
 
 	flow := Workflow{Product: "se9", FileName: "fw.tgz"}

--- a/source/pbmssm/pkg/ota/types.go
+++ b/source/pbmssm/pkg/ota/types.go
@@ -6,7 +6,11 @@
 // workflow 引擎结构与状态流转对齐 bmssm pkg/workflow。
 package ota
 
-import "time"
+import (
+	"time"
+
+	"bmssm/pkg/hazard"
+)
 
 // ---------------------------------------------------------------
 // 状态 / 类型常量（对齐 bmssm）
@@ -63,6 +67,11 @@ type Workflow struct {
 	FlashData      bool      `gorm:"-" json:"flashData"`
 	CreateTime     time.Time `gorm:"column:create_time" json:"createTime"`
 	LastRebootTime time.Time `gorm:"column:last_reboot_time" json:"lastRebootTime"`
+
+	// guard 是刷机/回滚窗口高危互斥锁的占用句柄（MYS-451）。
+	// 仅内存态、不落库（gorm 忽略未导出字段）；随 flow 值拷贝流转，
+	// 从 handleFlash 持锁到该 flow 到达终态（Success/Fail）才释放。
+	guard *hazard.Guard
 }
 
 // TableName 自定义表名。

--- a/source/pbmssm/pkg/ota/workflow.go
+++ b/source/pbmssm/pkg/ota/workflow.go
@@ -90,11 +90,20 @@ func (e *Engine) Query(id string) (*Workflow, error) {
 // ---------------------------------------------------------------
 
 // startCmd 消费 worker，按 Step 分发。退出条件：quit 关闭。
+// 退出前排空缓冲：残留 flow（如已入队的 reboot 步骤）可能携带刷机互斥锁
+// （MYS-451），释放避免泄漏——quit 仅测试 Stop 与进程退出路径触发。
 func (e *Engine) startCmd() {
 	for {
 		select {
 		case <-e.quit:
-			return
+			for {
+				select {
+				case flow := <-e.worker:
+					releaseFlashGuard(&flow)
+				default:
+					return
+				}
+			}
 		case flow := <-e.worker:
 			e.processFlow(flow)
 		}

--- a/source/pbmssm/pkg/ota/workflow.go
+++ b/source/pbmssm/pkg/ota/workflow.go
@@ -115,6 +115,12 @@ func (e *Engine) processFlow(flow Workflow) {
 // dryRun：直接标 Success（模拟）。
 // SOC 非干跑：runSOC 已置 Running + 启动轮询，ota.sh 自带 reboot。
 // PCIE/多节点非干跑：刷机成功后推进到 reboot 步骤并重新入队。
+//
+// MYS-451：非干跑刷机从本入口起全程持高危互斥锁（holder=HazardHolderFlash），
+// 直到本 flow 到达终态（Success/Fail）才释放——防止刷机/OTA 自带重启的窗口内
+// 被并发 reboot/shutdown 打断（brick 场景）。锁随 flow 拷贝携带：
+// SOC 由 pollSOC 终态判定后释放；PCIE/多节点随 flow 传递到 reboot 步骤执行完毕；
+// runCmd 失败与未知产品路径在本函数内释放。
 func (e *Engine) handleFlash(flow Workflow) {
 	if e.dryRun {
 		logger.Info("[dryRun] simulate flash success: product=%s file=%s flashData=%v", flow.Product, flow.FileName, flow.FlashData)
@@ -122,20 +128,29 @@ func (e *Engine) handleFlash(flow Workflow) {
 		return
 	}
 
+	// 已有人在刷机/高危操作中 → 本 flow 快速拒绝（不排队不等待），标 Fail 供查询。
+	if err := e.acquireFlashGuard(&flow); err != nil {
+		e.updateStatus(flow.ID, StatusFail, "hazard lock: "+err.Error())
+		return
+	}
+
 	if err := e.runCmd(flow); err != nil {
 		logger.Error("flash failed: product=%s wf=%s err=%v", flow.Product, flow.WorkflowID, err)
 		e.updateStatus(flow.ID, StatusFail, err.Error())
+		releaseFlashGuard(&flow)
 		return
 	}
 
 	switch productClass(flow.Product) {
 	case ClassSOC:
-		// runSOC 已置 Running 并启动轮询 goroutine，ota.sh 自带 reboot，无需推进。
+		// runSOC 已置 Running 并启动轮询 goroutine，ota.sh 自带 reboot，无需推进；
+		// 互斥锁由 pollSOC 在成功/失败终态判定后释放（flow.guard 随 flow 传入）。
 	case ClassPCIE, ClassMultiNode:
-		e.advanceToReboot(flow)
+		e.advanceToReboot(flow) // 锁随 flow 重新入队到 reboot 步骤，handleReboot 末尾释放
 	default:
 		logger.Warn("flash success but unknown product: %s", flow.Product)
 		e.updateStatus(flow.ID, StatusSuccess, "unknown product, marked success")
+		releaseFlashGuard(&flow)
 	}
 }
 
@@ -145,10 +160,16 @@ func (e *Engine) handleReboot(flow Workflow) {
 		e.updateStatus(flow.ID, StatusSuccess, "dryRun: reboot simulated")
 		return
 	}
+	// MYS-451：刷机窗口的互斥锁经 advanceToReboot 延续到此；reboot 步骤执行完毕
+	// 即该 flow 终态，延迟释放。doReboot 内 shutdown -r now 成功时进程随之重启、
+	// 内存锁随进程复位——此处显式释放是干净关闭的兜底（如重启命令失败的场景）。
+	defer releaseFlashGuard(&flow)
 	e.doReboot(flow)
 }
 
 // advanceToReboot 推进 flow 到 reboot 步骤并重新入队（对齐 bmssm nextStep+Strategy|=reboot）。
+// MYS-451：不重新入队即失败的路径（DB 更新失败 / worker 满）在此释放刷机互斥锁，
+// 避免锁被已失败 flow 泄漏。
 func (e *Engine) advanceToReboot(flow Workflow) {
 	newStrategy := flow.Strategy
 	if !strings.Contains(newStrategy, StrategyReboot) {
@@ -160,6 +181,7 @@ func (e *Engine) advanceToReboot(flow Workflow) {
 	}).Error; err != nil {
 		logger.Error("advanceToReboot update failed: %v", err)
 		e.updateStatus(flow.ID, StatusFail, "advance reboot step: "+err.Error())
+		releaseFlashGuard(&flow)
 		return
 	}
 	flow.Step = StepReboot
@@ -169,6 +191,7 @@ func (e *Engine) advanceToReboot(flow Workflow) {
 	default:
 		logger.Error("worker full when re-enqueueing reboot: wf=%s", flow.WorkflowID)
 		e.updateStatus(flow.ID, StatusFail, "worker queue full on reboot")
+		releaseFlashGuard(&flow)
 	}
 }
 


### PR DESCRIPTION
## 背景

MYS-389（bmssm 高危操作互斥/二次确认/审计）合入后，`ExecuteUpgrade`/`Rollback` 的 `requireHazardGuard` 只覆盖**入队瞬间**（`EnqueueFlow` 返回后 `defer guard.Release()` 即释放）；刷机实际执行 + 自带重启的整段窗口内没有持锁——另一会话可用合法确认码通过 `/admin/hardware/reboot` 真实执行 `/sbin/reboot`，即 MYS-389 首要 brick 场景「OTA 刷机中重启」（MYS-412 review 残留的 F2）。

## 修复内容

**刷机/回滚窗口全程持 hazard 互斥锁（holder = `ota.flash`）**：

- 非 dryRun 的 flow 从 `handleFlash` 入口 `TryAcquire`（`pkg/ota/hazardlock.go`），锁写入 `Workflow.guard`（未导出字段，不落库），随 flow 值拷贝流转到各释放点
- **SOC 路径**：锁经 `runSOC` 传入 `pollSOC`，在 success/error 标志判定的终态释放（覆盖 ota.sh 异步执行 + 自带 reboot 的窗口）；引擎 quit（进程退出/测试 Stop）路径同样释放
- **PCIE/多节点路径**：刷机成功后锁随 `advanceToReboot` 重新入队延续到 reboot 步骤，`handleReboot`/`doReboot` 执行完毕（flow 终态）释放；`advanceToReboot` 失败分支（DB 更新失败/worker 满）立即释放
- **失败路径**：`runCmd` 失败、持锁冲突 → flow 快速标 `Fail`（`StatusFail`，Info 点名 `ota.flash`），不排队不并发刷机
- `startCmd` 退出前排空 worker 缓冲，残留 flow 携带的锁一并释放

**窗口内效果**：`reboot`/`shutdown`/OTA upgrade/rollback 请求的 `TryAcquire` 一律冲突 → HTTP 409，**不实际执行** reboot/shutdown。二次确认（403）与审计语义不变。软件安装/升级沿用 MYS-389 已合的并发设计（holder 为空，不占排它锁）——其不触发重启，非本 brick 场景，故不改。

## 测试

- `pkg/ota` 新增 4 用例：SOC 刷机窗口持锁 → 终态释放；持锁中第二 upgrade/rollback 流被快速拒绝；PCIE reboot 步骤执行期间锁延续（blocking runner 卡 `shutdown` 观测窗口）；回滚窗口同语义
- `mvc/hardware`：锁被 `ota.flash` 持有时 `/hardware/reboot` → 409 且 fake rebooter **0 次调用**；释放后 → 200 且正常执行
- `mvc/compat`：刷机中 `upgrade`/`rollback`/`shutdown` → 409（body 点名 `ota.flash` 且未实际关机）；终态后恢复 200
- `fakeFlags` 加锁保护（`-race` 干净）

## 验证

- `go vet ./...` ✅
- `go test -count=1 ./...` 33 包全过 ✅
- 变更包 `go test -race` 全过 ✅（含 15 次重复防抖）
- arm64 交叉编译（musl 静态链接）✅
- 新测试对旧实现（无锁）红验证：行为断言如实失败 ✅