### PR TITLE
feat(se-rag-core): 内置网关默认顺序改为 FC 优先、CF 备用

### DIFF
--- a/source/se-rag-core/README.md
+++ b/source/se-rag-core/README.md
@@ -12,7 +12,7 @@ SE 系列知识库的 **Go RAG 检索核心**，替代现行 Python 栈（numpy 
 - **多知识库兼容**：不同知识库用不同 `-index-dir` / `--docs-dir` 即可，复用同一检索核心仅换目录
 - **供应商可切换**：siliconflow / sophnet 两族 embedding 与 reranker，可配置不写死
 - **内置默认 key（混淆内嵌）**：预置 siliconflow 免费 key，源码中以 XOR 混淆字节内嵌（不落明文）；模型固定 `BAAI/bge-m3`（embedding）与 `BAAI/bge-reranker-v2-m3`（rerank）；使用内置 key 时强制限流（并发≤1、单次≤2段落）；用户自备 key 放开
-- **内置网关故障转移链**：内置 key 请求经自建网关转发 SiliconFlow——主网关 Cloudflare Worker（`*.workers.dev`）不可达（连接超时 / 5xx / DNS 失败）时自动切换阿里云函数计算（FC3.0）同协议网关（`*.fcapp.run`，国内直连）；两网关均不可达时降级纯 BM25（见下文「内置网关故障转移链」）
+- **内置网关故障转移链**：内置 key 请求经自建网关转发 SiliconFlow——主网关阿里云函数计算（FC3.0）同协议网关（`*.fcapp.run`，国内直连免备案）不可达（连接超时 / 5xx / DNS 失败）时自动切换备用 Cloudflare Worker 网关（`*.workers.dev`，对 DNS 污染走 IP 优先 + DoH 兜底拨号）；两网关均不可达时降级纯 BM25（见下文「内置网关故障转移链」）
 - **供应商切换校验**：索引记录 embedding 指纹（`<provider>.<model>@<dim>`），切换供应商/模型后 `se-rag doctor` 检测并提示重建
 - **检索输出含来源信息**：每条结果标记源文件的相对路径与片段行号区间
 - **中文分词（BM25 兜底召回）**：汉字序列按 2-gram 滑窗切分（无词典、纯 Go 静态实现），
@@ -136,17 +136,17 @@ export SE_RAG_RERANK_KEY="sk-user-rerank-key"
 
 | 优先级 | 网关 | 地址 | 说明 |
 |--------|------|------|------|
-| 1 | Cloudflare Worker（主） | `se-rag-gateway.zetao-zhang.workers.dev` | 默认路径；对 `*.workers.dev` DNS 污染走 IP 优先 + DoH 兜底拨号，作用范围仅限该域名 |
-| 2 | 阿里云函数计算 FC3.0（备） | `se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run` | 国内直连免备案；`fcapp.run` 走系统 DNS，不受 IP 优先逻辑影响 |
+| 1 | 阿里云函数计算 FC3.0（主） | `se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run` | 国内直连免备案；`fcapp.run` 走系统 DNS，不受 IP 优先逻辑影响 |
+| 2 | Cloudflare Worker（备） | `se-rag-gateway.zetao-zhang.workers.dev` | 对 `*.workers.dev` DNS 污染走 IP 优先 + DoH 兜底拨号，作用范围仅限该域名 |
 | 3 | 纯 BM25（兜底） | — | 两网关均不可达时自动降级，离线可用（`mode=bm25`） |
 
 行为约定：
 
 - 同一 key / 同路径（`/v1/embeddings`、`/v1/rerank`）/ 同模型白名单，内置 key 零改动
