### PR TITLE
MYS-630: feat(get_info): CV84X2 soc 模式补齐 TPU/VPP 性能指标采集（v1.4.1）

### DIFF
--- a/source/pget_info/get_info.sh
+++ b/source/pget_info/get_info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GET_INFO_VERSION="1.4.0"
+GET_INFO_VERSION="1.4.1"
 
 shopt -s compat31
 
@@ -547,8 +547,13 @@ if [[ "${WORK_MODE}" == "SOC" ]]; then
     if [[ "${SOC_FAMILY}" == "cv" ]]; then
         DTS_MEM_FILE="/proc/device-tree/memory*/reg"
         # get_ddr_info 依赖 bm1684 家族的 iio:device0 ADC 与 devmem 0x27102014/0x27013050：
-        # CV84X2 dts 无 iio/adc 节点，且 0x27013050 未定义 → 实测输出空，保持留空即可。
-        DDR_TYPE=$(get_ddr_info 2>/dev/null)
+        # CV84X2 dts 无 iio/adc 节点，且 0x27013050 未定义。ADC 读空会让 vol_val_ddr 的算术
+        # 展开失败、各电压区间判断全部落空（此前输出为空属侥幸行为）；在装有 busybox devmem
+        # 的系统上 gpio117_val 还可能读到任意值，落入错误分支输出伪 DDR 类型。显式跳过，
+        # CV84X2 的 DDR_TYPE 保持留空。
+        if [[ "${CPU_MODEL}" != "cv84x6" ]]; then
+            DDR_TYPE=$(get_ddr_info 2>/dev/null)
+        fi
     else
         DTS_MEM_FILE="/proc/device-tree/memory/reg"
     fi
@@ -850,6 +855,13 @@ fi
 # TPU_USAGE
 TPU_USAGE=""
 if [[ "${WORK_MODE}" == "SOC" ]]; then
+    if [[ "${CPU_MODEL}" == "cv84x6" ]]; then
+        # CV84X6 的 npu_usage 被 driver 的 timer_on 门控（libsophon bm_attr.c npu_usage_show：
+        # timer_on==0 时输出 "Please, set [Usage enable] to 1"，默认 0）→ 直接读恒为空。
+        # 监测线程 bm_monitor 一直在后台采样（约 10ms/次），使能后立即可读：
+        #   echo 1 > /sys/class/bm-tpu/bm-tpu0/device/npu_usage_enable
+        write_to_file /sys/class/bm-tpu/bm-tpu0/device/npu_usage_enable 1
+    fi
     if [[ "${SOC_FAMILY}" == "cv" ]]; then
         TPU_USAGE=$(cat /sys/class/bm-tpu/bm-tpu0/device/npu_usage 2>/dev/null| awk -F':' '{print $2}' | awk '{print $1}' | tr '\n' ' ' | sed 's/ *$//')
     else
@@ -861,7 +873,14 @@ fi
 VPU_USAGE=""
 VPP_USAGE=""
 if [[ "${WORK_MODE}" == "SOC" ]]; then
-    if [[ "${SOC_FAMILY}" == "cv" ]]; then
+    if [[ "${CPU_MODEL}" == "cv84x6" ]]; then
+        # VPU 与其他 CV 系一致走 /proc/soph/vpuinfo（vc_drv_proc.h，PLATFORM_SOC）；
+        # VPP 则不同（osdrv vpss_proc.c，CV84X6 宏下无 soph/ 前缀）：/proc/vppinfo。
+        # vppinfo 的 usage 行格式为 {"id":N, "usage(instant|long)":  12%|  34%，
+        # 数值前有空格，且每核输出 instant|long 两个值——只取冒号后紧跟的 instant 值。
+        VPU_USAGE=$(cat /proc/soph/vpuinfo 2>/dev/null| tr -d '\n' | grep -ao ':[0-9]*%' | tr -d ':' | tr '\n' ',' | tr -d '%' | sed 's/ $//' | sed 's/,$//')
+        VPP_USAGE=$(cat /proc/vppinfo 2>/dev/null | tr -d '\n' | grep -aoE ':[[:space:]]*[0-9]+%' | tr -d ': ' | tr '\n' ',' | tr -d '%' | sed 's/,$//')
+    elif [[ "${SOC_FAMILY}" == "cv" ]]; then
         VPU_USAGE=$(cat /proc/soph/vpuinfo 2>/dev/null| tr -d '\n' | grep -ao ':[0-9]*%' | tr -d ':' | tr '\n' ',' | tr -d '%' | sed 's/ $//' | sed 's/,$//')
     else
         VPU_USAGE=$(cat /proc/vpuinfo 2>/dev/null| tr -d '\n' | grep -ao ':[0-9]*%' | tr -d ':' | tr '\n' ',' | tr -d '%' | sed 's/ $//' | sed 's/,$//')


