### PR TITLE
fix(pota_update): get_network_info.sh 非 root 下回退解析 netplan yaml（CV84X2 真机验证）

### DIFF
--- a/source/pota_update/get_network_info.sh
+++ b/source/pota_update/get_network_info.sh
@@ -282,6 +282,12 @@ sed 's/^[[:space:]]*gateway4:[[:space:]]*//')
 grep -E "^[[:space:]]*addresses:" | head -1 | \
 sed 's/^[[:space:]]*addresses:[[:space:]]*//' | tr -d '[]' | \
 awk -F',' '{print $1}' | tr -d ' ')
+    if [ -z "${CONFIG_DNS[$iface]}" ]; then
+        # 多行列表：取 nameservers 块内第一个 "- ip" 条目（netplan 常见格式）
+        CONFIG_DNS[$iface]=$(echo "$block" | grep -A 5 -E "^[[:space:]]*nameservers:" | \
+grep -E "^[[:space:]]*-[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+" | head -1 | \
+sed 's/^[[:space:]]*-[[:space:]]*//')
+    fi
 }
 
 # 函数：获取网口配置信息

--- a/source/pota_update/get_network_info.sh
+++ b/source/pota_update/get_network_info.sh
@@ -206,6 +206,84 @@ get_config_from_nm() {
         grep "dns=" | cut -d'=' -f2 | cut -d',' -f1 | cut -d';' -f1 | head -1)
 }
 
+# 函数：从netplan yaml配置中获取配置
+# 参数1：网卡名；参数2（可选）：yaml文件路径（测试用），缺省取 /etc/netplan/ 下
+# 第一个包含该网卡的 yaml。systemd-networkd 渲染出的 .network 文件在部分系统上
+# 权限为 root:systemd-network 0640（如 CV84X2 真机 Ubuntu 22.04 rootfs），非 root
+# 用户不可读，此时回退解析 world-readable 的 netplan 源 yaml。
+get_config_from_netplan() {
+    local iface=$1
+    local yaml_file=${2:-}
+
+    # 网卡名仅允许安全字符，防止拼进 awk 动态正则
+    [[ "$iface" =~ ^[A-Za-z0-9._-]+$ ]] || return 1
+
+    if [ -z "$yaml_file" ]; then
+        for f in /etc/netplan/*.yaml; do
+            [ -r "$f" ] || continue
+            if grep -qE "^[[:space:]]+${iface}[[:space:]]*:" "$f" 2>/dev/null; then
+                yaml_file=$f
+                break
+            fi
+        done
+    fi
+    [ -n "$yaml_file" ] && [ -r "$yaml_file" ] || return 1
+
+    # 提取 iface 键下缩进更深的所有行（直到同级或更浅缩进的下一个键）
+    local block
+    block=$(awk -v iface="$iface" '
+        !found && $0 ~ ("^[[:space:]]+" iface "[[:space:]]*:") {
+            found=1; match($0, /^[[:space:]]*/); ind=RLENGTH; next
+        }
+        found {
+            match($0, /^[[:space:]]*/); cur=RLENGTH
+            if (cur <= ind) exit
+            print
+        }' "$yaml_file")
+    [ -n "$block" ] || return 1
+
+    # 解析dhcp4（netplan 布尔：yes/no/true/false）
+    if echo "$block" | grep -qE "^[[:space:]]*dhcp4:[[:space:]]*(yes|true)[[:space:]]*$"; then
+        CONFIG_DHCP[$iface]="dhcp"
+    fi
+
+    # 解析addresses（inline 列表或多行列表），取第一个地址
+    local address=""
+    address=$(echo "$block" | grep -E "^[[:space:]]*addresses:" | head -1 | \
+sed 's/^[[:space:]]*addresses:[[:space:]]*//')
+    if [[ "$address" == "["* ]]; then
+        # inline 列表：addresses: [a/24, b/24]
+        address=$(echo "$address" | tr -d '[]' | awk -F',' '{print $1}' | tr -d ' ')
+    elif [ -z "$address" ]; then
+        # 多行列表：取其后第一个 "- ip/prefix" 行
+        address=$(echo "$block" | grep -E "^[[:space:]]*-[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/" | \
+head -1 | sed 's/^[[:space:]]*-[[:space:]]*//')
+    fi
+    if [ -n "$address" ] && [[ "$address" == *"/"* ]]; then
+        local parsed=$(parse_cidr "$address")
+        if [[ $parsed == *" "* ]]; then
+            CONFIG_IP[$iface]=$(echo "$parsed" | awk '{print $1}')
+            CONFIG_NETMASK[$iface]=$(echo "$parsed" | awk '{print $2}')
+        else
+            CONFIG_IP[$iface]=$parsed
+        fi
+        # 无 dhcp4 行但配置了地址时按静态处理（与 systemd 解析器语义一致）
+        if [ -z "${CONFIG_DHCP[$iface]}" ]; then
+            CONFIG_DHCP[$iface]="static"
+        fi
+    fi
+
+    # 解析网关（legacy gateway4；路由式 routes: to: default 不在范例支持范围）
+    CONFIG_GATEWAY[$iface]=$(echo "$block" | grep -E "^[[:space:]]*gateway4:" | head -1 | \
+sed 's/^[[:space:]]*gateway4:[[:space:]]*//')
+
+    # 解析DNS服务器（最多保留一个DNS，与 #133 修复保持一致）
+    CONFIG_DNS[$iface]=$(echo "$block" | grep -A 5 -E "^[[:space:]]*nameservers:" | \
+grep -E "^[[:space:]]*addresses:" | head -1 | \
+sed 's/^[[:space:]]*addresses:[[:space:]]*//' | tr -d '[]' | \
+awk -F',' '{print $1}' | tr -d ' ')
+}
+
 # 函数：获取网口配置信息
 get_interface_config() {
     local iface=$1
@@ -223,8 +301,16 @@ get_interface_config() {
         "systemd-networkd")
             config_file=$(find_systemd_network_config "$iface")
             if [ -n "$config_file" ]; then
-                echo -e "${YELLOW}配置文件：${NC}$config_file"
-                get_config_from_systemd "$config_file" "$iface"
+                if [ -r "$config_file" ]; then
+                    echo -e "${YELLOW}配置文件：${NC}$config_file"
+                    get_config_from_systemd "$config_file" "$iface"
+                else
+                    echo -e "${YELLOW}配置文件：${NC}$config_file（无读权限，回退解析 netplan yaml）"
+                    get_config_from_netplan "$iface"
+                fi
+            else
+                # 找不到 .network 文件时同样回退 netplan 源 yaml
+                get_config_from_netplan "$iface"
             fi
             ;;
         "NetworkManager")