-- 5xx / 429 / 连接错误（超时、DNS 失败）→ 有界重试（最多 6 次）并轮转至 FC 网关；4xx 快速失败不转移
-- 主网关的「IP 优先 + DoH 兜底」拨号依赖硬编码的 Cloudflare Anycast IP 与公共 DoH 服务器
-  （cf IP 段调整或 DoH 不可达时主路径失效；此时由 FC 备网关自动接管，FC 走系统 DNS 不受此影响）
-- 故障转移链可配置：`Provider.BaseURL`（主）+ `Provider.FallbackBaseURL`（备，默认 FC 网关）；
+- 5xx / 429 / 连接错误（超时、DNS 失败）→ 有界重试（最多 6 次）并轮转至 CF 备网关；4xx 快速失败不转移
+- 备用 CF 网关的「IP 优先 + DoH 兜底」拨号依赖硬编码的 Cloudflare Anycast IP 与公共 DoH 服务器
+  （cf IP 段调整或 DoH 不可达时备路径失效；此时 FC 主网关走系统 DNS 不受此影响）
+- 故障转移链可配置：`Provider.BaseURL`（主）+ `Provider.FallbackBaseURL`（备，默认 CF 网关）；
   两者相同即显式禁用故障转移；`se-rag` CLI 默认即启用
 - 用户自备 key 不经网关，直达官方 SiliconFlow，无故障转移项
 

--- a/source/se-rag-core/internal/config/config.go
+++ b/source/se-rag-core/internal/config/config.go
@@ -19,11 +19,12 @@ func BuiltinKey() string {
 	return string(b)
 }
 
-// GatewayBaseURL 是内置默认网关（se-rag-gateway Worker）地址，白名单仅 BAAI/bge-m3、BAAI/bge-reranker-v2-m3。
+// GatewayBaseURL 是内置网关 CF Worker（se-rag-gateway）地址，故障转移备用网关（第二跳），
+// 白名单仅 BAAI/bge-m3、BAAI/bge-reranker-v2-m3；对 *.workers.dev DNS 污染走 IP 优先 + DoH 兜底拨号。
 const GatewayBaseURL = "https://se-rag-gateway.zetao-zhang.workers.dev/v1"
 
-// GatewayFCBaseURL 是内置网关故障转移第二跳：阿里云函数计算（FC3.0）上部署的同协议网关镜像，
-// 国内直连（*.workers.dev 在该网络下不可达时使用）。与 CF 网关完全同协议：同 key / 同路径 /
+// GatewayFCBaseURL 是内置默认网关（主，第一跳）：阿里云函数计算（FC3.0）上部署的同协议网关镜像，
+// 国内直连免备案、无 DNS 污染问题。与 CF 网关完全同协议：同 key / 同路径 /
 // 同模型白名单，内置 key 零改动即可切换。
 const GatewayFCBaseURL = "https://se-rag-gateway-chrzlcfiqt.cn-hangzhou.fcapp.run/v1"
 
@@ -37,9 +38,9 @@ type Provider struct {
 	APIKey  string // 用户自备 key；空则用内置
 	Model   string
 	BaseURL string
-	// FallbackBaseURL 内置 key 时故障转移的第二网关（默认 GatewayFCBaseURL）：
-	// BaseURL（默认 CF Worker）不可达时自动切换；不适用于用户自备 key（直达官方 SiliconFlow）。
-	// 置空自动取 GatewayFCBaseURL；想禁用故障转移时显式置为与 BaseURL 相同的值。
+	// FallbackBaseURL 内置 key 时故障转移的第二网关（默认 GatewayBaseURL 即 CF Worker）：
+	// BaseURL（默认 FC 网关）不可达时自动切换；不适用于用户自备 key（直达官方 SiliconFlow）。
+	// 置空自动取 GatewayBaseURL；想禁用故障转移时显式置为与 BaseURL 相同的值。
 	FallbackBaseURL string
 	Dim             int // embedding 维度（reranker 不适用，置 0）
 }
@@ -66,11 +67,11 @@ func DefaultConfig() Config {
 			DocsDir: "docs/se7",
 			Embedder: Provider{
 				Type: "siliconflow", Model: "BAAI/bge-m3",
-				BaseURL: GatewayBaseURL, Dim: 1024,
+				BaseURL: GatewayFCBaseURL, FallbackBaseURL: GatewayBaseURL, Dim: 1024,
 			},
 			Reranker: Provider{
 				Type: "siliconflow", Model: "BAAI/bge-reranker-v2-m3",
-				BaseURL: GatewayBaseURL,
+				BaseURL: GatewayFCBaseURL, FallbackBaseURL: GatewayBaseURL,
 			},
 			UseBuiltinKey: true,
 		},
