### PR TITLE
[MYS-632] 会话稳定性修复第一批：重连丢回答/心跳/forwardKey/sending

### DIFF
--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -17,10 +17,12 @@ import (
 // wsPath WebSocket 端点路径（对齐设计文档 §6.3）。
 const wsPath = "/agent/ws"
 
-// wsIdleTimeout 连接 30 分钟无任何消息即关闭。
-const wsIdleTimeout = 30 * time.Minute
+// wsIdleTimeout 连接无任何消息(含客户端应用层 ping)即关闭。
+// MYS-632:原 30 分钟过长,半开连接最长假死 30 分钟;缩短到 3 分钟,
+// 配合 25s 客户端 ping 与服务端 30s 控制帧 ping,数次错过即可判定死连接。
+const wsIdleTimeout = 3 * time.Minute
 
-// wsPingInterval 心跳间隔。
+// wsPingInterval 服务端控制帧心跳间隔。
 const wsPingInterval = 30 * time.Second
 
 // clientFrame 客户端（webchatUI）发来的 WS 帧。
@@ -240,14 +242,18 @@ func (c *conn) pushFrames(frames []WSFrame) {
 func (c *conn) readLoop() {
 	defer c.close()
 
-	// 心跳：定期 ping
+	// 心跳：定期 ping；写失败说明对端已半开/TCP 已坏，立即关闭连接，不再静默忽略。
 	ticker := time.NewTicker(wsPingInterval)
 	defer ticker.Stop()
 	go func() {
 		for {
 			select {
 			case <-ticker.C:
-				_ = c.writePing()
+				if err := c.writePing(); err != nil {
+					logger.Warn("agentproxy: ws ping write failed, closing %s: %v", c.addr, err)
+					c.close()
+					return
+				}
 			case <-c.done:
 				return
 			}
@@ -270,6 +276,8 @@ func (c *conn) readLoop() {
 		if msgType != websocket.TextMessage {
 			continue
 		}
+		// 任何客户端消息(含应用层 ping)都刷新读空闲超时,防半开误杀。
+		_ = c.ws.SetReadDeadline(time.Now().Add(wsIdleTimeout))
 		var frame clientFrame
 		if err := json.Unmarshal(data, &frame); err != nil {
 			logger.Warn("agentproxy: invalid ws frame from %s: %v", c.addr, err)
@@ -288,6 +296,9 @@ func (c *conn) handleFrame(frame clientFrame) {
 	defer c.mu.Unlock()
 
 	switch frame.Type {
+	case "ping":
+		// 应用层心跳（MYS-632）：客户端 PicoWs 周期发 ping 探测连接是否真正可用，
+		// 半开连接下发送会失败触发前端重连。服务端无需回包，readLoop 已刷新读超时。
 	case "message.send":
 		c.handleMessageSendLocked(frame)
 	case "session.switch":
@@ -473,6 +484,15 @@ func (c *conn) handleSessionHistoryLocked(frame clientFrame) {
 		c.enqueueErrorLocked("会话不存在", "session_not_found")
 		return
 	}
+	// MYS-632 (P0-1): 拉取某会话历史即表示关注其实时流——重连后前端只发
+	// session.list + session.history 来恢复,若不绑定 byACP,该会话在途回合的
+	// message.create/typing.stop/session.busy=false 帧会经 Deliver 查询落空被丢弃,
+	// 表现为「切走切回后本回合回答丢失,需刷新才能恢复」。这里绑定即可重新订阅流。
+	// 只更新 byACP 路由,不动 c.session(连接的业务会话仍由 message.send 语义管理);
+	// 也不发 session.create 帧,避免与新建会话帧语义混淆。
+	c.hub.mu.Lock()
+	c.hub.byACP[s.ACPSessionID] = c
+	c.hub.mu.Unlock()
 	f := WSFrame{
 		Type:      "session.history",
 		SessionID: sid,

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -893,3 +893,105 @@ func TestWSNoDuplicateFrames(t *testing.T) {
 		t.Fatalf("message.create delivered %d times, want exactly 1 (duplicate bug)", creates)
 	}
 }
+
+// TestWSHistoryBindsACP MYS-632 (P0-1)：拉取某会话历史即绑定 byACP 订阅其实时流。
+// 重连后前端只发 session.list + session.history,若不绑定,该会话在途回合的
+// message.create/typing.stop/busy=false 帧会经 Deliver 查询落空被丢弃。
+func TestWSHistoryBindsACP(t *testing.T) {
+	mod, _ := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	sm := mod.sessions
+	sm.mu.Lock()
+	sm.sessions["web-h"] = &WebchatSession{
+		ID: "web-h", ACPSessionID: "acp-h", Title: "绑定",
+		Messages: []ChatMessage{{Role: "user", Content: "hi"}},
+	}
+	sm.mu.Unlock()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	// 重连场景：新连接不发 message.send,只发 session.history
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-h"})
+
+	// 先消费 session.history 响应帧（读到为止）
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "session.history" {
+			break
+		}
+	}
+
+	// 拉历史后 byACP 已绑定到本连接 → Deliver 在途帧可达
+	h.Deliver("acp-h", []WSFrame{{
+		Type:      "message.create",
+		SessionID: "web-h",
+		Payload:   map[string]any{"content": "在途答案", "kind": "text", "message_id": "mh"},
+	}})
+
+	deadline = time.Now().Add(3 * time.Second)
+	found := false
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "message.create" && m["payload"].(map[string]any)["content"] == "在途答案" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("in-flight turn frames dropped after history-only reconnect (byACP not bound)")
+	}
+}
+
+// TestWSPingFrame 客户端应用层 ping 帧不产生回包、不关闭连接,可继续收发。
+func TestWSPingFrame(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-p"}})
+		req2, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "method": "session/update", "params": map[string]any{"sessionId": "acp-p", "update": map[string]any{"sessionUpdate": map[string]any{"agent_message_chunk": map[string]any{"messageId": "mp", "content": map[string]any{"text": "ping后仍有回复"}}}}}})
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	// 发送应用层 ping
+	_ = conn.WriteJSON(map[string]any{"type": "ping"})
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "问"}})
+
+	// ping 后消息仍能正常收发（连接未被 ping 帧关闭/无回包干扰）
+	deadline := time.Now().Add(4 * time.Second)
+	gotCreate, gotTypingStop := false, false
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		switch m["type"] {
+		case "ping":
+			t.Fatal("server must not echo client ping frame")
+		case "message.create":
+			gotCreate = true
+		case "typing.stop":
+			gotTypingStop = true
+		}
+		if gotCreate && gotTypingStop {
+			break
+		}
+	}
+	if !gotCreate || !gotTypingStop {
+		t.Fatalf("after ping: gotCreate=%v gotTypingStop=%v, want both", gotCreate, gotTypingStop)
+	}
+}

--- a/source/psophliteos/frontend/src/api/aiAgent/ws.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/ws.ts
@@ -27,6 +27,11 @@ interface PicoWsOpts {
   onStatus?: (status: WsStatus) => void;
 }
 
+// 应用层心跳间隔（MYS-632 P0-2）：浏览器 WebSocket 无法主动发 control ping，
+// 用 25s 一条 {type:'ping'} 帧保持服务端读空闲不超时；半开连接时客户端消息也
+// 到不了服务端，服务端 3 分钟读超时关闭 → TCP 断开信号经 onclose 回到客户端。
+const HEARTBEAT_INTERVAL = 25_000;
+
 export class PicoWs {
   url: string;
   token: string;
@@ -39,6 +44,7 @@ export class PicoWs {
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectCount = 0;
   private queue: any[] = [];
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(opts: PicoWsOpts) {
     this.url = opts.url;
@@ -55,6 +61,7 @@ export class PicoWs {
       return;
     }
     this.closed = false;
+    this.bindNetworkEvents();
     this.emitStatus('connecting');
     try {
       this.ws = new WebSocket(this.url, ['token.' + this.token]);
@@ -66,6 +73,7 @@ export class PicoWs {
     this.ws.onopen = () => {
       this.ready = true;
       this.reconnectCount = 0;
+      this.startHeartbeat();
       this.flushQueue();
       this.emitStatus('open');
     };
@@ -84,6 +92,8 @@ export class PicoWs {
     this.ws.onclose = () => {
       const wasReady = this.ready;
       this.ready = false;
+      this.stopHeartbeat();
+      this.unbindNetworkEvents();
       if (wasReady) this.emitStatus('closed');
       this.scheduleReconnect();
     };
@@ -122,6 +132,8 @@ export class PicoWs {
   close(): void {
     this.closed = true;
     this.queue = [];
+    this.stopHeartbeat();
+    this.unbindNetworkEvents();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
@@ -135,6 +147,59 @@ export class PicoWs {
       this.ws = null;
     }
     this.ready = false;
+  }
+
+  // ---------- 心跳（MYS-632 P0-2） ----------
+  // 浏览器 WebSocket 不允许发送 control ping，应用层 ping 帧让服务端保持读空闲
+  // 不超时；半开连接时消息到不了服务端，服务端 3 分钟读超时关闭连接，触发本地
+  // onclose → scheduleReconnect，从而结束「已连接但发消息无反应」的假死。
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+      try {
+        this.ws.send(JSON.stringify({ type: 'ping' }));
+      } catch (e) {
+        // 发送抛异常说明连接已坏，交给 onclose/reconnect 恢复
+      }
+    }, HEARTBEAT_INTERVAL);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  // ---------- 网络事件（MYS-632 P0-2） ----------
+  // 页面切回前台 / 网络恢复：若连接已半开（ws.ready 仍 true 但实际已断），主动
+  // reconnect 而非被动等 onclose；若连接已断开则恢复重连调度。
+  private onVisibilityChange = () => {
+    if (document.visibilityState !== 'visible') return;
+    if (this.closed) return;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.reconnect();
+    }
+  };
+
+  private onOnline = () => {
+    if (this.closed) return;
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      this.reconnect();
+    }
+  };
+
+  private bindNetworkEvents(): void {
+    if (typeof window === 'undefined') return;
+    window.addEventListener('visibilitychange', this.onVisibilityChange);
+    window.addEventListener('online', this.onOnline);
+  }
+
+  private unbindNetworkEvents(): void {
+    if (typeof window === 'undefined') return;
+    window.removeEventListener('visibilitychange', this.onVisibilityChange);
+    window.removeEventListener('online', this.onOnline);
   }
 
   private buildFrame(sessionId?: string, content?: string, media?: string[]): any {

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -234,6 +234,10 @@
 
   let ws: PicoWs | null = null;
   let forwardKey = '';
+  // P1-1：配置拉取重试句柄（失败 30s 内重试 3 次，成功后更新 token 供后续重连使用）
+  let configRetryTimer: ReturnType<typeof setTimeout> | null = null;
+  // P1-2：最近一次发送成功时间（sending 在途标记超时兜底用）
+  let lastSendAt = 0;
   // 本地 message 渲染序号（避免重复 key）
   let msgSeq = 0;
   // 兜底：agent 回答完仍转圈的动画 BUG（MYS-199）。
@@ -555,6 +559,10 @@
         break;
       case 'typing.stop':
         typing.value = false;
+        // MYS-632 P1-2：typing.stop 在首个内容 chunk 到达时也会下发一次
+        // （protocol.go messageChunk 停打字指示器），并非只对应回合结束——不能在此
+        // 复位 sending，否则快速连发两条仍会让第二条 StartTurn 取消第一条。
+        // sending 仅在 busy=false / error / turn.error 时复位（见对应分支）。
         // 回合结束：思考已结束，后续新思考应另起折叠块
         clearOpenThought();
         break;
@@ -566,7 +574,19 @@
         break;
       case 'session.busy':
         // 需求 2：会话忙碌状态（agent 正在干活）的转圈标记
-        setSessionBusy(msg.session_id || payload.session_id, !!payload.busy);
+        {
+          const bsid = msg.session_id || payload.session_id;
+          const wasBusy = !!sessions.value.find((x) => x.id === bsid)?.busy;
+          setSessionBusy(bsid, !!payload.busy);
+          if (!payload.busy) {
+            // 回合结束：允许下一条消息（MYS-632 P1-2）
+            sending.value = false;
+            // MYS-632 P0-1：回合可能在重连/切会话期间结束，本回合 assistant 只在
+            // 服务端回合结束才落库，若流式帧因重连丢失，本地看不到答案。收到
+            // busy=false 对该会话补拉一次 history reconcile（mergeHistory 幂等）。
+            if (wasBusy && bsid) pullHistory(bsid);
+          }
+        }
         break;
       case 'session.updated':
         // 需求 3：自定义标题后的回执 + 自动审批开关跨浏览器同步回执
@@ -578,6 +598,13 @@
         break;
       case 'permission.responded':
         markPermissionDone(payload.request_id, !!payload.allow);
+        break;
+      case 'turn.error':
+        // MYS-632 P1-2：回合错误与 error 同语义，终止在途标记（否则 sending 卡死）
+        errorMsg.value = payload.message || '发生错误';
+        sending.value = false;
+        typing.value = false;
+        setSessionBusy(msg.session_id || activeId.value, false);
         break;
       case 'error':
         errorMsg.value = payload.message || '发生错误';
@@ -685,6 +712,13 @@
       delete busyCalibAt[s.id];
       if (s.busy && now - (sessionLastWsAt[s.id] || 0) >= BUSY_CALIBRATE_WINDOW) {
         s.busy = false;
+        // 复位 busy 同步复位发送/输入态：终结态帧丢失时用户仍可继续发消息（MYS-632 P1-2）
+        if (s.id === activeId.value) {
+          sending.value = false;
+          typing.value = false;
+        }
+        // MYS-632 P0-1：校准复位可能是回合已完成但终态帧丢失，补拉 reconcile 幂等
+        if (ws && ws.ready) pullHistory(s.id, true);
       }
     });
   }
@@ -700,6 +734,14 @@
       if (!s.busy) return;
       if (now - (sessionLastWsAt[s.id] || 0) > BUSY_STALL_TIMEOUT) {
         s.busy = false;
+        // 复位 busy 同步复位发送/输入态：终结态帧丢失时用户仍可继续发消息（MYS-632 P1-2）
+        if (s.id === activeId.value) {
+          sending.value = false;
+          typing.value = false;
+        }
+        // MYS-632 P0-1：回合实际结束但终态帧丢失的兜底——补拉历史把落库答案
+        // reconcile 回本地；mergeHistory 幂等，可安全重复。
+        if (ws && ws.ready) pullHistory(s.id, true);
       }
     });
   }
