### PR TITLE
[MYS-635] 会话稳定性修复第二批：未知会话不静默新建/删除断线入队/history 分页/localStorage 防抖

### DIFF
--- a/source/pbmssm/mvc/agentproxy/session.go
+++ b/source/pbmssm/mvc/agentproxy/session.go
@@ -188,6 +188,8 @@ func (sm *SessionManager) Close(ctx context.Context, client *Client, webchatID s
 }
 
 // Delete 删除会话（ACP session/delete + 本地记录删除）。
+// MYS-637: client 可能为 nil(reasonix 未启动)A CP 调用会 nil panic——本地删除
+// 始终执行,ACP session/delete 仅 client 存在时尽力而为(失败仅告警,不阻塞本地删除)。
 func (sm *SessionManager) Delete(ctx context.Context, client *Client, webchatID string) error {
 	sm.mu.Lock()
 	s, ok := sm.sessions[webchatID]
@@ -199,8 +201,10 @@ func (sm *SessionManager) Delete(ctx context.Context, client *Client, webchatID 
 	if !ok {
 		return nil
 	}
-	if err := client.DeleteSession(ctx, s.ACPSessionID); err != nil {
-		logger.Warn("agentproxy: acp session/delete failed: %v", err)
+	if client != nil {
+		if err := client.DeleteSession(ctx, s.ACPSessionID); err != nil {
+			logger.Warn("agentproxy: acp session/delete failed: %v", err)
+		}
 	}
 	if sm.db != nil {
 		if err := sm.db.Where("id = ?", webchatID).Delete(&WebchatSession{}).Error; err != nil {

--- a/source/pbmssm/mvc/agentproxy/session_test.go
+++ b/source/pbmssm/mvc/agentproxy/session_test.go
@@ -140,6 +140,26 @@ func TestSessionDelete(t *testing.T) {
 	}
 }
 
+// TestSessionDeleteNilClientNoPanic MYS-637：client 为 nil(reasonix 未启动)时
+// Delete 不 panic,本地记录仍删除(ACP session/delete 尽力而为)。
+func TestSessionDeleteNilClientNoPanic(t *testing.T) {
+	db := newTestDB(t)
+	sm := NewSessionManager(db, t.TempDir())
+	ctx := context.Background()
+	// 直接植入会话,跳过 ACP 创建(reasonix 未启动场景)
+	s := &WebchatSession{ID: "web-nil-client", ACPSessionID: "acp-nil-client", Title: "t"}
+	sm.mu.Lock()
+	sm.sessions[s.ID] = s
+	sm.mu.Unlock()
+
+	if err := sm.Delete(ctx, nil, s.ID); err != nil {
+		t.Fatalf("Delete with nil client: %v", err)
+	}
+	if _, ok := sm.Get(s.ID); ok {
+		t.Fatal("session still present after delete with nil client")
+	}
+}
+
 // TestSessionSwitchResume 验证 Switch：closed 会话 resume 后 active。
 func TestSessionSwitchResume(t *testing.T) {
 	db := newTestDB(t)

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -357,8 +357,15 @@ func (c *conn) handleMessageSendLocked(frame clientFrame) {
 				return
 			}
 			c.resumeSessionLocked(sw)
+		} else if c.session != nil {
+			// MYS-635 (P1-3): 本连接已绑定会话却收到未知 wid(会话被另一标签页删除/
+			// 服务端清库)→ 回错误帧,不再静默新建。否则新会话 id 与前端已 serverBound
+			// 的本地 id 不一致,回包被会话隔离过滤,用户看到「已发送没回」+ 幽灵「新会话」。
+			c.enqueueErrorLocked("会话不存在,可能已被删除", "session_not_found")
+			return
 		}
-		// wid 存在但 Get 未命中 → 视为未知会话，落回新建分支（向后兼容）
+		// wid 存在但 Get 未命中 → 未知会话;若本连接尚未绑定任何会话(全新连接/前端
+		// 本地新会话首消息,服务端尚无该 id),落回新建分支创建(向后兼容)。
 	}
 	if c.session == nil {
 		if err := c.ensureSessionLocked(); err != nil {
@@ -467,8 +474,10 @@ func (c *conn) handleSessionListLocked() {
 	}
 }
 
-// handleSessionHistoryLocked session.history：返回指定 webchat 会话的全量消息。
-// 前置：持 c.mu。
+// handleSessionHistoryLocked session.history：返回指定 webchat 会话的消息。
+// 支持分页：payload.limit 限制返回条数(最近 N 条),payload.before 传已加载的
+// 最早消息索引(从后往前第 N 条起再往前取),返回附带 hasMore 供前端判断上翻可续。
+// 不带 limit/before 时保持旧行为返回全量(向前兼容旧前端/测试)。前置：持 c.mu。
 func (c *conn) handleSessionHistoryLocked(frame clientFrame) {
 	sid := frame.SessionID
 	if sid == "" {
@@ -493,20 +502,57 @@ func (c *conn) handleSessionHistoryLocked(frame clientFrame) {
 	c.hub.mu.Lock()
 	c.hub.byACP[s.ACPSessionID] = c
 	c.hub.mu.Unlock()
+
+	// MYS-635 (P1-4): 分页窗口。history 一次全量传输在长会话(数百条)下拖慢重连/切换;
+	// 前端滚动懒加载窗口按 limit 取最近 N 条,before=已载的最早索引时继续往前取。
+	messages := s.Messages
+	hasMore := false
+	if limit, ok := intFromPayload(frame.Payload, "limit"); ok && limit > 0 {
+		total := len(messages)
+		end := total // 截断终点(不含)
+		if before, ok := intFromPayload(frame.Payload, "before"); ok && before > 0 && before <= total {
+			end = total - before
+		}
+		start := end - limit
+		if start < 0 {
+			start = 0
+		}
+		hasMore = start > 0 // 前面还有更早消息
+		messages = messages[start:end]
+	}
 	f := WSFrame{
 		Type:      "session.history",
 		SessionID: sid,
 		Payload: map[string]any{
-			"session_id":  sid,
-			"messages":    s.Messages,
-			"title":       s.Title,
-			"autoApprove": s.AutoApprove, // 自动审批开关（跨浏览器/设备持久化）
+			"session_id": sid,
+			"messages":   messages,
+			"title":      s.Title,
+			// 自动审批开关（跨浏览器/设备持久化）
+			"autoApprove": s.AutoApprove,
 			"running":     c.module.HasTurn(s.ACPSessionID),
+			"hasMore":     hasMore, // MYS-635 P1-4: 是否还有更早消息可翻页
 		},
 	}
 	select {
 	case c.send <- []WSFrame{f}:
 	case <-c.done:
+	}
+}
+
+// intFromPayload 从 map 读取 int 型字段(容忍 float64/int 两种 JSON 解码形态)。
+func intFromPayload(payload map[string]any, key string) (int, bool) {
+	if payload == nil {
+		return 0, false
+	}
+	switch v := payload[key].(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	default:
+		return 0, false
 	}
 }
 

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -995,3 +995,174 @@ func TestWSPingFrame(t *testing.T) {
 		t.Fatalf("after ping: gotCreate=%v gotTypingStop=%v, want both", gotCreate, gotTypingStop)
 	}
 }
+
+// TestWSMessageSendUnknownWidOnBoundConn MYS-635 (P1-3)：本连接已绑定会话却携带
+// 未知 wid → 回 session_not_found,不再静默新建。防「已发送没回」+ 幽灵「新会话」。
+func TestWSMessageSendUnknownWidOnBoundConn(t *testing.T) {
+	mod, tr := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	mod.hub = h
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	go func() {
+		sc := bufioNewScanner(tr.in)
+		req, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		// 首次 message.send(无 wid) → session/new 创建会话
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{"sessionId": "acp-ok"}})
+		req2, err := tr.readRequestErr(sc)
+		if err != nil {
+			return
+		}
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "method": "session/update", "params": map[string]any{"sessionId": "acp-ok", "update": map[string]any{"sessionUpdate": map[string]any{"agent_message_chunk": map[string]any{"messageId": "m1", "content": map[string]any{"text": "第一条"}}}}}})
+		_ = tr.reply(map[string]any{"jsonrpc": "2.0", "id": *req2.ID, "result": map[string]any{"stopReason": "end_turn"}})
+	}()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+	// 首次正常发消息,连接绑定到会话
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "payload": map[string]any{"content": "hi"}})
+	waitFor(t, 3*time.Second, "session bound", func() bool {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		return len(h.byACP) == 1
+	})
+
+	// 绑定后发送未知 wid(会话已被删/清库)→ 期望 session_not_found,而非新建
+	_ = conn.WriteJSON(map[string]any{"type": "message.send", "session_id": "deleted-session-xyz", "payload": map[string]any{"content": "hello", "session_id": "deleted-session-xyz"}})
+
+	deadline := time.Now().Add(3 * time.Second)
+	gotErr := false
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] == "error" {
+			p := m["payload"].(map[string]any)
+			if p["code"] == "session_not_found" {
+				gotErr = true
+				break
+			}
+		}
+	}
+	if !gotErr {
+		t.Fatal("unknown wid on bound conn: expected session_not_found error, got none")
+	}
+}
+
+// TestWSHistoryPagination MYS-635 (P1-4)：session.history 支持 limit/before 分页,
+// 返回最近 limit 条 + hasMore;before 往前翻页。
+func TestWSHistoryPagination(t *testing.T) {
+	mod, _ := mockModuleForWS(t)
+	h := newHub(mod, "key")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+
+	sm := mod.sessions
+	sm.mu.Lock()
+	msgs := make([]ChatMessage, 0, 25)
+	for i := 0; i < 25; i++ {
+		msgs = append(msgs, ChatMessage{Role: "user", Content: "m" + strconv.Itoa(i)})
+	}
+	sm.sessions["web-page"] = &WebchatSession{
+		ID: "web-page", ACPSessionID: "acp-page", Title: "分页",
+		Messages: msgs,
+	}
+	sm.mu.Unlock()
+
+	conn := dialWS(t, wsURL(srv.URL)+wsPath, "token.key")
+
+	// 第一页：limit=10,期望返回最后 10 条,hasMore=true
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-page", "payload": map[string]any{"limit": 10}})
+	deadline := time.Now().Add(3 * time.Second)
+	var gotHasMore bool
+	var firstLen int
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.history" {
+			continue
+		}
+		p := m["payload"].(map[string]any)
+		firstLen = len(p["messages"].([]any))
+		if b, ok := p["hasMore"].(bool); ok && b {
+			gotHasMore = true
+		}
+		// 最后一条应为 m24
+		msgsAny := p["messages"].([]any)
+		last := msgsAny[len(msgsAny)-1].(map[string]any)
+		if last["content"] != "m24" {
+			t.Fatalf("first page last = %v, want m24", last["content"])
+		}
+		break
+	}
+	if firstLen != 10 {
+		t.Fatalf("first page len = %d, want 10", firstLen)
+	}
+	if !gotHasMore {
+		t.Fatal("first page hasMore = false, want true")
+	}
+
+	// 第二页：before=10(跳过尾部 10 条),再往前取 10 条(m5..m14),hasMore=true
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-page", "payload": map[string]any{"limit": 10, "before": 10}})
+	deadline = time.Now().Add(3 * time.Second)
+	var secondFirst, secondLast string
+	var secondLen int
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.history" {
+			continue
+		}
+		p := m["payload"].(map[string]any)
+		msgsAny := p["messages"].([]any)
+		secondLen = len(msgsAny)
+		secondFirst = msgsAny[0].(map[string]any)["content"].(string)
+		secondLast = msgsAny[len(msgsAny)-1].(map[string]any)["content"].(string)
+		break
+	}
+	if secondLen != 10 {
+		t.Fatalf("second page len = %d, want 10", secondLen)
+	}
+	if secondFirst != "m5" || secondLast != "m14" {
+		t.Fatalf("second page range = %s..%s, want m5..m14 (before=跳过尾部N条)", secondFirst, secondLast)
+	}
+
+	// 第三页：before=20,剩余前 5 条(m0..m4),hasMore=false
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-page", "payload": map[string]any{"limit": 10, "before": 20}})
+	deadline = time.Now().Add(3 * time.Second)
+	var lastHasMore *bool
+	var thirdFirst, thirdLast string
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.history" {
+			continue
+		}
+		p := m["payload"].(map[string]any)
+		msgsAny := p["messages"].([]any)
+		thirdFirst = msgsAny[0].(map[string]any)["content"].(string)
+		thirdLast = msgsAny[len(msgsAny)-1].(map[string]any)["content"].(string)
+		b := p["hasMore"].(bool)
+		lastHasMore = &b
+		break
+	}
+	if thirdFirst != "m0" || thirdLast != "m4" {
+		t.Fatalf("third page range = %s..%s, want m0..m4", thirdFirst, thirdLast)
+	}
+	if lastHasMore == nil || *lastHasMore {
+		t.Fatalf("third page hasMore = %v, want false", lastHasMore)
+	}
+
+	// 不带 limit → 全量(向后兼容)
+	_ = conn.WriteJSON(map[string]any{"type": "session.history", "session_id": "web-page"})
+	deadline = time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		m := readFrame(t, conn)
+		if m["type"] != "session.history" {
+			continue
+		}
+		p := m["payload"].(map[string]any)
+		if n := len(p["messages"].([]any)); n != 25 {
+			t.Fatalf("no-limit history len = %d, want 25 (backward compat)", n)
+		}
+		break
+	}
+}

