### PR TITLE
feat(bmssm): SE13/CV84X2 命名链与全模块适配（MYS-753）

### DIFF
--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # bmssm .deb 打包：交叉编译 arm64 静态二进制 + 组装 deb 数据树 + dpkg-deb。
 # 用法: bash build/build-deb-bmssm.sh [VERSION] [ARCH] [REASONIX_BIN]
-#   VERSION      默认 2.3.0（与 build/version.sh 一致）
+#   VERSION      默认 2.3.1（与 build/version.sh 一致）
 #   ARCH         默认 arm64（设备）；amd64 用于 PCIE/开发机
 #   REASONIX_BIN 可选：reasonix arm64 二进制路径。提供则把 Reasonix 一并嵌入 deb，
 #               安装到 /opt/sophon/reasonix/bin/reasonix，并在 bmssm.yaml 里把
@@ -16,7 +16,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
-VERSION="${1:-2.3.0}"
+VERSION="${1:-2.3.1}"
 VERSION="${VERSION//\//-}"
 ARCH="${2:-arm64}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # 生成版本头信息，写入 build/version.txt 供 ldflags 读取
 set -e
-VERSION="${1:-2.3.0}"
+VERSION="${1:-2.3.1}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"
 cat > "$(dirname "$0")/version.txt" <<EOF

--- a/source/pbmssm/pkg/device/devinfo.go
+++ b/source/pbmssm/pkg/device/devinfo.go
@@ -32,6 +32,23 @@ const (
 	CTRLShell2    = "/root/se_ctrl/sectr.sh"
 )
 
+// CV84X2 产品命名（一处定义，sophliteos 前端透传消费，不重复造映射）。
+// CV84X2 与 CV84X6 是同一芯片的不同称呼：SDK/内核侧标识为 cv84x6，
+// 对外产品命名（芯片名称/设备型号）统一显示 CV84X2 / SE13。
+const (
+	CpuModelCv84x6  = "cv84x6" // SDK 标识（/proc/cpuinfo model name，经 CPU part 0xd05 修正）
+	ChipNameCv84x2  = "CV84X2" // 芯片对外显示名（cv84x6 → CV84X2）
+	DeviceModelSE13 = "SE13"   // CV84X2 单板默认设备型号
+)
+
+// boot1 OEM 区布局（对齐 pget_info get_info.sh cv 家族 DEVICE_MODEL 读取）。
+const (
+	Boot1ProductOffset = 208 // 0xD0：OEM PRODUCT，16 字节
+	Boot1ProductLen    = 16
+	Boot1ModuleOffset  = 112 // 0x70：OEM MODULE_TYPE，16 字节
+	Boot1ModuleLen     = 16
+)
+
 // 进程级状态（与 global 同步：GetDeviceInfo 会回写 global，见 initialization）。
 var (
 	DeviceType   string
@@ -157,23 +174,15 @@ func readSnFromRawWithPaths(cpuinfo, boot1, nvmem string) {
 	}
 }
 
-// ReadCpuModel 从 /proc/cpuinfo 读 "model name" 字段（小写），对齐 get_info.sh CPU_MODEL。
+// ReadCpuModel 从 /proc/cpuinfo 读芯片型号（小写），对齐 get_info.sh CPU_MODEL。
+// 经 system.DetectCpuModel 两级识别：CPU part 0xd05（Cortex-A55，仅 CV84X2/CV84X6）
+// 优先于 model name（CV84X2 上 model name 可能误报 bm1688/cv186ah），dts compatible 兜底。
 func ReadCpuModel(path string) string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "model name") {
-			eq := strings.Index(line, ":")
-			if eq < 0 {
-				continue
-			}
-			return strings.ToLower(strings.TrimSpace(line[eq+1:]))
-		}
-	}
-	return ""
+	return system.DetectCpuModel(string(data), system.DeviceTreeRoot)
 }
 
 // readSnFromMmcblkBoot1 从 /dev/mmcblk0boot1 读 CHIP_SN(offset 0) 和 DEVICE_SN(offset 32)，
@@ -219,6 +228,8 @@ func GetDeviceInfo() {
 }
 
 // getDeviceInfo 接受路径参数，供测试注入临时路径。
