### PR TITLE
fix(sophliteos): 修复 CV84X2 构建/部署三处坑（CV84X2 真机验证）

### DIFF
--- a/source/psophliteos/build/build-deb-sophliteos.sh
+++ b/source/psophliteos/build/build-deb-sophliteos.sh
@@ -23,11 +23,23 @@ ARCH="$([ "$PRODUCT" = "pcie" ] && echo amd64 || echo arm64)"
 bash build/version.sh "V$VERSION"
 
 # 2. 前端 dist（本地 pnpm，无 docker；无 node_modules 时自动 install）
+# pnpm<10 会把仅含 allowBuilds（无 packages:）的 pnpm-workspace.yaml 当 workspace 根，
+# pnpm install/run 均报 "packages field missing or empty"——构建期临时移开，完事还原。
 cd frontend
+_WS="pnpm-workspace.yaml"
+_WS_BAK=""
+if [ -f "$_WS" ] && ! grep -qE '^[[:space:]]*packages:' "$_WS"; then
+  _PNPM_MAJOR="$(pnpm --version 2>/dev/null | cut -d. -f1 || true)"
+  if [ -z "$_PNPM_MAJOR" ] || [ "$_PNPM_MAJOR" -lt 10 ] 2>/dev/null; then
+    _WS_BAK="${_WS}.build-bak"
+    mv "$_WS" "$_WS_BAK"
+  fi
+fi
 if [ ! -d node_modules ]; then
   pnpm install || yarn install
 fi
 pnpm run build || yarn build
+[ -n "$_WS_BAK" ] && mv "$_WS_BAK" "$_WS"
 cd ..
 # 合入内嵌暂存目录 dist/（覆盖占位的 dist/index.html），go:embed 即在下一步编译期把整套前端打进二进制
 cp -r frontend/dist/. dist/

--- a/source/psophliteos/build/sophliteos/DEBIAN/postinst
+++ b/source/psophliteos/build/sophliteos/DEBIAN/postinst
@@ -8,6 +8,31 @@ set -e
 # 日志目录由 postinst 确保存在。
 mkdir -p /var/lib/sophliteos/db /var/log/sophliteos
 
+# 清理 ≤1.1.2 升级残留：旧包把二进制装在 /bin/sophliteos，且 /etc/systemd/system 下
+# 指向它的旧 unit 优先级高于包内 unit，二者叠加会持续拉起旧版本（Web 表现为数据全空、
+# 请求打到已废弃的 /bitmain 路径 404）。升级到本包时一并清除（CV84X2 真机实测踩坑）。
+if [ -e /bin/sophliteos ]; then
+    echo "postinst: removing legacy /bin/sophliteos (≤1.1.2)" >&2
+    rm -f /bin/sophliteos
+fi
+ETC_UNIT=/etc/systemd/system/sophliteos.service
+if [ -f "$ETC_UNIT" ] && ! grep -q "^ExecStart=/opt/sophon/sophliteos/bin/sophliteos" "$ETC_UNIT"; then
+    echo "postinst: removing stale $ETC_UNIT (points to old path)" >&2
+    rm -f "$ETC_UNIT"
+fi
+
+# CV84X2 Ubuntu 22.04 rootfs（overlay）上 systemd 实测不识别 /usr/lib/systemd/system 下的
+# 新装 unit（unit-paths 含该路径但 cat/status 均报 not found，bmssm 同现象），此处兜底：
+# daemon-reload 后 unit 仍不可见则显式落到 /etc/systemd/system（优先级最高，必定生效）。
+LIB_UNIT=/usr/lib/systemd/system/sophliteos.service
+if [ -f "$LIB_UNIT" ]; then
+    systemctl daemon-reload
+    if ! systemctl cat sophliteos >/dev/null 2>&1; then
+        echo "postinst: unit not visible from $LIB_UNIT, installing to $ETC_UNIT" >&2
+        cp "$LIB_UNIT" "$ETC_UNIT"
+    fi
+fi
+
 systemctl daemon-reload
 systemctl enable sophliteos 2>/dev/null || true
 # 升级时重启新版本；首次安装时启动。失败不阻断 dpkg（避免卡死包管理）