@@ -87,7 +88,7 @@ func (p Provider) EffectiveKey() string {
 }
 
 // EffectiveBaseURL 依 key 归属决定上游地址：
-// 内置 key → 默认网关（Worker，白名单两模型）；用户自备 key → 回落官方 SiliconFlow，直达不被网关替换。
+// 内置 key → 默认网关（FC，白名单两模型）；用户自备 key → 回落官方 SiliconFlow，直达不被网关替换。
 func (p Provider) EffectiveBaseURL() string {
 	if p.APIKey != "" {
 		return officialSiliconflowBaseURL
@@ -96,19 +97,19 @@ func (p Provider) EffectiveBaseURL() string {
 }
 
 // EffectiveBaseURLs 依 key 归属决定上游地址有序列表（网关故障转移链）：
-// 内置 key → [BaseURL（默认 CF Worker），FallbackBaseURL（默认阿里云 FC 网关）]，CF 不可达
-// 时自动切换 FC；相同地址去重。用户自备 key → 官方 SiliconFlow 直达，不经网关、无故障转移项。
+// 内置 key → [BaseURL（默认阿里云 FC 网关），FallbackBaseURL（默认 CF Worker）]，FC 不可达
+// 时自动切换 CF；相同地址去重。用户自备 key → 官方 SiliconFlow 直达，不经网关、无故障转移项。
 func (p Provider) EffectiveBaseURLs() []string {
 	if p.APIKey != "" {
 		return []string{officialSiliconflowBaseURL}
 	}
 	primary := p.BaseURL
 	if primary == "" {
-		primary = GatewayBaseURL
+		primary = GatewayFCBaseURL
 	}
 	fallback := p.FallbackBaseURL
 	if fallback == "" {
-		fallback = GatewayFCBaseURL
+		fallback = GatewayBaseURL
 	}
 	if fallback == primary {
 		return []string{primary}

--- a/source/se-rag-core/internal/config/config_test.go
+++ b/source/se-rag-core/internal/config/config_test.go
@@ -44,9 +44,9 @@ func TestEffectiveKeyUsesBuiltinWhenEmpty(t *testing.T) {
 func TestEffectiveBaseURL(t *testing.T) {
 	d := DefaultConfig()
 	p := d.Products[0].Embedder
-	// 内置 → 默认网关
-	if p.EffectiveBaseURL() != GatewayBaseURL {
-		t.Errorf("builtin effective base url = %q, want gateway %q", p.EffectiveBaseURL(), GatewayBaseURL)
+	// 内置 → 默认网关（FC 主）
+	if p.EffectiveBaseURL() != GatewayFCBaseURL {
+		t.Errorf("builtin effective base url = %q, want gateway %q", p.EffectiveBaseURL(), GatewayFCBaseURL)
 	}
 	// 自备 key → 回落官方 SiliconFlow，直达不被网关替换
 	u := p
@@ -77,15 +77,15 @@ func TestGatewayFCBaseURLShape(t *testing.T) {
 		t.Errorf("GatewayFCBaseURL %q should be the Alibaba FC gateway host", GatewayFCBaseURL)
 	}
 	if GatewayFCBaseURL == GatewayBaseURL {
-		t.Errorf("FC fallback must differ from CF gateway, got %q", GatewayFCBaseURL)
+		t.Errorf("FC primary must differ from CF gateway, got %q", GatewayFCBaseURL)
 	}
 }
 
-// 故障转移链：内置 key → [CF 网关, FC 网关]；自备 key → 官方 SiliconFlow 直达（无故障转移项）。
+// 故障转移链：内置 key → [FC 网关（主）, CF 网关（备）]；自备 key → 官方 SiliconFlow 直达（无故障转移项）。
 func TestEffectiveBaseURLs(t *testing.T) {
 	d := DefaultConfig()
 	p := d.Products[0].Embedder
-	want := []string{GatewayBaseURL, GatewayFCBaseURL}
+	want := []string{GatewayFCBaseURL, GatewayBaseURL}
 	if got := p.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint(want) {
 		t.Errorf("builtin effective base urls = %v, want %v", got, want)
 	}
@@ -98,7 +98,7 @@ func TestEffectiveBaseURLs(t *testing.T) {
 	}
 }
 
-// 显式指定主/备地址与去重：主地址为空回落默认 CF；备与主相同则去重为单地址。
+// 显式指定主/备地址与去重：主地址为空回落默认 FC；备与主相同则去重为单地址。
 func TestEffectiveBaseURLsExplicitAndDedup(t *testing.T) {
 	d := DefaultConfig()
 	p := d.Products[0].Embedder
@@ -112,8 +112,8 @@ func TestEffectiveBaseURLsExplicitAndDedup(t *testing.T) {
 
 	// 备与主相同 → 去重（显式禁用故障转移）
 	dup := p
-	dup.FallbackBaseURL = GatewayBaseURL
-	if got := dup.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint([]string{GatewayBaseURL}) {
+	dup.FallbackBaseURL = GatewayFCBaseURL
+	if got := dup.EffectiveBaseURLs(); fmt.Sprint(got) != fmt.Sprint([]string{GatewayFCBaseURL}) {
 		t.Errorf("dedup base urls = %v", got)
 	}
 }

--- a/source/se-rag-core/internal/embed/gateway_transport.go
+++ b/source/se-rag-core/internal/embed/gateway_transport.go
@@ -12,12 +12,12 @@ import (
 	"time"
 )
 
-// 内置默认 SiliconFlow 网关（自建 Cloudflare Worker se-rag-gateway）在部分网络下存在
+// 内置网关故障转移链的备用网关（自建 Cloudflare Worker se-rag-gateway）在部分网络下存在
 // *.workers.dev 域名 DNS 污染：本地 resolver 把域名解析到错误 IP 导致连接超时。
-// 因此对内置网关域名采用「IP 优先 + DoH 兜底」，其他域名（sophnet、官方回落自备 key 等）
-// 一律走系统 DNS，作用范围严格收窄到内置网关。
+// 因此对 CF 备网关域名采用「IP 优先 + DoH 兜底」，其他域名（主网关 fcapp.run、sophnet、官方回落自备 key 等）
+// 一律走系统 DNS，作用范围严格收窄到 CF 备网关。
 
-// gatewayHost 内置网关域名，仅对其应用 IP 优先拨号。
+// gatewayHost CF 备网关域名，仅对其应用 IP 优先拨号。
 const gatewayHost = "se-rag-gateway.zetao-zhang.workers.dev"
 
 // gatewayIPFallbacks 权威 CF Anycast IP（Cloudflare 官方，TCP 已验证可达），拨号优先直连绕开污染 resolver。


### PR DESCRIPTION
## 背景

MYS-405 决策（2026-08-18）为「主网关改为阿里云 FC，CF Worker 降为第二方案」，但合入时的代码默认仍是 CF 第一跳（`[CF, FC]`）。本次将默认顺序落为 FC 优先。

## 改动

- `internal/config/config.go`：默认主/备引用互换——内置 key 请求顺序 `[CF, FC]` → `[FC, CF]`；`DefaultConfig` 显式 `BaseURL=FC 主、FallbackBaseURL=CF 备`；常量值（`GatewayBaseURL`=CF、`GatewayFCBaseURL`=FC）与配置字段语义不变，用户显式设置 `BaseURL` 不受影响，向后兼容
- `internal/config/config_test.go`：默认顺序断言与去重用例同步更新
- `internal/embed/gateway_transport.go`：注释更新（IP 优先 + DoH 兜底仍仅作用于 CF 备网关域名，逻辑零改动）
- `README.md`：网关链路表与故障转移说明更新为主 FC / 备 CF

## 验证

- `go vet ./...`、`go test -count=1 ./...`、`go test -race`（config/embed）全绿
- 真机 E2E（13.24，真实内置 key）：
  - 默认 build 745ms 快速成功；**屏蔽 CF 后 413ms 照常成功** → 证明默认路径不经 CF（FC 优先生效）
  - **屏蔽 FC 后 6.0s 轮转经 CF 成功** → FC 不可达自动切备网关，故障转移链正常
  - query `mode=hybrid` 437ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)