### PR TITLE
fix(psoph_phytool): 硬件探测改用用户指定 device/phy_addr + CV84X2 适配说明

### DIFF
--- a/source/psoph_phytool/readme.md
+++ b/source/psoph_phytool/readme.md
@@ -28,3 +28,26 @@ linaro@bm1684:~$ ./sophon_phytool.sh write RTL eth1 0x0 0xd08 0x15 0x19
 [info]: ic page reg: 0x1f
 [info]: eth1: page: 0xd08, reg addr: 0x15, write data: 0x19
 ```
+
+## CV84X2/CV84X6 适用说明
+
+CV84X2（CV84X6）EVB 板载双 Realtek RTL8211F PHY，PHY ID 为 `0x001cc916`，属于脚本 RTL 分支支持范围，无需新增 PHY 分支。真机（EVB，内核 5.10）实测信息：
+
+| 网口 | PHY 型号 | phy_addr | page_reg |
+|---|---|---|---|
+| eth0 | RTL8211F | 0x0 | 0x1f |
+| eth1 | RTL8211F | 0x0 | 0x1f |
+
+CV84X2 上读取示例（已在 EVB 真机验证，含扩展 page 切换）：
+``` bash
+linaro@sophon:~$ ./sophon_phytool.sh read RTL eth0 0x0 0xd08 0x15
+[info]: ic page reg: 0x1f
+[info]: PHY chip ID: 0x001cc916
+[info]: eth0: page is 0xd08 , reg addr is 0x15, reg value is 0x0019
+```
+
+注意事项：
+
+* 硬件探测读取的是用户参数指定的 `<device>/<phy_addr>` 的 PHY ID（历史版本固定读 eth1，多网口且 PHY 型号不一致时会误显示所操作网口的型号）
+* `read` 操作内部会对 page 选择寄存器（RTL 为 reg 0x1f）执行「切换 page → 读寄存器 → 恢复 page 0」，属读流程的正常行为
+* `write` 操作会直接改写 PHY 寄存器，可能导致网口失联，请在明确风险并确认参数无误后再执行

--- a/source/psoph_phytool/sophon_phytool.sh
+++ b/source/psoph_phytool/sophon_phytool.sh
@@ -51,17 +51,23 @@ case "$ic_name" in
         ;;
 esac
 
-# 硬件探测（参数校验通过后进行）
-reg1=$(sudo phytool read eth1/0/0x02)  # PHY ID1
-reg2=$(sudo phytool read eth1/0/0x03)  # PHY ID2
+# 硬件探测（参数校验通过后进行，按用户指定的 device/phy_addr 读取 PHY ID，不再固定读 eth1）
+reg1=$(sudo phytool read ${device}/${phy_addr}/0x02 2>/dev/null)  # PHY ID1
+reg2=$(sudo phytool read ${device}/${phy_addr}/0x03 2>/dev/null)  # PHY ID2
 
-reg1_dec=$((reg1))
-reg2_dec=$((reg2))
+if [ -n "$reg1" ] && [ -n "$reg2" ]; then
+    reg1_dec=$((reg1))
+    reg2_dec=$((reg2))
 
-combined_dec=$(( (reg1_dec << 16) | reg2_dec ))
-combined_hex=$(printf "0x%08x" $combined_dec)
+    combined_dec=$(( (reg1_dec << 16) | reg2_dec ))
+    combined_hex=$(printf "0x%08x" $combined_dec)
 
-echo "[info]: PHY chip ID: $combined_hex"
+    echo "[info]: PHY chip ID: $combined_hex"
+else
+    echo "[Warning]: read PHY ID failed on ${device}/${phy_addr}, device or phy_addr may be wrong."
+    echo "[Warning]: you can run 'sudo phytool read ${device}/${phy_addr}/0x02' to check the real error."
+    exit 1
+fi
 
 function read_phy_reg() {
 	device=$1


### PR DESCRIPTION
Closes MYS-742

## 背景

CV84X2（CV84X6）EVB 上验证 psoph_phytool 兼容性。

## 真机结论（CV84X2 EVB，linaro@10.42.0.123，内核 5.10）

- 板载双 Realtek **RTL8211F**（eth0/eth1，PHY ID `0x001cc916`，phy_addr `0x0`），**RTL 分支直接适用**，无需新增 PHY 分支
- read 路径真机验证通过：page0 读（BMCR / PHY ID）与扩展 page 切换读（`0xd08/0x15`、`0xa43/0x10`）均正常，读后 page 恢复 0，eth0 链路 1000Mb/s 不受影响
- write 路径未执行（破坏性操作），仅代码审查级验证

## 改动

1. **`sophon_phytool.sh`**：硬件探测原本固定读 `eth1/0` 的 PHY ID —— 多网口且 PHY 型号不一致时报错型号，无 eth1 的板子直接探测失败（且失败时静默输出 `0x00000000`）。改为读用户参数指定的 `<device>/<phy_addr>`，失败时输出明确告警
2. **`readme.md`**：新增 CV84X2/CV84X6 适用章节（PHY 型号/地址表、真机验证示例、read 内部 page 切换说明、write 风险提示）

## 验证

- [x] `bash -n` 语法检查
- [x] 修改前脚本真机 read 验证（page0 + 扩展 page）
- [x] 修改后脚本真机复验（正常读 ×2、非法 device 告警路径、参数不足 usage 路径，rc 均符合预期）
- [x] 操作前后 `ethtool eth0` 链路状态复查正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)