--- a/source/psophliteos/frontend/src/api/aiAgent/ws.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/ws.ts
@@ -114,7 +114,10 @@ export class PicoWs {
   sendFrame(frame: any, opts?: { queued?: boolean }): boolean {
     const o = opts || {};
     const value = JSON.stringify(frame);
-    if (this.ready && this.ws && this.ws.readyState === WebSocket.OPEN && !o.queued) {
+    // MYS-637 修复：优先发送——连接就绪时即使标记 queued 也直接发送，避免
+    // 「入队后立刻被 next reconnect 清队」导致帧从不送达（session.delete 在线删除回归）。
+    // queued 语义收敛为「仅未就绪时入队,等重连 flush」。
+    if (this.ready && this.ws && this.ws.readyState === WebSocket.OPEN) {
       this.ws.send(value);
       return true;
     }
@@ -125,13 +128,13 @@ export class PicoWs {
   }
 
   reconnect(): void {
-    this.close();
+    this.close({ keepQueue: true }); // 跨重连保留未发送帧（断线期间的 delete 等）,onopen flush
     this.connect();
   }
 
-  close(): void {
+  close(opts?: { keepQueue?: boolean }): void {
     this.closed = true;
-    this.queue = [];
+    if (!opts?.keepQueue) this.queue = [];
     this.stopHeartbeat();
     this.unbindNetworkEvents();
     if (this.reconnectTimer) {

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -372,7 +372,7 @@
           key && sessionId && activeId.value === sessionId && activeSess.value?.messages.some((x) => x.key === key);
         if (stillActive && m.__renderSeq === mark) {
           m.html = html;
-          saveSessions();
+          scheduleSave(); // 渲染结果写回,流式期间高频 → 防抖合并
         }
       })
       .catch(() => {
@@ -455,9 +455,40 @@
           }),
         };
       });
-      localStorage.setItem(SESSIONS_KEY, JSON.stringify(snap));
-    } catch (e) {
-      /* ignore */
+      const serialized = JSON.stringify(snap);
+      localStorage.setItem(SESSIONS_KEY, serialized);
+    } catch (e: any) {
+      // MYS-635 P1-4：写入失败(通常 QuotaExceeded)不再静默吞掉——提示一次,避免
+      // 用户以为已持久化实际刷新即丢。仅在阈值外提示,防长回话说一句刷屏。
+      if (e && (e.name === 'QuotaExceededError' || e.code === 22 || e.code === 1014)) {
+        const now = Date.now();
+        if (now - (lastStorageQuotaWarnAt || 0) > 60_000) {
+          lastStorageQuotaWarnAt = now;
+          console.warn('[sophon-webchat] localStorage 容量超限,会话本地持久化失效(服务端仍在线,刷新后历史由 session.history 恢复)', e);
+        }
+      }
+    }
+  }
+
+  // MYS-635 P1-4：流式写入防抖——每个流式 chunk 都 saveSessions() 全量序列化所有会话,
+  // 长会话下每 chunk 都写 localStorage 拖慢 UI。结构性操作(新建/删除/切换/绑定/权限)仍
+  // 调 saveSessions() 立即落盘;高频流式(handleCreate/handleUpdate)改走本函数 500ms 合并,
+  // 一轮连发多个 chunk 只写一次。
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastStorageQuotaWarnAt = 0;
+  function scheduleSave() {
+    if (saveTimer) return;
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      saveSessions();
+    }, 500);
+  }
+  // 组件卸载时冲刷防抖缓冲,避免「刷新/关闭瞬间丢失最后一段内容」。
+  function flushScheduleSave() {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+      saveSessions();
     }
   }
 
