### PR TITLE
fix(memory_edit): CV84X2 真机 dts 名自动检测回退 + pqt_memory_edit CV84X2 适配文档 (MYS-745)

### DIFF
--- a/source/pmemory_edit/readme.md
+++ b/source/pmemory_edit/readme.md
@@ -49,6 +49,17 @@ for bm1688, please use "memory_edit.sh -c -npu 2048 -vpu 0 -vpp 2048"
 3. 将新生成的itb文件cp到/boot目录下替换同名文件，然后执行sync并重启
 4. 修改完成
 
+### CV84X2（CV84X6）说明
+
+CV84X2 与 bm1688 同用 `/boot/boot.itb`，脚本按 multi.its 中的 dts 节点名自动识别
+cv84x6（板名含 cv84x6 前缀）。与 bm1688 的差异：
+
+- CV84X2 的 boot1 分区（/dev/mmcblk0boot1 offset160）**不存放板名**，multi.its 仅含
+  一个 fdt 节点时自动回退采用该节点（v2.12.1 起）；
+- vpu 不可配置，仅 npu/vpp（用法同 bm1688：`-c -npu 2048 -vpu 0 -vpp 2048`）；
+- 32GB 单条内存基址 0x10_00000000，ion 区域 ddr 索引固定 0x10；
+- vpp 顶部 2MB 为 FREERTOS 预留，vpp 校验上限 8GB。
+
 ### 设备树文件二次修改说明
 
 0. 获取memory_edit [https://github.com/sophgo/sophon-tools/releases](https://github.com/sophgo/sophon-tools/releases)

--- a/source/pmemory_edit/release.sh
+++ b/source/pmemory_edit/release.sh
@@ -4,7 +4,7 @@
 #   ARCH:    arm64（唯一支持平台）。bintools（cpio/dtc/dumpimage/file/mkimage）
 #            为 aarch64 预编译二进制，无 x86_64 版本，故本包仅产出 arm64 deb。
 #            传 amd64 会报错退出，避免与 arm64 产物混淆。
-#   VERSION: 显式版本号（默认从 source/memory_edit/memory_edit.sh 提取 2.12）
+#   VERSION: 显式版本号（默认从 source/memory_edit/memory_edit.sh 提取 2.12.1）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pmemory_edit/）
 set -uo pipefail
 

--- a/source/pmemory_edit/source/memory_edit/memory_edit.sh
+++ b/source/pmemory_edit/source/memory_edit/memory_edit.sh
@@ -313,7 +313,7 @@ ddr1_size=0
 ddr2_size=0
 ddr3_size=0
 ddr4_size=0
-echo "INFO: version: 2.12"
+echo "INFO: version: 2.12.1"
 if ( [ $# -eq 1 ] || [ $# -eq 2 ] ) && [ "$1" == "-p" ]; then
 	# 仅打印信息
 	print_info=1
@@ -380,7 +380,17 @@ else
 		# dts_file_name="athena2_wevb_1686a_emmc.dts"
 		sudo dd if=/dev/mmcblk0boot1 of=${memory_edit_PWD}/bm1688_dts_name.log count=32 bs=1 skip=160 2> /dev/null
 		dts_file_name=$(tr -d '\0' < ${memory_edit_PWD}/bm1688_dts_name.log)
-		get_dts_node_info ${memory_edit_PWD}/multi.its "${dts_file_name} " "fdt =" >> $log_file_path; fdt_node_name=$(echo "$get_dts_node_info_data" | awk -F'"' '{print $2}')
+		if [[ "$dts_file_name" != "" ]]; then
+			get_dts_node_info ${memory_edit_PWD}/multi.its "${dts_file_name} " "fdt =" >> $log_file_path; fdt_node_name=$(echo "$get_dts_node_info_data" | awk -F'"' '{print $2}')
+		fi
+		if [[ "$fdt_node_name" == "" ]]; then
+			# CV84X2 的 boot1 分区 offset160 处不存放板名（bm1688 存放），按板名查找失效；
+			# 回退：multi.its 仅含一个 fdt 配置节点时直接采用该节点
+			if [[ "$(grep -c "fdt = " ${memory_edit_PWD}/multi.its)" == "1" ]]; then
+				fdt_node_name=$(grep "fdt = " ${memory_edit_PWD}/multi.its | awk -F'"' '{print $2}')
+				echo "Info: no board name in boot1, use the only fdt node: $fdt_node_name" | tee -a $log_file_path
+			fi
+		fi
 		get_dts_node_info ${memory_edit_PWD}/multi.its "${fdt_node_name} " "data =" >> $log_file_path; dts_file_name=$(echo "$get_dts_node_info_data" | awk -F'"' '{print $2}' | awk -F'/' '{print $2}')
 	fi
 	fi

--- a/source/pqt_memory_edit/CMakeLists.txt
+++ b/source/pqt_memory_edit/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 # edit by user
 # 允许构建时用 -DMY_PROJECT_VERSION=... 覆盖默认版本（linux_release.sh/release.sh 透传）
 if(NOT DEFINED MY_PROJECT_VERSION)
-  set(MY_PROJECT_VERSION "V2.12.1")
+  set(MY_PROJECT_VERSION "V2.12.2")
 endif()
 configure_file(
   "${CMAKE_SOURCE_DIR}/version.h.in"

--- a/source/pqt_memory_edit/README.md
+++ b/source/pqt_memory_edit/README.md
@@ -14,6 +14,31 @@ openssl在windows中使用opensslv3，在linux中使用opensslv1.1.1(ubuntu18)
 
 需要将最新版本的memory_edit.tar.xz文件cp到当前目录
 
+> 统一构建入口 `docker/pqt/build-pqt.sh --project pqt_memory_edit --linux` 会自动执行
+> `source/pmemory_edit/release.sh` 生成并复制该文件，无需手动操作。
+
+## CV84X2（CV84X6）使用说明
+
+工具本身（Qt + libssh2）不含芯片判断，芯片识别由内嵌的 memory_edit 后端完成；
+CV84X2/CV84X6 支持自 memory_edit v2.12.1 起完整可用（dts 名自动识别 cv84x6：
+boot 文件为 boot.itb 时按 dts 节点名区分 bm1688/cv84x6；CV84X2 的 boot1 分区
+不存放板名，multi.its 仅含一个 fdt 节点时自动回退采用该节点）。
+
+真机（CV84X2 EVB，Ubuntu 22.04，32GB DDR）实测行为：
+
+- **获取信息（读路径，只读安全）**：走 NPU+VPP 合并模式——VPU 输入框锁定为 0，
+  NPU 与 VPP 输入框联动约束（NPU+VPP 合计 ≤ 30376 MiB），VPP 单独上限 8192 MiB；
+  当前值 NPU 24320 MiB / VPP 4094 MiB，过程文件（含重新打包的 boot.itb）回传为
+  `memory_edit_p_<ip>_<port>_<时间戳>.tgz`。
+- **进行配置 / 批量配置（写路径）**：后端按 cv84x6 规则校验（vpp 顶部避开 2MB
+  FREERTOS 预留、ddr 索引 0x10 即基址 0x10_00000000、vpp 上限 8GB），修改后写
+  `/boot/boot.itb`（自动备份为 `boot.itb.memeditBak`），重启生效。**修改内存布局
+  属高风险操作，务必先确认获取信息显示的数值合理再执行。**
+
+批量配置预设（`batchConf/`）中的 inSE6conf.json / outSE6conf.json 仅为 SE6 集群
+示例设备清单，与本机芯片无关；CV84X2 设备直接在表格/JSON 中按
+`IP/Port/Username/Password` 填写即可。
+
 ## linux中编译方式
 
 ### 实机编译


### PR DESCRIPTION
## 背景

MYS-745：pqt_memory_edit（PC 端远程内存修改工具）CV84X2 兼容 + 真机只读验证。后端 memory_edit 的 cv84x6 适配（PR #58）此前无真机，本次首跑即发现问题并修复。

## 改动

### 1. memory_edit.sh 修复 dts 名自动检测（2.12 → 2.12.1）

**真机现象**（CV84X2 EVB，10.42.0.123）：`./memory_edit.sh -p` 报 `Error: cannot find used dts file on bm1688`。

**根因**（两层）：
- CV84X2 的 boot1 分区（`/dev/mmcblk0boot1` offset 160）**不存放板名**（bm1688 存放），读出的 `dts_file_name` 为空；
- 板名为空时 `get_dts_node_info` 的起始匹配模式退化为单个空格 `" "`，**所有行**（包括目标 `fdt = ...` 行本身）都被第一分支命中，`elif` 永远不会执行——后续按 fdt 节点找 data 的查找也一并失效，最终 `dts_file_name` 为空报错。

**修复**：板名为空（或按名查找失败）时，若 multi.its 仅含一个 `fdt = ` 配置节点则直接采用该节点（CV84X2 EVB 的 multi.its 只有一个 fdt：`fdt-cv84x6_wevb_emmc`）。bm1688 既有路径不变。

### 2. pqt_memory_edit V2.12.1 → V2.12.2

- 重编 AppImage 内嵌修复版后端（构建由 `docker/pqt/build-pqt.sh` 自动生成 memory_edit.tar.xz）
- README 补 CV84X2 使用说明（npu+vpp 合并模式实测数值、写路径风险提示、batchConf 预设与芯片无关）
- pmemory_edit readme 同步补 CV84X2 差异说明（boot1 无板名回退、vpu 不可配、ddr 索引 0x10、vpp 8GB 上限）

## 真机验证（读路径，GUI 端到端）

AppImage（V2.12.2）在 Xvfb 下以 GUI 实际点击「获取信息」，对 linaro@10.42.0.123 完整走通 comP 链路（SFTP 上传后端 → 解压 → `sudo ./memory_edit.sh -p` → 结果解析回显 → 过程文件 tgz 回传）：

```
Info: no board name in boot1, use the only fdt node: fdt-cv84x6_wevb_emmc
Info: ddr_size 32768 MiB
Info: max npu+vpp size: 0x76a800000 [30376 MiB]
Info: max vpp size: 0x200000000 [8192 MiB]
Info: now npu size: 0x5f0000000 [24320 MiB]
Info: now vpp size: 0xffe00000 [4094 MiB]
```

GUI 正确进入 npu+vpp 合并模式（VPU 锁 0，NPU/VPP 联动上限 30376 MiB），过程文件 `memory_edit_p_10.42.0.123_22_*.tgz`（14M）正常回传。

**写路径（进行配置/批量配置）未在真机执行**（修改 /boot/boot.itb 属高风险操作，需另行许可）；已做代码审查级确认：cv84x6 校验链（vpp 顶部避开 2MB FREERTOS、vpp 上限 8GB、npu+vpp ≤ ddr_size）、ddr 索引 0x10、tpu 3-phandle 容忍、`/boot/boot.itb.memeditBak` 自动备份，逻辑与 PR #58 设计一致。

## 测试

- [x] `bash -n memory_edit.sh` 语法检查
- [x] AppImage 构建（25341 KiB）+ 启动冒烟（V2.12.2 标题正常）
- [x] 真机 GUI 读路径端到端（如上）
- [x] 真机 `-p` 自动检测（不带 dts 名参数）修复后通过
- [ ] 写路径真机执行（待许可）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
