### PR TITLE
fix(pota_update): get_network_info.sh 生成命令时最多保留一个 DNS

### DIFF
--- a/source/pota_update/get_network_info.sh
+++ b/source/pota_update/get_network_info.sh
@@ -151,8 +151,8 @@ get_config_from_systemd() {
     # 解析网关
     CONFIG_GATEWAY[$iface]=$(grep "Gateway=" "$config_file" | sed 's/Gateway=//g' | head -1)
 
-    # 解析DNS服务器
-    CONFIG_DNS[$iface]=$(grep "DNS=" "$config_file" | sed 's/DNS=//g' | head -1 | tr ' ' ',')
+    # 解析DNS服务器（最多保留一个DNS）
+    CONFIG_DNS[$iface]=$(grep "DNS=" "$config_file" | sed 's/DNS=//g' | head -1 | awk '{print $1}')
 }
 
 # 函数：从NetworkManager配置文件中获取配置


### PR DESCRIPTION
## 背景

`source/pota_update/get_network_info.sh`（保留网络配置 OTA 流程的自动抓取网络配置范例）中，systemd-networkd 配置若为单行空格分隔的多 DNS 形式（`DNS=8.8.8.8 114.114.114.114`），原 `tr ' ' ','` 会生成逗号分隔的多 DNS 参数：

```bash
bm_set_ip eth0 '192.168.1.10' '255.255.255.0' '192.168.1.1' '8.8.8.8,114.114.114.114'
```

## 修改

只取第一个 DNS，不再生成多个逗号分隔的 DNS：

```bash
bm_set_ip eth0 '192.168.1.10' '255.255.255.0' '192.168.1.1' '8.8.8.8'
```

- `get_config_from_systemd`（get_network_info.sh:154）：`tr ' ' ','` → `awk '{print $1}'`
- NetworkManager 路径本已通过 `cut -d';' -f1` 只取第一个 DNS，无需修改

## 验证

- `bash -n` 语法检查通过
- mock systemd-networkd 环境端到端实测：
  - 单行多 DNS `DNS=8.8.8.8 114.114.114.114` → DNS 参数 `'8.8.8.8'` ✅
  - 多行多 DNS（每行一个 `DNS=`）→ DNS 参数 `'223.5.5.5'` ✅
  - 生成的 `set_network_config_by_bm_set_ip_autogen.sh` 中无逗号分隔 DNS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