@@ -503,8 +534,10 @@
     // 先同步到服务端真实删除（此前只做本地移除，重连后 session.list 会把服务端仍在的
     // 会话拉回来 → 点击消失又复现）。后端 handleSessionDeleteLocked 会删除服务端会话
     // 并解绑本连接对该会话的 byACP 订阅，此后重连 session.list 不再返回它。
-    if (ws && ws.ready) {
-      ws.sendFrame({ type: 'session.delete', session_id: id, payload: { session_id: id } });
+    // MYS-635 P1-3：queued:true —— 断线期间删除入队,重连后 flush 真正送达服务端,
+    // 避免「删了又复活」(旧行为仅本地移除,断线删除静默失败,重连拉回)。
+    if (ws) {
+      ws.sendFrame({ type: 'session.delete', session_id: id, payload: { session_id: id } }, { queued: true });
     }
     sessions.value = sessions.value.filter((s) => s.id !== id);
     if (activeId.value === id) {
@@ -857,7 +890,7 @@
         open: false,
       });
     }
-    saveSessions();
+    scheduleSave(); // 流式创建,高频 → 防抖合并(MYS-635 P1-4)
     scrollToBottom();
   }
 
@@ -894,7 +927,7 @@
       if (last && last.role === 'assistant' && last.kind === 'thought')
         last.content = accumulate(last.content, content);
     }