--- a/source/psophliteos/release.sh
+++ b/source/psophliteos/release.sh
@@ -43,14 +43,41 @@ trap restore_lockfile EXIT
 # 这里先用 pnpm --no-frozen-lockfile 显式装好（M2 实测路径），node_modules 复用。
 prepare_frontend() {
   local fe="$SCRIPT_DIR/frontend"
+  # 两个构建环境兼容点（CV84X2 真机验证踩坑记录，2026-08-26）：
+  # ① pnpm-workspace.yaml 仅含 pnpm 10 的 allowBuilds 字段（无 packages:），pnpm 9 会把
+  #    它当 workspace 根解析并报 "packages field missing or empty"——pnpm<10 时构建期
+  #    临时移开，装完还原（pnpm 10 下该文件合法且被消费，不动）。
+  # ② husky 的 prepare 脚本在 docker 挂载源码树里找不到 .git，HUSKY=0 跳过。
+  local ws="$fe/pnpm-workspace.yaml" ws_bak=""
+  if [ -f "$ws" ] && ! grep -qE '^[[:space:]]*packages:' "$ws"; then
+    local pnpm_major
+    pnpm_major="$(pnpm --version 2>/dev/null | cut -d. -f1 || true)"
+    if [ -z "$pnpm_major" ] || [ "$pnpm_major" -lt 10 ] 2>/dev/null; then
+      ws_bak="${ws}.release-bak"
+      mv "$ws" "$ws_bak"
+      echo "==> pnpm<10 且 workspace 文件无 packages 字段, 构建期临时移开 $ws"
+    fi
+  fi
+  # husky v7 的 prepare("husky install") 在 docker 挂载源码树内找不到 .git 导致安装失败
+  # （HUSKY=0/HUSKY_SKIP_INSTALL 对 v7 均无效），构建期把它替换为 no-op，装完还原。
+  local pkg="$fe/package.json" pkg_bak=""
+  if grep -q '"prepare"[[:space:]]*:[[:space:]]*"husky' "$pkg" 2>/dev/null; then
+    pkg_bak="${pkg}.release-bak"
+    cp "$pkg" "$pkg_bak"
+    node -e "const fs=require('fs'),p=process.argv[1];const j=JSON.parse(fs.readFileSync(p,'utf8'));j.scripts.prepare='node -e 0';fs.writeFileSync(p,JSON.stringify(j,null,2)+'\n')" "$pkg"
+    echo "==> 构建期临时替换 husky prepare 钩子为 no-op"
+  fi
   if [ ! -d "$fe/node_modules" ]; then
     echo "==> 前端依赖 pnpm install ..."
     (cd "$fe" && rm -rf node_modules && CI=true pnpm install --no-frozen-lockfile) \
       || (cd "$fe" && CI=true npm install --no-frozen-lockfile 2>/dev/null) \
-      || { echo "ERROR: 前端依赖安装失败" >&2; exit 1; }
+      || { [ -n "$ws_bak" ] && mv "$ws_bak" "$ws"; [ -n "$pkg_bak" ] && mv "$pkg_bak" "$pkg"; \
+           echo "ERROR: 前端依赖安装失败" >&2; exit 1; }
   else
     echo "==> 前端 node_modules 已存在, 复用"
   fi
+  [ -n "$ws_bak" ] && mv "$ws_bak" "$ws"
+  [ -n "$pkg_bak" ] && mv "$pkg_bak" "$pkg"
 }
 
 prepare_frontend


### PR DESCRIPTION
## 背景

CV84X2 真机（10.42.0.123）bmssm+sophliteos 整体功能测试中发现的三处构建/部署问题，全部修复并真机验证。

## 修复内容

1. **pnpm<10 构建兼容**：`pnpm-workspace.yaml` 仅含 pnpm 10 的 `allowBuilds` 字段（无 `packages:`），pnpm 9 把它当 workspace 根解析，`pnpm install/run` 均报 `packages field missing or empty`——release.sh 与 build-deb 脚本在 pnpm<10 时构建期临时移开该文件、装完还原（pnpm 10 下该文件合法且被消费，不动）
2. **husky v7 prepare 钩子**：`husky install` 在 docker 挂载源码树内找不到 .git 导致前端依赖安装失败（`HUSKY=0`/`HUSKY_SKIP_INSTALL` 对 v7 均无效）——构建期用 node 把 prepare 替换为 no-op，装完还原
3. **postinst 升级清理 + unit 兜底**：
   - ≤1.1.2 旧包的 `/bin/sophliteos` 残留二进制 + 指向它的 `/etc/systemd/system` 旧 unit 叠加遮蔽新部署（Web 表现为数据全空、请求打到废弃 `/bitmain` 路径 404）——升级时自动清理
   - CV84X2 Ubuntu 22.04 overlay rootfs 上 systemd 不识别 `/usr/lib/systemd/system` 新装 unit（unit-paths 含该路径但 cat/status 报 not found）——postinst 检测 unit 不可见时兜底落 `/etc/systemd/system`

## 验证

- sophon-tools-build 容器全量构建通过：前端 pnpm install + vite build 直接走通（不再依赖 yarn 回退），产物 deb 正常
- 真机模拟旧残留升级实测：`postinst: removing legacy /bin/sophliteos` / `removing stale unit` / `unit not visible ... installing to /etc` 三条日志齐全，服务自动拉起新二进制，Web 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)