### PR TITLE
fix(bmssm): 指标对齐 get_info v1.5.1——板温伪值/CPU频率/频率 exporter 缺失

### DIFF
--- a/source/pbmssm/pkg/metrics/cpu.go
+++ b/source/pbmssm/pkg/metrics/cpu.go
@@ -63,20 +63,21 @@ func modelLine(content string) string {
 	return ""
 }
 
-// cpuFrequency 读 scaling_cur_freq（kHz），fallback cpuinfo_max_freq，转 MHz。
+// cpuFrequency 读 scaling_cur_freq（kHz），fallback cpuinfo_max_freq，
+// 再 fallback debugfs clk（CPUFrequencyClk，按芯片选 clk_* 路径）。
+// CV84X2 无 cpufreq 驱动（/sys/.../cpufreq 不存在），此前恒返 0；
+// debugfs clk_ap_ca55 与 get_info CPU_CLK 同源（对齐 get_info v1.5.1）。
 func (c *Collector) cpuFrequency() int {
 	s := c.readStr(cpuFreqPath)
 	if s == "" {
 		s = c.readStr(cpuFreqMaxPath)
 	}
-	if s == "" {
-		return 0
+	if s != "" {
+		if v, err := strconv.Atoi(s); err == nil {
+			return v / 1000 // kHz → MHz
+		}
 	}
-	v, err := strconv.Atoi(s)
-	if err != nil {
-		return 0
-	}
-	return v / 1000 // kHz → MHz
+	return int(c.CPUFrequencyClk()) // Hz → MHz（accelerator.go）
 }
 
 // cpuUtilization /proc/stat 双采样：首行 "cpu " 的 user,nice,sys,idle,iowait,irq,softirq

--- a/source/pbmssm/pkg/metrics/prometheus.go
+++ b/source/pbmssm/pkg/metrics/prometheus.go
@@ -56,6 +56,10 @@ type MetricsRegistry struct {
 	PowerUsage   *prometheus.GaugeVec
 	HealthStatus *prometheus.GaugeVec
 
+	CPUFreq *prometheus.GaugeVec
+	TPUFreq *prometheus.GaugeVec
+	VPUFreq *prometheus.GaugeVec
+
 	ChipInfo *prometheus.GaugeVec
 }
 
@@ -96,6 +100,12 @@ func NewMetricsRegistry() *MetricsRegistry {
 		PowerUsage:   newGaugeVec("power_usage_watts", "Power usage in watts"),
 		HealthStatus: newGaugeVec("health_status", "Device health status (1=healthy, 0=unhealthy)"),
 
+		// 频率（Hz，debugfs clk，对齐 get_info CPU_CLK/TPU_CLK/VPU_CLK；
+		// 采集自 CollectAll 的 CPUFreqMHz/TPUFreqMHz/VPUFreqMHz × 1e6）
+		CPUFreq: newGaugeVec("cpu_frequency_hz", "CPU frequency in hertz (debugfs clk)"),
+		TPUFreq: newGaugeVec("tpu_frequency_hz", "TPU frequency in hertz (debugfs clk)"),
+		VPUFreq: newGaugeVec("vpu_frequency_hz", "VPU frequency in hertz (debugfs clk)"),
+
 		ChipInfo: newGaugeVec("chip_info", "Chip information"),
 	}
 
@@ -114,6 +124,7 @@ func NewMetricsRegistry() *MetricsRegistry {
 		r.VPPUsage, r.JPUUsage,
 		r.ChipTemp, r.BoardTemp, r.FanSpeed, r.PowerUsage,
 		r.HealthStatus, r.ChipInfo,
+		r.CPUFreq, r.TPUFreq, r.VPUFreq,
 	} {
 		prometheus.MustRegister(g)
 	}
@@ -176,6 +187,11 @@ func (r *MetricsRegistry) Update(hw *HardwareMetrics, dev DeviceLabels) {
 	// 健康状态
 	set(r.HealthStatus, float64(hw.HealthStatus))
 
+	// 频率（MHz → Hz，对齐 get_info CPU_CLK/TPU_CLK/VPU_CLK）
+	setInt(r.CPUFreq, hw.CPUFreqMHz*1e6)
+	setInt(r.TPUFreq, hw.TPUFreqMHz*1e6)
+	setInt(r.VPUFreq, hw.VPUFreqMHz*1e6)
+
 	// 芯片信息（值为 1 表示设备存在）
 	set(r.ChipInfo, 1.0)
 }
@@ -199,6 +215,7 @@ func (r *MetricsRegistry) Reset() {
 		r.VPPUsage, r.JPUUsage,
 		r.ChipTemp, r.BoardTemp, r.FanSpeed, r.PowerUsage,
 		r.HealthStatus, r.ChipInfo,
+		r.CPUFreq, r.TPUFreq, r.VPUFreq,
 	} {
 		g.Reset()
 	}

--- a/source/pbmssm/pkg/metrics/prometheus_test.go
+++ b/source/pbmssm/pkg/metrics/prometheus_test.go
@@ -22,6 +22,7 @@ func TestNewMetricsRegistry(t *testing.T) {
 			r.VPPUsage, r.JPUUsage,
 			r.ChipTemp, r.BoardTemp, r.FanSpeed, r.PowerUsage,
 			r.HealthStatus, r.ChipInfo,
+			r.CPUFreq, r.TPUFreq, r.VPUFreq,
 		} {
 			prometheus.Unregister(g)
 		}
@@ -55,6 +56,7 @@ func TestMetricsRegistryUpdateAndReset(t *testing.T) {
 			r.VPPUsage, r.JPUUsage,
 			r.ChipTemp, r.BoardTemp, r.FanSpeed, r.PowerUsage,
 			r.HealthStatus, r.ChipInfo,
+			r.CPUFreq, r.TPUFreq, r.VPUFreq,
 		} {
 			prometheus.Unregister(g)
 		}

--- a/source/pbmssm/pkg/metrics/thermal.go
+++ b/source/pbmssm/pkg/metrics/thermal.go
@@ -24,7 +24,15 @@ func (c *Collector) ChipTemp() int {
 // BoardTemp 读取板温（thermal_zone1），milli-celsius → 整数 ℃。
 // 对齐 pget_info：BOARD_TEMP=$(cat thermal_zone1/temp); /1000。
 // 失败返 0。
+//
+// CV84X2 不可抗说明（2026-08-26 真机核实，与 get_info v1.5.1 结论对齐）：
+// 无独立板温传感器——thermal_zone0/1/2 全是 SoC 片内传感器（dts soc_thermal_0/1/2），
+// 借读 zone1 会输出伪板温；EVB MCU 温度寄存器读回无意义值（压测冻结）。
+// 故 cv84x6 板温恒返 0（get_info 同样输出 0），不再借读 zone1。
 func (c *Collector) BoardTemp() int {
+	if c.ChipType() == "cv84x6" {
+		return 0
+	}
 	return c.readTempC(boardTempPath)
 }
 


### PR DESCRIPTION
## 背景

真机双采对比 get_info v1.5.1 与 bmssm 2.3.1（API + Prometheus），核心指标（内存布局/温度/使用率/SN/算力）已对齐，发现三处不对齐，本 PR 全部修复。

## 修复内容

1. **BoardTemp cv84x6 伪值**：`thermal.go` 借读 thermal_zone1（SoC 片内传感器，dts soc_thermal_0/1/2）当板温输出 29℃ 伪值。get_info v1.5.1 已核实 CV84X2 无独立板温传感器（MCU 温度寄存器读回无意义值、压测冻结）——cv84x6 改返 0，与 get_info BOARD_TEMP 对齐
2. **cpu.frequency 恒 0**：`cpu.go` 走 cpufreq sysfs，CV84X2 无 cpufreq 驱动。增加 fallback 到 `CPUFrequencyClk()`（debugfs clk_ap_ca55，与 get_info CPU_CLK 同源），实测 0 → **2000 MHz**
3. **Prometheus 频率指标缺失**：`CollectAll()` 采集的 CPU/TPU/VPUFreqMHz 此前无任何消费方——新增 `sophon_cpu_frequency_hz` / `sophon_tpu_frequency_hz` / `sophon_vpu_frequency_hz` 三个 gauge（对齐 get_info CPU_CLK/TPU_CLK/VPU_CLK），Update/Reset/测试 cleanup 同步

## 验证（真机 10.42.0.123，bmssm 2.3.2）

| 指标 | get_info v1.5.1 | bmssm 修复后 |
|---|---|---|
| CPU_CLK | 2GHz | cpu.frequency=2000 MHz ✅ / `sophon_cpu_frequency_hz`=2e9 ✅ |
| TPU_CLK | 1GHz | `sophon_tpu_frequency_hz`=1e9 ✅ |
| VPU_CLK | 650MHz | `sophon_vpu_frequency_hz`=6.5e8 ✅ |
| BOARD_TEMP | 0（无传感器结论） | board.temperature=0 ✅ / `sophon_board_temperature_celsius`=0 ✅ |
| CHIP_TEMP | 28℃（zone0） | 29℃（同源波动）✅ |

go test 32 包全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)