-    saveSessions();
+    scheduleSave(); // 每个流式 chunk 高频 → 防抖合并,一轮只写一次 localStorage (MYS-635 P1-4)
     scrollToBottom();
   }
 
@@ -1074,10 +1107,12 @@
         autoApprove: typeof ss.autoApprove === 'boolean' ? ss.autoApprove : existing ? !!existing.autoApprove : false,
       };
     });
-    // 保留本地尚未同步到服务端的会话
+    // 保留本地尚未同步到服务端的会话——仅未绑定(serverBound=false)的本地临时新会话。
+    // 已绑定且服务端不存在的本地会话视为「已被删除(另一标签页/清库)」,同步移除,
+    // 避免「删了又复活」与长期幽灵会话(MYS-635 P1-3)。
     const storedIds = new Set(stored.map((s) => s.id));
     sessions.value.forEach((s) => {
-      if (!storedIds.has(s.id)) stored.push(s);
+      if (!storedIds.has(s.id) && !s.serverBound) stored.push(s);
     });
     sessions.value = stored;
     if (!sessions.value.some((s) => s.id === activeId.value)) {
@@ -1365,6 +1400,7 @@
       configRetryTimer = null;
     }
     if (renderTimer) clearTimeout(renderTimer);
+    flushScheduleSave(); // 冲刷防抖缓冲,退出页面前最后落盘一次 (MYS-635 P1-4)
     if (ws) ws.close();
   });
 </script>