+// 推断链（高 → 低）：I2C JSON model → OEMconfig PRODUCT → CV84X2 兜底
+// （boot1 OEM 0xD0 PRODUCT → 默认 SE13）。
 func getDeviceInfo(i2cPath, oemPath, boardIPPath string) {
 	// 清旧值，避免二次调用（重检测/测试）时上一分支残留污染本次结果
 	DeviceType = UNKNOWN_DEV
@@ -229,6 +240,15 @@ func getDeviceInfo(i2cPath, oemPath, boardIPPath string) {
 	ModuleType = ""
 	ModuleTypeEx = ""
 
+	detectFromI2COrOEM(i2cPath, oemPath, boardIPPath)
+
+	// CV84X2（cv84x6）兜底：SE13 等 cv 家族新平台 I2C/OEM 均未烧写时，
+	// 按 CPU 识别补默认型号/角色/芯片名（有明确 product 信息时不覆盖）。
+	applyCv84x6Fallback(CpuInfoPath, Mmcblk0Boot1Path)
+}
+
+// detectFromI2COrOEM 原有 I2C → OEMconfig.ini → SE6 控制器裸板三段探测。
+func detectFromI2COrOEM(i2cPath, oemPath, boardIPPath string) {
 	// 1) I2C device information 优先（与 bmssm 顺序一致）
 	if ok, _ := system.PathExists(i2cPath); ok {
 		DeviceType = SOC_DEV
@@ -258,6 +278,53 @@ func getDeviceInfo(i2cPath, oemPath, boardIPPath string) {
 		DeviceRole = SE6_CTRL
 		DeviceTypeEx = "SE8"
 	}
+}
+
+// applyCv84x6Fallback CV84X2（cv84x6）兜底：仅在设备侧无更高优先级信息时补默认值，
+// 有明确 product 信息（I2C model / OEM PRODUCT / boot1 0xD0）时以设备侧为准。
+//
+//	DeviceTypeEx：boot1 OEM 0xD0 PRODUCT，未烧写则默认 SE13
+//	ModuleTypeEx：boot1 OEM 0x70 MODULE_TYPE（未烧写留空）
+//	ModuleType：芯片显示名 CV84X2（供 health 展示与 ChipCapacity 查算力）
+//	DeviceType/DeviceRole：SOC / SE5（SE13 为单板）
+//	SN：boot1 offset 0/32（与 get_info.sh cv 家族 SN 布局一致）
+func applyCv84x6Fallback(cpuinfo, boot1 string) {
+	if ReadCpuModel(cpuinfo) != CpuModelCv84x6 {
+		return
+	}
+	if DeviceType != SOC_DEV {
+		DeviceType = SOC_DEV
+	}
+	if DeviceRole == "" {
+		DeviceRole = SE5
+	}
+	if DeviceTypeEx == "" {
+		DeviceTypeEx = readFixedStringAt(boot1, Boot1ProductOffset, Boot1ProductLen)
+		if DeviceTypeEx == "" {
+			DeviceTypeEx = DeviceModelSE13
+		}
+	}
+	if ModuleTypeEx == "" {
+		if m := readFixedStringAt(boot1, Boot1ModuleOffset, Boot1ModuleLen); m != "" {
+			ModuleTypeEx = m
+		}
+	}
+	if ModuleType == "" {
+		ModuleType = ChipNameCv84x2
+	}
+	if ChipSn == "" || DeviceSnEx == "" {
+		readSnFromRawWithPaths(cpuinfo, boot1, NvmemSnPath)
+	}
+}
+
+// readFixedStringAt 打开 path，在 offset 处读 n 字节，去掉 \0 与首尾空白。
+func readFixedStringAt(path string, offset int64, n int) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	return readFixedString(f, offset, n)
 }
 
 // loadFromI2C 读取 i2c information（JSON），按 model 推断角色，并提取 chip/product sn。

--- a/source/pbmssm/pkg/device/devinfo_test.go
+++ b/source/pbmssm/pkg/device/devinfo_test.go
@@ -374,6 +374,7 @@ func resetGlobals() {
 	DeviceSnEx = ""
 	ChipSn = ""
 	ModuleType = ""
+	ModuleTypeEx = ""
 }
 
 // TestParseOEMConfigSE9Format SE9 用 SN + DEVICE_SN 独立键（非两条 SN 行）。
@@ -474,5 +475,149 @@ func TestReadSnFromRawCv84x6(t *testing.T) {
 	}
 	if DeviceSnEx != "CV84X6DEVSN001" {
 		t.Errorf("DeviceSnEx=%q, want CV84X6DEVSN001", DeviceSnEx)
+	}
+}
+
+// TestReadCpuModelPartD05 真机场景：CV84X2 上 model name 误报 bm1688，
+// 但 CPU part 0xd05（Cortex-A55，仅 CV84X2/CV84X6）是硬件直读、可靠。
+// ReadCpuModel 应返回 cv84x6（对齐 get_info.sh CPU part 两级识别）。
+func TestReadCpuModelPartD05(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "cpuinfo")
+	content := `processor : 0
+model name : bm1688
+CPU part : 0xd05
+`
+	if err := os.WriteFile(f, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if got := ReadCpuModel(f); got != "cv84x6" {
+		t.Errorf("cpuModel=%q, want cv84x6 (part 0xd05 优先于 model name)", got)
+	}
+}
+
+// writeBoot1Fixture 生成 256 字节 boot1 夹具：offset 0/32 为 SN，
+// 0xD0(208) 为 PRODUCT，0x70(112) 为 MODULE_TYPE（各 16 字节，NUL 填充）。
+func writeBoot1Fixture(t *testing.T, chipSn, deviceSn, product, moduleType string) string {
+	t.Helper()
+	buf := make([]byte, 256)
+	copy(buf[0:], chipSn)
+	copy(buf[32:], deviceSn)
+	copy(buf[Boot1ProductOffset:], product)
+	copy(buf[Boot1ModuleOffset:], moduleType)
+	p := filepath.Join(t.TempDir(), "boot1")
+	if err := os.WriteFile(p, buf, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// writeCpuinfoFixture 生成 cpuinfo 夹具。part 传空则不含 CPU part 行。
+func writeCpuinfoFixture(t *testing.T, modelName, part string) string {
+	t.Helper()
+	content := "processor : 0\nmodel name : " + modelName + "\n"
+	if part != "" {
+		content += "CPU part : " + part + "\n"
+	}
+	p := filepath.Join(t.TempDir(), "cpuinfo")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestApplyCv84x6FallbackSE13Default SE13 真机场景：I2C 无、OEM 全空、
+// boot1 OEM 区未烧写（全 0）→ 兜底默认 SE13 / 芯片名 CV84X2 / SOC 单板角色。
+func TestApplyCv84x6FallbackSE13Default(t *testing.T) {
+	cpuinfo := writeCpuinfoFixture(t, "bm1688", "0xd05")
+	boot1 := writeBoot1Fixture(t, "", "", "", "")
+
+	resetGlobals()
+	applyCv84x6Fallback(cpuinfo, boot1)
+
+	if DeviceType != SOC_DEV {
+		t.Errorf("DeviceType=%q, want soc", DeviceType)
+	}
+	if DeviceRole != SE5 {
+		t.Errorf("DeviceRole=%q, want SE", DeviceRole)
+	}
+	if DeviceTypeEx != "SE13" {
+		t.Errorf("DeviceTypeEx=%q, want SE13", DeviceTypeEx)
+	}
+	if ModuleType != "CV84X2" {
+		t.Errorf("ModuleType=%q, want CV84X2", ModuleType)
+	}
+	if ModuleTypeEx != "" {
+		t.Errorf("ModuleTypeEx=%q, want empty (boot1 OEM 未烧写)", ModuleTypeEx)
+	}
+}
+
+// TestApplyCv84x6FallbackBoot1OEM boot1 OEM 区已烧写：0xD0 PRODUCT 与
+// 0x70 MODULE_TYPE 生效（对齐 get_info.sh cv 家族 DEVICE_MODEL 读取），SN 同步读取。
+func TestApplyCv84x6FallbackBoot1OEM(t *testing.T) {
+	cpuinfo := writeCpuinfoFixture(t, "bm1688", "0xd05")
+	boot1 := writeBoot1Fixture(t, "CVCHIPSN0001", "CVDEVSN0001", "SE9", "16-BP1-11")
+
+	resetGlobals()
+	applyCv84x6Fallback(cpuinfo, boot1)
+
+	if DeviceTypeEx != "SE9" {
+		t.Errorf("DeviceTypeEx=%q, want SE9 (boot1 0xD0 PRODUCT)", DeviceTypeEx)
+	}
+	if ModuleTypeEx != "16-BP1-11" {
+		t.Errorf("ModuleTypeEx=%q, want 16-BP1-11 (boot1 0x70)", ModuleTypeEx)
+	}
+	if ChipSn != "CVCHIPSN0001" {
+		t.Errorf("ChipSn=%q, want CVCHIPSN0001 (boot1 offset 0)", ChipSn)
+	}
+	if DeviceSnEx != "CVDEVSN0001" {
+		t.Errorf("DeviceSnEx=%q, want CVDEVSN0001 (boot1 offset 32)", DeviceSnEx)
+	}
+}
+
+// TestApplyCv84x6FallbackKeepsHigherSource 有更高优先级信息（I2C model /
+// OEM PRODUCT 已填 DeviceTypeEx，OEM CHIP 已填 ModuleType）时不覆盖——
+// "有明确 product 信息时以设备侧为准"。
+func TestApplyCv84x6FallbackKeepsHigherSource(t *testing.T) {
+	cpuinfo := writeCpuinfoFixture(t, "bm1688", "0xd05")
+	boot1 := writeBoot1Fixture(t, "", "", "SE7 V1", "XX-MODULE")
+
+	resetGlobals()
+	DeviceType = SOC_DEV
+	DeviceRole = SE5
+	DeviceTypeEx = "SE7 V1"
+	ModuleType = "BM1684X"
+	applyCv84x6Fallback(cpuinfo, boot1)
+
+	if DeviceTypeEx != "SE7 V1" {
+		t.Errorf("DeviceTypeEx=%q, want SE7 V1 (设备侧信息优先)", DeviceTypeEx)
+	}
+	if ModuleType != "BM1684X" {
+		t.Errorf("ModuleType=%q, want BM1684X (设备侧信息优先)", ModuleType)
+	}
+	// ModuleTypeEx 在 i2c/OEM 链路中本就为空（无更高优先级来源），boot1 0x70 兜底补上
+	if ModuleTypeEx != "XX-MODULE" {
+		t.Errorf("ModuleTypeEx=%q, want XX-MODULE (boot1 0x70 兜底)", ModuleTypeEx)
+	}
+}
+
+// TestApplyCv84x6FallbackNonCv84x6 非 cv84x6 芯片（如 bm1684x，part 0xd03）
+// 不触发兜底：无 i2c/OEM 时维持原 PCIE 降级结果。
+func TestApplyCv84x6FallbackNonCv84x6(t *testing.T) {
+	cpuinfo := writeCpuinfoFixture(t, "bm1684x", "0xd03")
+	boot1 := writeBoot1Fixture(t, "", "", "SE9", "16-BP1-11")
+
+	resetGlobals()
+	DeviceType = PCIE_DEV
+	DeviceTypeEx = "PCIE"
+	applyCv84x6Fallback(cpuinfo, boot1)
+
+	if DeviceType != PCIE_DEV {
+		t.Errorf("DeviceType=%q, want pcie (非 cv84x6 不兜底)", DeviceType)
+	}
+	if DeviceTypeEx != "PCIE" {
+		t.Errorf("DeviceTypeEx=%q, want PCIE", DeviceTypeEx)
+	}
+	if ModuleType != "" {
+		t.Errorf("ModuleType=%q, want empty", ModuleType)
 	}
 }

--- a/source/pbmssm/pkg/metrics/chip_capacity.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity.go
@@ -8,7 +8,7 @@ import "strings"
 //
 //	BM1684X (0x1686)      → 32 TOPS, chipType 2
 //	BM1688  (0x1688)      → 16 TOPS, chipType 3
-//	CV84X6  (0x1694)      → 16 TOPS, chipType 3  (占位，对齐 BM1688 档位；真机确认后修正)
+//	CV84X6/CV84X2 (0x1694) → 16 TOPS, chipType 3  (占位，对齐 BM1688 档位；真机确认后修正)
 //	BM1684  (non-X)       → 16 TOPS, chipType 1
 //	unknown / empty       → 16 TOPS, chipType 1  (bmssm default branch)
 //
@@ -16,7 +16,8 @@ import "strings"
 func ChipCapacity(chipModel string) (calcCapacity float64, chipType int) {
 	upper := strings.ToUpper(chipModel)
 	switch {
-	case strings.Contains(upper, "84X6"):
+	case strings.Contains(upper, "84X6"), strings.Contains(upper, "84X2"):
+		// CV84X2 与 CV84X6 为同一芯片的不同称呼，同一档位
 		return 16, 3
 	case strings.Contains(upper, "1686") || strings.Contains(upper, "1684X"):
 		return 32, 2

--- a/source/pbmssm/pkg/metrics/chip_capacity_test.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity_test.go
@@ -87,6 +87,19 @@ func TestChipCapacity(t *testing.T) {
 			wantCalcCapacity: 16,
 			wantChipType:     3,
 		},
+		{
+			// CV84X2 与 CV84X6 为同一芯片的不同称呼（设备侧命名链输出 CV84X2）
+			name:             "CV84X2 (display name)",
+			chipModel:        "CV84X2",
+			wantCalcCapacity: 16,
+			wantChipType:     3,
+		},
+		{
+			name:             "lowercase cv84x2",
+			chipModel:        "cv84x2",
+			wantCalcCapacity: 16,
+			wantChipType:     3,
+		},
 	}
 
 	for _, tt := range tests {

--- a/source/pbmssm/pkg/metrics/cpu.go
+++ b/source/pbmssm/pkg/metrics/cpu.go
@@ -29,7 +29,8 @@ func (c *Collector) CPUInfo() CPU {
 	content := c.readStr(cpuInfoPath)
 	if content != "" {
 		cpu.Cores = countCores(content)
-		cpu.Type = modelLine(content)
+		// 经 CPU part 0xd05 修正的型号（CV84X2 上 model name 可能误报 bm1688）
+		cpu.Type = c.cpuModel()
 	}
 	cpu.Frequency = c.cpuFrequency()
 	cpu.UtilizationRate = c.cpuUtilization()

--- a/source/pbmssm/pkg/metrics/ion_memory.go
+++ b/source/pbmssm/pkg/metrics/ion_memory.go
@@ -3,6 +3,8 @@ package metrics
 import (
 	"strconv"
 	"strings"
+
+	"bmssm/pkg/system"
 )
 
 // ion heap sumary 路径（按芯片类型）。
@@ -14,14 +16,12 @@ const (
 	ionVppHeapV2 = "/sys/kernel/debug/ion/cvi_vpp_heap_dump/summary"
 )
 
-// ChipType 读取 /proc/cpuinfo 的 model name，返回小写芯片型号。
+// ChipType 读取 /proc/cpuinfo，返回小写芯片型号。
 // "bm1684x", "bm1684", "bm1688", "cv186ah", "cv84x6"，失败返空串。
+// 经 system.DetectCpuModel 两级识别：CPU part 0xd05 优先于 model name
+// （CV84X2 上 model name 可能误报 bm1688/cv186ah），dts compatible 兜底。
 func (c *Collector) ChipType() string {
-	content := c.readStr(cpuInfoPath)
-	if content == "" {
-		return ""
-	}
-	s := strings.ToLower(modelLine(content))
+	s := c.cpuModel()
 	switch {
 	case strings.Contains(s, "bm1684x"):
 		return "bm1684x"
@@ -36,6 +36,15 @@ func (c *Collector) ChipType() string {
 	default:
 		return ""
 	}
+}
+
+// cpuModel 返回规范化芯片型号（小写，经 CPU part/dts 两级识别）。
+func (c *Collector) cpuModel() string {
+	content := c.readStr(cpuInfoPath)
+	if content == "" {
+		return ""
+	}
+	return system.DetectCpuModel(content, system.DeviceTreeRoot)
 }
 
 // chipFamily 归一化芯片家族：bm1684（含 bm1684x）/ cv（bm1688、cv186ah、cv84x6）。

--- a/source/pbmssm/pkg/metrics/ion_memory_test.go
+++ b/source/pbmssm/pkg/metrics/ion_memory_test.go
@@ -80,6 +80,36 @@ func TestChipTypeMissing(t *testing.T) {
 	}
 }
 
+// TestChipTypePartD05Override 真机场景：CV84X2 上 model name 误报 bm1688，
+// CPU part 0xd05（Cortex-A55，仅 CV84X2/CV84X6）应把 ChipType 修正为 cv84x6，
+// 使时钟（clk_ap_ca55 等）/ion heap（cvi_）/SDK 版本走 cv84x6 路径。
+func TestChipTypePartD05Override(t *testing.T) {
+	fr := &fakeFileReader{files: map[string]string{
+		"/proc/cpuinfo": "model name	: bm1688\nCPU part	: 0xd05\n",
+	}}
+	c := NewCollector(fr, nil)
+	if got := c.ChipType(); got != "cv84x6" {
+		t.Errorf("ChipType() = %q, want cv84x6 (part 0xd05 优先于误报的 model name)", got)
+	}
+}
+
+// TestChipDisplayName 芯片显示名映射（一处定义）：cv84x6 → CV84X2，
+// 其余芯片大写。空串保持空串（前端显示 '-'）。
+func TestChipDisplayName(t *testing.T) {
+	cases := []struct{ chip, want string }{
+		{"cv84x6", "CV84X2"},
+		{"bm1684x", "BM1684X"},
+		{"bm1688", "BM1688"},
+		{"cv186ah", "CV186AH"},
+		{"", ""},
+	}
+	for _, tt := range cases {
+		if got := ChipDisplayName(tt.chip); got != tt.want {
+			t.Errorf("ChipDisplayName(%q) = %q, want %q", tt.chip, got, tt.want)
+		}
+	}
+}
+
 // realDeviceIonSummary 是真机 BM1684X 上 cat summary 的实际输出格式：
 //
 //	Summary:\n
@@ -222,8 +252,8 @@ func TestMemoryLayoutBM1684X(t *testing.T) {
 	c := NewCollector(fr, nil)
 	lay := c.MemoryLayout()
 
-	if lay.ChipType != "bm1684x" {
-		t.Fatalf("ChipType = %q, want bm1684x", lay.ChipType)
+	if lay.ChipType != "BM1684X" {
+		t.Fatalf("ChipType = %q, want BM1684X (显示名)", lay.ChipType)
 	}
 	// 系统：6277 MB total，used = 6277-5781(available) = 496，使用率 ~7.90%
 	// （buff/cache 可回收不计入，available 口径）
@@ -274,8 +304,8 @@ func TestMemoryLayoutBM1688(t *testing.T) {
 	c := NewCollector(fr, nil)
 	lay := c.MemoryLayout()
 
-	if lay.ChipType != "bm1688" {
-		t.Fatalf("ChipType = %q, want bm1688", lay.ChipType)
+	if lay.ChipType != "BM1688" {
+		t.Fatalf("ChipType = %q, want BM1688 (显示名)", lay.ChipType)
 	}
 	if !approxEqual(lay.TPU.TotalMB, 1536, 0.01) {
 		t.Errorf("TPU.TotalMB = %v, want 1536", lay.TPU.TotalMB)
@@ -288,7 +318,8 @@ func TestMemoryLayoutBM1688(t *testing.T) {
 	}
 }
 
-// TestMemoryLayoutCv84x6 CV84X2 内存布局：cvi_ ion heap + chipType 识别为 cv84x6。
+// TestMemoryLayoutCv84x6 CV84X2 内存布局：cvi_ ion heap + chipType 输出显示名 CV84X2
+// （cv84x6 → CV84X2 映射在 bmssm 一处定义，sophliteos 前端透传显示"芯片名称"）。
 func TestMemoryLayoutCv84x6(t *testing.T) {
 	fr := &fakeFileReader{files: map[string]string{
 		"/proc/cpuinfo": "model name\t: cv84x6\n",
@@ -299,8 +330,8 @@ func TestMemoryLayoutCv84x6(t *testing.T) {
 	c := NewCollector(fr, nil)
 	lay := c.MemoryLayout()
 
-	if lay.ChipType != "cv84x6" {
-		t.Fatalf("ChipType = %q, want cv84x6", lay.ChipType)
+	if lay.ChipType != "CV84X2" {
+		t.Fatalf("ChipType = %q, want CV84X2 (显示名)", lay.ChipType)
 	}
 	if !approxEqual(lay.TPU.TotalMB, 1536, 0.01) {
 		t.Errorf("TPU.TotalMB = %v, want 1536", lay.TPU.TotalMB)

--- a/source/pbmssm/pkg/metrics/memory_layout.go
+++ b/source/pbmssm/pkg/metrics/memory_layout.go
@@ -1,5 +1,18 @@
 package metrics
 
+import "strings"
+
+// ChipDisplayName 芯片对外显示名（SE13/CV84X2 产品命名，一处定义：
+// sophliteos 前端透传 memoryLayout.chipType 显示"芯片名称"，不重复造映射）。
+// cv84x6（SDK/内核标识）对外显示 CV84X2——CV84X2 与 CV84X6 是同一芯片的不同称呼；
+// 其余芯片显示大写型号（bm1684x → BM1684X）。
+func ChipDisplayName(chip string) string {
+	if chip == "cv84x6" {
+		return "CV84X2"
+	}
+	return strings.ToUpper(chip)
+}
+
 // MemoryLayout 返回设备内存布局：系统 + TPU + VPU + VPP 四区域（MB + 使用率 0-100）。
 // 复用 Memory()/TpuMemory/VpuMemory/VppMemory（均经 c.readStr，root 可读 debugfs）。
 // bytes→MB（/1024/1024，与 Memory().Total 的 kB→MB 口径区分：ion heap 原值是字节）。
@@ -14,7 +27,8 @@ func (c *Collector) MemoryLayout() MemoryLayout {
 		sysAvail = sys.Free
 	}
 	layout := MemoryLayout{
-		ChipType: chip,
+		// 对外输出显示名（cv84x6 → CV84X2），前端"芯片名称"透传此值
+		ChipType: ChipDisplayName(chip),
 		System:   memRegionMBFloat(sys.Total, sys.Total-sysAvail),
 	}
 	tpuT, tpuU := c.TpuMemory(chip)

--- a/source/pbmssm/pkg/metrics/os.go
+++ b/source/pbmssm/pkg/metrics/os.go
@@ -104,7 +104,8 @@ var socModels = map[string]bool{
 //	  - PCIE（model name 非 SOC 型号）：/proc/bmsophon/driver_version 冒号第 2 字段再取第 1 词
 //	主分支失败/不命中返空串。
 func (c *Collector) SdkVersion() string {
-	cpu := modelLine(c.readStr(cpuInfoPath))
+	// 经 CPU part 0xd05 修正的型号（CV84X2 上 model name 可能误报 bm1688）
+	cpu := c.cpuModel()
 	kernel := c.kernelVersion()
 
 	if socModels[cpu] {

--- a/source/pbmssm/pkg/ota/dispatch.go
+++ b/source/pbmssm/pkg/ota/dispatch.go
@@ -4,15 +4,17 @@ import "strings"
 
 // productClass 按 Product 名称映射设备模式。
 //
-//	SE5/SE7/SE9（及小写、含后缀如 "SE7 V01"）→ SOC
+//	SE5/SE7/SE9/SE13（及小写、含后缀如 "SE7 V01"）→ SOC
 //	SC5/SC7（及小写、含后缀）            → PCIE
 //	SE6/SE8（及小写、含后缀）             → MultiNode
 //
 // 用前缀匹配而非精确匹配，兼容 global.DeviceTypeEx 形如 "SE7 V01" 的完整型号串。
+// SE13（CV84X2 单板）为 SOC 设备；刷机走通用 pota_update .tgz + ota.sh 流程，
+// 刷机包由 pota_update 侧按芯片打包，bmssm 层芯片无关（真机刷机未在本任务验证）。
 func productClass(product string) ProductClass {
 	p := strings.ToLower(strings.TrimSpace(product))
 	switch {
-	case strings.HasPrefix(p, "se5"), strings.HasPrefix(p, "se7"), strings.HasPrefix(p, "se9"):
+	case strings.HasPrefix(p, "se5"), strings.HasPrefix(p, "se7"), strings.HasPrefix(p, "se9"), strings.HasPrefix(p, "se13"):
 		return ClassSOC
 	case strings.HasPrefix(p, "sc5"), strings.HasPrefix(p, "sc7"):
 		return ClassPCIE

--- a/source/pbmssm/pkg/ota/engine_test.go
+++ b/source/pbmssm/pkg/ota/engine_test.go
@@ -30,6 +30,10 @@ func TestProductClass(t *testing.T) {
 		{"se9 v02", ClassSOC},
 		{"SC5 pro", ClassPCIE},
 		{"se8 v1", ClassMultiNode},
+		// SE13（CV84X2 单板）为 SOC 设备：接口/展示层面归类 SOC，
+		// 刷机走通用 pota_update 流程（真机刷机未验证，不在本任务范围）
+		{"SE13", ClassSOC},
+		{"se13 v1", ClassSOC},
 	}
 	for _, tt := range cases {
 		got := productClass(tt.product)

--- a/source/pbmssm/pkg/system/cpu_model.go
+++ b/source/pbmssm/pkg/system/cpu_model.go
@@ -1,0 +1,116 @@
+// CV84X2（SDK 标识 cv84x6）芯片型号识别，对齐 pget_info get_info.sh 的两级识别。
+package system
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"sync"
+)
+
+// DeviceTreeRoot 设备树根（compatible 扫描用）。
+const DeviceTreeRoot = "/proc/device-tree"
+
+// cv84x6CompatPrefix CV84X2 内核 dts 专属 compatible 前缀
+// （如 cvitek,cv84x6-clk / cvitek,cv84x6-emmc；真实 bm1688/cv186ah 的 dts 不含）。
+const cv84x6CompatPrefix = "cvitek,cv84x6-"
+
+// cortexA55Part CPU part（MIDR）值：Cortex-A55(0xd05) 仅 CV84X2/CV84X6 搭载，
+// 其余 SDK 芯片（bm1684x/bm1684/bm1688/cv186ah）均为 Cortex-A53(0xd03)，天然分开。
+const cortexA55Part = "0xd05"
+
+// dtsScanCache compatible 扫描结果缓存：ChipType 等高频采集路径每次都会调用
+// DetectCpuModel，设备树内容运行期不变，扫描一次后缓存（按 root 记忆化）。
+var (
+	dtsScanMu    sync.Mutex
+	dtsScanCache = map[string]bool{}
+)
+
+// DetectCpuModel 返回规范化芯片型号（小写），两级识别均不依赖 model name 的准确值：
+//
+//  1. 首选 CPU part（MIDR 硬件直读，无条件打印）：Cortex-A55(0xd05) → cv84x6。
+//     model name 在 CV84X2 上不可靠——内核 cpuinfo.c 仅 32-bit compat 模式打印此行，
+//     且取 CHIP_INFO(0x27102014)&0x7 判定，可能输出 null/缺行/cv186ah/bm1688。
+//  2. 兜底 dts 信号：dtsRoot 下任一 compatible 文件含 "cvitek,cv84x6-" → cv84x6。
+//
+// 未命中时返回 model name（小写）；无 model name 返空串。
+func DetectCpuModel(cpuinfoContent, dtsRoot string) string {
+	model := parseModelName(cpuinfoContent)
+	if strings.Contains(strings.ToLower(parseCpuPart(cpuinfoContent)), cortexA55Part) {
+		return "cv84x6"
+	}
+	if model != "cv84x6" && dtsRoot != "" && dtsHasCv84x6Compat(dtsRoot) {
+		return "cv84x6"
+	}
+	return model
+}
+
+// parseModelName 取 cpuinfo "model name" 行的值（小写）。
+func parseModelName(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.HasPrefix(line, "model name") {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx >= 0 {
+			return strings.ToLower(strings.TrimSpace(line[idx+1:]))
+		}
+	}
+	return ""
+}
+
+// parseCpuPart 取 cpuinfo "CPU part" 行的值（如 "0xd05"）。
+func parseCpuPart(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if !strings.HasPrefix(line, "CPU part") {
+			continue
+		}
+		idx := strings.Index(line, ":")
+		if idx >= 0 {
+			return strings.TrimSpace(line[idx+1:])
+		}
+	}
+	return ""
+}
+
+// dtsHasCv84x6Compat 扫描 dtsRoot 下所有 compatible 文件，任一含 cv84x6 前缀即 true。
+// 结果按 dtsRoot 记忆化（设备树运行期不变）。
+func dtsHasCv84x6Compat(dtsRoot string) bool {
+	dtsScanMu.Lock()
+	if hit, ok := dtsScanCache[dtsRoot]; ok {
+		dtsScanMu.Unlock()
+		return hit
+	}
+	dtsScanMu.Unlock()
+
+	hit := scanCompatible(dtsRoot)
+
+	dtsScanMu.Lock()
+	dtsScanCache[dtsRoot] = hit
+	dtsScanMu.Unlock()
+	return hit
+}
+
+// scanCompatible 递归扫描 compatible 文件（NUL 分隔字符串，按字节包含匹配）。
+func scanCompatible(dtsRoot string) bool {
+	fsys := os.DirFS(dtsRoot)
+	found := false
+	_ = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || found {
+			return fs.SkipAll
+		}
+		if d.IsDir() || d.Name() != "compatible" {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, path)
+		if err != nil {
+			return nil
+		}
+		if strings.Contains(string(data), cv84x6CompatPrefix) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}

--- a/source/pbmssm/pkg/system/cpu_model_test.go
+++ b/source/pbmssm/pkg/system/cpu_model_test.go
@@ -1,0 +1,100 @@
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const cpuinfoBm1688 = `processor	: 0
+model name	: bm1688
+CPU part	: 0xd03
+`
+
+const cpuinfoCv84x6PartD05 = `processor	: 0
+model name	: bm1688
+CPU part	: 0xd05
+`
+
+const cpuinfoCv84x6 = `processor	: 0
+model name	: cv84x6
+CPU part	: 0xd05
+`
+
+const cpuinfoBm1684x = `processor	: 0
+model name	: bm1684x
+CPU part	: 0xd03
+`
+
+// TestDetectCpuModelModelName model name 可靠时直接返回（小写归一）。
+func TestDetectCpuModelModelName(t *testing.T) {
+	cases := []struct {
+		name, content, want string
+	}{
+		{"bm1684x", cpuinfoBm1684x, "bm1684x"},
+		{"cv84x6", cpuinfoCv84x6, "cv84x6"},
+		{"empty", "", ""},
+		{"missing part", "model name\t: bm1688\n", "bm1688"},
+	}
+	for _, tc := range cases {
+		if got := DetectCpuModel(tc.content, ""); got != tc.want {
+			t.Errorf("%s: DetectCpuModel() = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+// TestDetectCpuModelPartD05Override CPU part 0xd05（Cortex-A55，仅 CV84X2/CV84X6）
+// 优先于 model name——CV84X2 内核可能输出 bm1688/cv186ah/null，model name 不可靠。
+// 对齐 get_info.sh CPU part 两级识别。
+func TestDetectCpuModelPartD05Override(t *testing.T) {
+	if got := DetectCpuModel(cpuinfoCv84x6PartD05, ""); got != "cv84x6" {
+		t.Errorf("DetectCpuModel(part=0xd05) = %q, want cv84x6", got)
+	}
+	// d05 大写十六进制同样命中
+	upper := "model name\t: bm1688\nCPU part\t: 0xD05\n"
+	if got := DetectCpuModel(upper, ""); got != "cv84x6" {
+		t.Errorf("DetectCpuModel(part=0xD05) = %q, want cv84x6", got)
+	}
+}
+
+// TestDetectCpuModelDtsFallback model name 非 cv84x6 且无 d05 时，
+// 扫描 dts compatible 含 "cvitek,cv84x6-" 的节点兜底升级为 cv84x6。
+func TestDetectCpuModelDtsFallback(t *testing.T) {
+	dts := t.TempDir()
+	node := filepath.Join(dts, "soc@0")
+	if err := os.MkdirAll(node, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// compatible 文件为 NUL 分隔字符串，与真机设备树一致
+	compat := "cvitek,cv84x6-clk\x00cvitek,syscon\x00"
+	if err := os.WriteFile(filepath.Join(node, "compatible"), []byte(compat), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectCpuModel(cpuinfoBm1688, dts); got != "cv84x6" {
+		t.Errorf("DetectCpuModel(dts cv84x6 compat) = %q, want cv84x6", got)
+	}
+	// 无匹配 compatible 的 dts 不升级
+	other := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(other, "soc@0"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(other, "soc@0", "compatible"), []byte("cvitek,bm1688\x00"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := DetectCpuModel(cpuinfoBm1688, other); got != "bm1688" {
+		t.Errorf("DetectCpuModel(dts no match) = %q, want bm1688", got)
+	}
+	// dtsRoot 不存在（空串）不升级
+	if got := DetectCpuModel(cpuinfoBm1688, ""); got != "bm1688" {
+		t.Errorf("DetectCpuModel(no dts) = %q, want bm1688", got)
+	}
+}
+
+// TestDetectCpuModelDtsNotScannedWhenPartMatched model name 已是 cv84x6 或
+// part 命中 d05 时不再扫 dts（短路，避免每次采集都走目录树）。
+func TestDetectCpuModelDtsNotScannedWhenPartMatched(t *testing.T) {
+	// d05 命中 + dtsRoot 不存在：仍应返回 cv84x6（不依赖 dts）
+	if got := DetectCpuModel(cpuinfoCv84x6PartD05, "/nonexistent-dts-root"); got != "cv84x6" {
+		t.Errorf("DetectCpuModel(d05, bad dts root) = %q, want cv84x6", got)
+	}
+}

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -2,7 +2,7 @@
 # pbmssm 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION] [REASONIX_BIN]
 #   ARCH:          arm64 | amd64 | all（默认 arm64）
-#   VERSION:       显式版本号（默认 2.3.0，与 build/version.sh 一致）
+#   VERSION:       显式版本号（默认 2.3.1，与 build/version.sh 一致）
 #   REASONIX_BIN:  可选 reasonix arm64 二进制路径；与 build-deb-bmssm.sh 语义一致，
 #                  传入则把 Reasonix 一并打进 deb。
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbmssm/）
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-2.3.0}"
+VERSION="${2:-2.3.1}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pbmssm}"
 


### PR DESCRIPTION
## 概要

CV84X2（设备型号 **SE13**）bmssm 完整适配：命名链一处定义 + 全模块适配核对 + 真机部署验证。关联 MYS-753。

## 命名链设计（bmssm 侧一处定义，sophliteos 透传消费）

**问题**：CV84X2 真机 `/proc/cpuinfo` model name 误报 `bm1688`（内核 cpuinfo.c 仅 32-bit compat 模式打印，取 CHIP_INFO 判定可能输出 null/cv186ah/bm1688）；I2C information 不存在、OEMconfig 全空、boot1 OEM 区未烧写（全 0）。

**方案**（对齐 get_info.sh v1.4.1 两级识别）：

1. `pkg/system.DetectCpuModel`：CPU part **0xd05**（Cortex-A55，仅 CV84X2/CV84X6 搭载，MIDR 硬件直读）优先于 model name；dts compatible 含 `cvitek,cv84x6-` 兜底；compatible 扫描按 root 记忆化（高频采集路径）
2. 设备型号推断链：I2C model > OEMconfig PRODUCT > **boot1 OEM 0xD0(16B) PRODUCT** > 默认 **SE13**（有明确 product 信息时以设备侧为准）
3. 芯片名称：`metrics.ChipDisplayName` cv84x6 → **CV84X2**（一处映射），经 `memoryLayout.chipType` 输出，sophliteos 前端透传显示"芯片名称"；Prometheus `chip_type` 标签同步
4. `ModuleType` 兜底显示名 CV84X2 → `ChipCapacity` 识别 CV84X2（与 CV84X6 同档 16 TOPS / chipType 3）
5. OTA `productClass` 归类 SE13 → SOC（接口/展示层；真机刷机未执行）

## 全模块适配结论

| 模块 | 结论 |
|---|---|
| metrics（accelerator/ion_memory/thermal/os/chip_capacity/memory_layout） | **已适配**：ChipType/CPUInfo/SdkVersion 走两级识别，CV84X2 真机时钟（clk_ap_ca55/clk_tpu_ip/clk_ve_axi）不再被误报 model name 带偏 |
| device（devinfo） | **已适配**：SE13 兜底链 + boot1 OEM 0xD0/0x70 读取 + SN boot1 0/32 |
| health / compat | **已适配**：SE13/CV84X2 输出验证通过 |
| OTA | **接口适配**：SE13 归类 SOC；刷机流真机未执行（按任务约束） |
| agent 会话（agentproxy） | **无需改动**：接口正常；reasonix 默认 disabled（配置项，需部署后启用） |
| 文件管理/审计/用户/告警/日志/systemd/ports/docker/software/network | **无需改动**：真机 API 验证通过 |
| 防火墙 / NAT | **受限**：CV84X2 内核未编 iptables/nftables（`Failed to initialize nft`、`ip_tables not found`），与策略路由缺失同源（内核配置问题，见 BSP-NOTES §17，已建跟进 issue）；bmssm 侧报错降级正确 |
| 硬件 LED/card | **受限**：无 bmlib（预期降级，返回 available:false） |

## 真机验证（linaro@10.42.0.123，CV84X2 EVB，部署 bmssm 2.3.1）

- `/healthz`：`deviceTypeEx: "SE13"`、`moduleType: "CV84X2"`
- `/api/v1/device/basic`：deviceType=SE13、SDK 2.1、Ubuntu 22.04.5
- `/api/v1/device/resource`：deviceModel=SE13、cpu.type=cv84x6（0xd05 修正）、memoryLayout.chipType=CV84X2、算力 16 TOPS、TPU heap 24320MB、温度 29/28°C、eMMC 分区布局完整
- Prometheus `sophon_tpu_usage_percent{chip_type="CV84X2"}`
- 其余 20+ GET 端点全部验证通过（清单见 issue 评论）

## 测试

- go test 全绿（32 包；agentproxy TestSessionPromptStream 偶发 flaky，与本次改动无关，重跑通过）
- arm64 musl 静态编译通过（2.3.1，deb 产物 noskill/se7 两变体）
- 新增单测：CPU part 0xd05 优先级、dts compatible 兜底、SE13 默认链、boot1 OEM 读取、设备侧信息优先、非 cv84x6 不兜底、ChipDisplayName、ChipCapacity CV84X2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