@@ -233,6 +319,9 @@ get_interface_config() {
                 echo -e "${YELLOW}配置文件：${NC}$config_file"
                 get_config_from_nm "$config_file" "$iface"
             fi
+            ;;
+        "netplan")
+            get_config_from_netplan "$iface"
             ;;
     esac
 

--- a/source/pota_update/ota.sh
+++ b/source/pota_update/ota.sh
@@ -205,7 +205,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f "${LOGFILE}"*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "[INFO] ota update tool, version: v1.5.0"
+echo "[INFO] ota update tool, version: v1.5.1"
 
 WORK_DIR=""
 if [ ! -d "${RUN_WORK_DIR}/sdcard" ]; then

--- a/source/pota_update/readme.md
+++ b/source/pota_update/readme.md
@@ -31,6 +31,11 @@
 3. 针对BM1688和CV186AH平台，适用于1.5-最新release版本（边侧）的OTA升级
 4. 针对CV84X2（cv84x6）平台，与BM1688/CV186AH 同属 CV 系，走相同刷机/烧录路径
 
+> CV84X2（cv84x6）平台注意：
+> - CV84X2 刷机包的 partition xml 使用 `size_in_sectors`（512B/扇区）单位，v1.5.0 起自动折算，无需手工处理
+> - CV84X2 EVB 的 U-Boot 未编入 `led` 与 `bm_savelog` 命令，刷机期间的 LED 状态指示与 U-Boot 阶段日志保存不可用（脚本不会中断，属功能降级），进度与错误请通过串口日志观察
+> - 刷机前 `get_network_info.sh` 保留网络配置流程：部分系统（如 CV84X2 真机 Ubuntu 22.04 rootfs）的 `/run/systemd/network/*.network` 为 root-only（0640），非 root 运行会自动回退解析 `/etc/netplan/` 源 yaml（v1.5.1 起）
+
 ## 使用条件
 
 1. 准备sd卡卡刷包，且sd卡卡刷包可以正常刷机并启动新的系统


### PR DESCRIPTION
## 问题

CV84X2 真机（10.42.0.123，Ubuntu 22.04 rootfs，netplan + systemd-networkd renderer）实测：`/run/systemd/network/10-netplan-*.network` 权限为 `root:systemd-network 0640`。非 root 运行 `get_network_info.sh` 时 grep 全部 Permission denied，eth0/eth1 均报"未找到有效配置"，生成的 bm_set_ip 脚本为空——保留网络配置的 OTA 流程在普通用户下不可用。

## 修复

- systemd-networkd 路径：`.network` 文件存在但不可读（`[ ! -r ]`）或找不到时，回退解析 world-readable 的 `/etc/netplan/` 源 yaml
- `detect_network_manager` 已返回但从未接线的 `"netplan"` 分支同样接入该解析
- 解析能力：inline/多行 `addresses:`（缩进无关，16 空格/2 空格 yaml 均可）、`dhcp4: yes/no/true/false`、`gateway4`、`nameservers.addresses`（DNS 仍最多保留一个，与 #133 一致）
- 网卡名做 `^[A-Za-z0-9._-]+$` 校验后再进 awk 动态正则，防注入
- 版本 v1.5.0 → v1.5.1；readme 补 CV84X2 平台注意事项

## 验证

- **单元测试**：14 项 yaml 解析用例全过（真机 yaml 快照 + 2 空格缩进多行列表 + gateway4/nameservers + dhcp4:true + 网口缺失返回非0 + 空地址不误判 static）
- **真机端到端**：非 root 与 root 运行产出完全一致——`bm_set_ip_auto eth0` / `bm_set_ip eth1 '192.168.150.1' '255.255.255.0' '' ''`；root 路径行为不变（仍直接读 .network）

## 关联

- MYS-758（pota_update CV84X2 完整功能适配复核 + 真机非破坏性验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)