@@ -1052,12 +1094,16 @@
     }
   }
 
+  // 校准/超时复位引发的 history 补拉：只合并消息做 reconcile，不恢复 busy。
+  // 若恢复 busy，服务端 running=true 又会重设校准窗口 → 复位 → 再补拉 → 无限循环。
+  const reconcileOnly = new Set<string>();
+
   function handleSessionHistory(payload: any) {
     const sid = payload.session_id;
     const raw = Array.isArray(payload.messages) ? payload.messages : [];
     const s = sessions.value.find((x) => x.id === sid);
     if (!s) return;
-    // 需求(MYS-209)：后端一轮回答会按 message_id 拆成多条 message.create，落库后
+    const onlyReconcile = reconcileOnly.delete(sid); // 在合并前消费标记
     // history 里会出现成段的相邻 text 小片段（agent 一条完整回答被切成 text-1..text-N），
     // 且一句话中间可能夹 thought / tool_calls（内部思考、工具调用）。若这些把 text
     // 切断成多泡，会把「同一条连续回答」显示成碎片。故加载历史时，把相邻的 assistant
@@ -1100,7 +1146,9 @@
     if (payload.title && s.title !== payload.title) s.title = payload.title;
     // 自动审批开关跨浏览器同步：以 bmssm 服务端为准
     if (typeof payload.autoApprove === 'boolean') s.autoApprove = payload.autoApprove;
-    restoreBusy(s.id, !!payload.running); // 需求 4：恢复 busy 时走一次性校准
+    if (!onlyReconcile) {
+      restoreBusy(s.id, !!payload.running); // 需求 4：恢复 busy 时走一次性校准
+    }
     clearOpenThought();
     saveSessions();
     resetRenderWindow(); // 懒加载：历史到达后只渲染尾部窗口，避免一次性渲染全部导致卡顿
@@ -1112,8 +1160,9 @@
     ws.sendFrame({ type: 'session.list' }, { queued: true });
   }
 