### PR DESCRIPTION
## 背景

MYS-630：get_info 对 CV84X2（SDK 标识 cv84x6）软件层 100% 兼容。在 #124（v1.4.0，芯片识别 + 路径适配）基础上，对照 84x2_dev 分支最新 BSP 源码（2026-08-19 sync）逐项复核 soc 模式采集路径，修复剩余三处软件层缺口。

## 改动（get_info.sh v1.4.0 → v1.4.1，仅 soc 模式 cv84x6 分支）

| 指标 | 问题（源码依据） | 修复 |
|---|---|---|
| TPU_USAGE | `npu_usage` 被 driver `timer_on` 门控（libsophon `bm_attr.c:51`，默认 0 → 输出 `Please, set [Usage enable] to 1`），直接读恒为空 | 读取前 `echo 1 > npu_usage_enable`；监测线程 `bm_monitor` 一直在后台采样（~10ms/次），使能后立即可读 |
| VPP_USAGE | CV84X6 的 VPSS proc 是 `/proc/vppinfo`（osdrv `vpss_proc.c:20`，CV84X6 宏下无 `soph/` 前缀，与其他 CV 系不同）；usage 格式 `"usage(instant|long)":  12%\|  34%` 数值前带空格，原正则 `:[0-9]*%` 无法匹配 | 新增 cv84x6 分支：VPP 走 `/proc/vppinfo` + 宽松正则只取每核 instant 值；VPU 仍走 `/proc/soph/vpuinfo` |
| DDR_TYPE | cv84x6 走 `get_ddr_info`（依赖 iio ADC + devmem 0x27013050），CV84X2 均不存在；此前靠算术展开失败"碰巧"输出空，装 busybox devmem 的系统会落入错误分支输出伪值 | cv84x6 显式跳过，保持留空 |

## 复核确认（对最新 84x2_dev 源码，无改动）

- 识别：CPU part `0xd05`（A55）+ dts `cvitek,cv84x6-` 兜底 ✓
- 时钟：`clk_ap_ca55`/`clk_tpu_ip`/`clk_ve_axi`（`clk-cv84x6.c:415,523,1108`）✓
- ION：`cvi_npu/cvi_vpp_heap_dump` 的 `total_mem/alloc_mem`（`cvitek_ion.c:65`、`cvitek_ion_debugfs.c:208,238,250`）✓
- 温度：`thermal_zone0`（dts `soc_thermal_0`）✓
- SN/DTS/DEVICE_MODEL：eMMC boot1 偏移 0/32/0xA0/0xD0/0x70（FSBL `bl2_load.c:737-752`）✓
- MCU：I2C 0x17 命令字节协议 cmd 0/1/2（`84x6_card.c:69`）✓
- SDK 版本：`bm_version` 首行 `SophonSDK(<chip>) 2.1` ✓
- bm1684/bm1688/cv186ah 行为不变（新增分支均以 `cv84x6` 判收）

## 测试

- `bash -n` 语法通过
- 三个解析管道单测（用驱动真实输出格式构造样本）：npu_usage 多核 `12 45 0` ✓、vpuinfo `45,0` ✓、vppinfo（带空格 instant|long）`12,0` ✓
- 端到端：mount namespace 伪造 `/proc/cpuinfo`（CPU part 0xd05）→ 正确输出 `WORK_MODE|SOC`、`CPU_MODEL|cv84x6`，全字段无报错、缺路径优雅降级
- 真机（10.80.40.31）复核仍待环境恢复（MCU 值域、clk debugfs 实际值）

Closes MYS-630