### PR DESCRIPTION
## Summary

MYS-629 review 的剩余 P1 项(第一批 P0-1/P0-2/P1-1/P1-2 见依赖的 PR #135)。**本 PR 为 stacked PR,base 指向 PR #135 的分支;PR #135 合入 main 后需改 base 为 main。**

- **P1-3 未知会话静默新建 + 删除会话断线复活**：服务端本连接已绑定会话却收到未知 `wid`(另一标签页已删/清库)→ 回 `session_not_found`,不再静默新建(防「已发送没回」+ 幽灵「新会话」),全新连接首消息仍照常新建(向后兼容);前端 `session.delete` 加 `queued:true` 断线入队重连 flush,`handleSessionList` 移除服务端已不存在的已绑定本地会话(防「删了又复活」)。
- **P1-4 长会话全量传输 + 每 chunk 全量写 localStorage**：服务端 `session.history` 支持 `limit`/`before` 分页(最近 N 条 + `hasMore`,`before`=跳过尾部 N 条向前翻),不带参数保持全量(向后兼容);前端 `saveSessions` 500ms 防抖合并流式高频写、localStorage 配额超限不再静默吞掉(提示一次)、卸载时冲刷防抖缓冲。

## 测试

- 服务端：`go test ./mvc/agentproxy/...` 全绿,新增 `TestWSMessageSendUnknownWidOnBoundConn`、`TestWSHistoryPagination`(含向后兼容无参全量)
- 前端：`vue-tsc` src 无错、`vite build` 成功
- SE7 真机已部署验证:未知会话 `session_not_found`、history limit=5 截断 + hasMore=true

## 非目标

P2 各项(双标签页广播、promptTimeout watchdog、apiConfig 校验、respondPermission 断线留卡、updates 通道丢 chunk 计数)后续评估。