-  function pullHistory(sessionId: string) {
+  function pullHistory(sessionId: string, onlyReconcile = false) {
     if (!ws || !ws.ready || !sessionId) return;
+    if (onlyReconcile) reconcileOnly.add(sessionId);
     ws.sendFrame({ type: 'session.history', session_id: sessionId }, { queued: true });
   }
 
@@ -1147,7 +1196,11 @@
 
     try {
       ws.send(serverId, content, []);
-      sending.value = false;
+      lastSendAt = Date.now();
+      // 在途标记：保持 sending=true 直到本轮回合结束信号（session.busy=false /
+      // turn.error / error）到达，期间用户再 Enter 会被 sendMessage 顶部的
+      // `if (sending.value) return` 拦下，避免第二条 StartTurn 取消第一条的回答
+      // （MYS-632 P1-2）。
     } catch (err: any) {
       sending.value = false;
       errorMsg.value = err.message || '发送失败，请检查连接';
@@ -1237,19 +1290,26 @@
   }
 
   // ---------- 连接 ----------
+  // P1-1：配置拉取短退避周期重试（30s 内最多重试 3 次，累计 ~3s/10s/25s）。
+  // 服务端 /agent/ws 自 MYS-379 起不再校验子协议 key，配置失败不阻塞建连；
+  // 重试成功后更新 forwardKey，供后续重建连接时携带子协议 token（兼容回显）。
+  async function refreshAgentConfig(retries: number): Promise<void> {
+    const cfg = await getAgentConfig();
+    if (cfg?.forwardKey) {
+      forwardKey = cfg.forwardKey;
+      if (ws) ws.token = cfg.forwardKey;
+      return;
+    }
+    if (retries >= 3) return;
+    const delays = [3000, 7000, 15000];
+    configRetryTimer = setTimeout(() => refreshAgentConfig(retries + 1), delays[retries]);
+  }
+
   async function connect() {
     if (!forwardKey) {
-      const cfg = await getAgentConfig();
-      forwardKey = cfg?.forwardKey || '';
-    }
-    // MYS-386：llm-proxy/config 已改为 admin-only。非管理员（或配置读取
-    // 失败）拿不到 forwardKey，空 token 会持续 WS 握手失败重连，这里
-    // 明确提示并跳过连接，避免无限重连。
-    if (!forwardKey) {
-      statusText.value = '未连接';
-      statusClass.value = 'bad';
-      errorMsg.value = '无法连接智能体：配置读取失败（需管理员权限，或服务未就绪），请刷新页面重试';
-      return;
+      // 异步读取配置（首个尝试等快速失败），拿到失败/超时结果前直接建连——
+      // 非 admin / bmssm 刚启动配置未就绪的场景也能立即进入对话页。
+      void refreshAgentConfig(0);
     }
     if (ws) {
       ws.close();
@@ -1287,6 +1347,11 @@
     busyStallTimer = setInterval(() => {
       clearStalledBusy();
       calibrateRestoredBusy();
+      // P1-2 兜底：sending 在途标记长期不落位（终态帧丢失/回合卡死）会阻塞后续
+      // 发送，超时后复位（busy 走 BUSY_STALL_TIMEOUT 同一阈值）。
+      if (sending.value && Date.now() - lastSendAt > BUSY_STALL_TIMEOUT) {
+        sending.value = false;
+      }
     }, BUSY_SCAN_INTERVAL);
   });
 
@@ -1294,6 +1359,10 @@
     if (busyStallTimer) {
       clearInterval(busyStallTimer);
       busyStallTimer = null;
+    }
+    if (configRetryTimer) {
+      clearTimeout(configRetryTimer);
+      configRetryTimer = null;
     }
     if (renderTimer) clearTimeout(renderTimer);
     if (ws) ws.close();


### PR DESCRIPTION
## Summary

MYS-629 review 确认的「会话不稳定/没回复」4 项缺陷的第一批修复（基于 main @ e767507，自 MYS-629 起无新提交）。

- **P0-1 回合进行中重连/切会话 → 本轮回答彻底丢失**：服务端 `handleSessionHistoryLocked` 对目标会话绑定 `byACP`，重连后前端仅发 `session.list`+`session.history` 即重建实时流订阅；前端收到 `session.busy=false` / busy 校准·超时复位后对该会话补拉一次 `session.history` reconcile（`mergeHistory` 幂等，reconcile 拉取不恢复 busy，避免校准循环）。
- **P0-2 传输层无客户端心跳 → 半开连接假死**：PicoWs 25s 应用层 ping + `visibilitychange`/`online` 主动重连；服务端 ping 写失败立即 `close()`，读空闲超时 30min → 3min，任一帧到达刷新读超时。
- **P1-1 forwardKey 前置残留**：移除 forwardKey 连接前提（非 admin / 配置拉取失败直接建连），配置失败 30s 内短退避重试 3 次。
- **P1-2 message.send 防重失效**：发送后保持 `sending=true` 直至 `busy=false`/`error`/`turn.error`/超时兜底复位；`typing.stop` 在首 chunk 即下发不作为复位信号，快速连发第二条被拦截，避免第二条 `StartTurn` 取消第一条。

## 测试

- `go test ./mvc/agentproxy/...` 全绿（新增 `TestWSHistoryBindsACP`、`TestWSPingFrame`）
- `go build ./...`（bmssm）通过
- sophliteos 前端 `vue-tsc --noEmit --skipLibCheck` 无 src 错误、`vite build` 成功

## 非目标（第二批）

P1-3（未知会话静默新建/删除断线不入队）、P1-4（history 全量传输/localStorage 全量写）、P2 各项，另行处理。
