### PR TITLE
fix(psocbak): CV84X2 真机验证发现的三处缺陷修复

### DIFF
--- a/source/psocbak/socbak/script/ota_update/ota_update.sh
+++ b/source/psocbak/socbak/script/ota_update/ota_update.sh
@@ -89,7 +89,9 @@ CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
 case "${CPU_MODEL}" in
     ""|null|cv186ah)
         if [ -d /proc/device-tree ]; then
-            _cv_match=$(find /proc/device-tree -name compatible -type f \
+            # /proc/device-tree 是指向 /sys/firmware/devicetree/base 的符号链接，
+            # find 必须加 -L 才会遍历（否则恒返回空，兜底失效）
+            _cv_match=$(find -L /proc/device-tree -name compatible -type f \
                 -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null)
             if [ -n "${_cv_match}" ]; then
                 CPU_MODEL="cv84x6"

--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -57,7 +57,9 @@ ROOTFS_INCLUDE_PATHS=' ./var/log/nginx ./var/log/redis ./var/log/mosquitto ./var
 
 declare -A -g PART_EXCLUDE_FLAGS
 PART_EXCLUDE_FLAGS["boot"]=' --exclude=./spi_flash.bin.socBakNew --exclude=./u-boot.env '
-PART_EXCLUDE_FLAGS["data"]='  '
+# socrepack 为 socbak 自身产物目录：当外置存储缺省、产物直接落在 /data/socrepack 时，
+# 若不排除会把正在生成的 *.tgz 打进 data 包（自包含递归）。rootfs 侧已有同样排除。
+PART_EXCLUDE_FLAGS["data"]=' --exclude=./socrepack '
 
 # These parameters define several generated files and
 # their default sizes for repackaging. Users can modify
@@ -130,7 +132,11 @@ socbak_cleanup() {
 	umount ${TGZ_FILES_PATH}/sparse-path* &>/dev/null
 	exit 0
 }
-trap socbak_cleanup EXIT ERR SIGHUP SIGINT SIGQUIT SIGTERM
+# 注意：不能挂 ERR。tar 打包运行中的根文件系统时，"File removed before we read it"
+# 等瞬态警告会使 tar 以 1 退出（属预期、可容忍，追加 pass 本就带 --ignore-failed-read），
+# ERR trap 会把这类警告当成致命错误：cleanup 提前退出且 exit 0，备份被静默截断还报成功
+# （CV84X2 真机实测踩坑）。关键步骤失败由各处的 "$?" 显式检查处理。
+trap socbak_cleanup EXIT SIGHUP SIGINT SIGQUIT SIGTERM
 
 SOCBAK_GET_TAR_SIZE_KB=0
 socbak_get_tar_size() {
@@ -164,6 +170,18 @@ if [[ "$(busybox devmem 0x50010000 2>/dev/null)" == "0x16860000" ]]; then
 elif [[ "$(busybox devmem 0x50010000 2>/dev/null)" == "0x16840000" ]]; then
 	SOC_NAME="bm1684"
 fi
+# cv84x6（CV84X2，SDK 标识 cv84x6）识别：/proc/device-tree/model 根 compatible 可能为通用
+# "linux,dummy-virt"（或缺失），不能直接判。与 get_info 一致采用两级信号：
+# 1) 首选 CPU part（MIDR 硬件直读）：Cortex-A55(0xd05) 仅 cv84x6（CV84X2），其余 SDK 芯片
+#    （bm1684x/bm1684/bm1688/cv186ah）均为 Cortex-A53(0xd03)，天然分开；
+# 2) 兜底 dts 信号：内核 dts 递归含 "cvitek,cv84x6-*" compatible。注意 /proc/device-tree 是
+#    指向 /sys/firmware/devicetree/base 的符号链接，find 必须加 -L 才会遍历（真机踩坑，
+#    不加 -L 时 find 返回空导致 CV84X2 真机识别失败退出）。
+# 检测到即按 CV 系（bm1688/cv186ah/cv84x6）路径打包。
+CPU_PART=$(awk -F': ' '/CPU part/{print $2; exit}' /proc/cpuinfo 2>/dev/null)
+if [[ "${SOC_NAME}" == "" ]] && [[ "${CPU_PART}" == "0xd05" || "${CPU_PART}" == "d05" ]]; then
+	SOC_NAME="cv84x6"
+fi
 if [[ "${SOC_NAME}" == "" ]]; then
 	if [[ "$(grep -ai "bm1688" '/proc/device-tree/model' 2>/dev/null | wc -l)" != "0" ]]; then
 		SOC_NAME="bm1688"
@@ -171,11 +189,8 @@ if [[ "${SOC_NAME}" == "" ]]; then
 		SOC_NAME="bm1688"
 	fi
 fi
-# cv84x6（CV84X2，SDK 标识 cv84x6）兜底：/proc/device-tree/model 根 compatible 可能为通用
-# "linux,dummy-virt"，不能直接判。以内核 dts 递归含 "cvitek,cv84x6-*" compatible 为权威信号
-#（与 get_info 的判法一致），检测到即按 CV 系（bm1688/cv186ah/cv84x6）路径打包。
 if [[ "${SOC_NAME}" == "" ]] && [ -d /proc/device-tree ]; then
-	if [ -n "$(find /proc/device-tree -name compatible -type f \
+	if [ -n "$(find -L /proc/device-tree -name compatible -type f \
 		-exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null)" ]; then
 		SOC_NAME="cv84x6"
 	fi
@@ -471,7 +486,7 @@ else
 				echo "INFO: tar $TGZ_FILE flags : $ROOTFS_EXCLUDE_FLAGS ..."
 				systemctl enable resize-helper.service
 				rm -rf $TGZ_FILES_PATH/$TGZ_FILE.tar
-				tar --checkpoint=500 --checkpoint-action=ttyout='[%d sec]: C%u, %T%*\r' -capSf $TGZ_FILES_PATH/$TGZ_FILE.tar --numeric-owner $ROOTFS_EXCLUDE_FLAGS "./"
+				tar --checkpoint=500 --checkpoint-action=ttyout='[%d sec]: C%u, %T%*\r' --ignore-failed-read --numeric-owner -capSf $TGZ_FILES_PATH/$TGZ_FILE.tar $ROOTFS_EXCLUDE_FLAGS "./"
 				tar --checkpoint=500 --checkpoint-action=ttyout='[%d sec]: C%u, %T%*\r' --ignore-failed-read -rapSf $TGZ_FILES_PATH/$TGZ_FILE.tar --numeric-owner $ROOTFS_INCLUDE_PATHS
 				systemctl disable resize-helper.service
 				echo "INFO: gzip tar file..."
@@ -486,7 +501,7 @@ else
 				set +u
 				EXT_FLAG="${PART_EXCLUDE_FLAGS["$TGZ_FILE"]}"
 				set -u
-				tar --checkpoint=500 --checkpoint-action=ttyout='[%d sec]: C%u, %T%*\r' -I ${PIGZ_GZIP_COM} -cpSf $TGZ_FILES_PATH/$TGZ_FILE.tgz --numeric-owner ${EXT_FLAG} "./"
+				tar --checkpoint=500 --checkpoint-action=ttyout='[%d sec]: C%u, %T%*\r' --ignore-failed-read -I ${PIGZ_GZIP_COM} -cpSf $TGZ_FILES_PATH/$TGZ_FILE.tgz --numeric-owner ${EXT_FLAG} "./"
 				if [ $TGZ_FILE == "data" ]; then
 					TAR_SIZE=$((512*1024))
 				else
@@ -590,6 +605,9 @@ fi
 echo "</physical_partition>" >> $TGZ_FILES_PATH/$SOCBAK_PARTITION_FILE
 cat $TGZ_FILES_PATH/$SOCBAK_PARTITION_FILE
 
+# output 目录仅在 all-in-one 模式下提前创建，tgz-only 模式走到这里不存在，
+# 直接 pushd 会报 "No such file or directory"（CV84X2 真机实测踩坑，不影响产物）
+mkdir -p $TGZ_FILES_PATH/output
 pushd $TGZ_FILES_PATH/output
 if [[ "${SOC_BAK_FIXED_DATA_START}" != "" ]]; then
 	advcp -g  ${TGZ_FILES_PATH}/binTools/mk_gpt .

--- a/source/psocbak/socbak/socbak_md5.txt
+++ b/source/psocbak/socbak/socbak_md5.txt
@@ -5,7 +5,9 @@ d2f4121431ae31a6658212b2aa9f22a0  ./binTools/advmv
 0d2c7e010a5b7bf934a9da0e006cb752  ./binTools/chattr
 1e326dae2194ff6ec6dc4723027ca3a8  ./binTools/compile_et
 09c12d470d7e14298895201c9ceb42c7  ./binTools/debugfs
+b0a0527f516529b20c94d667a9cfa443  ./binTools/dtc
 0e9be3dc0430fd1d1b4c7e19a19d7590  ./binTools/dumpe2fs
+8620b74073ad2f449220fa872d647522  ./binTools/dumpimage
 97bc8115220d85a7ec67f5fcb6a42792  ./binTools/e2freefrag
 dc4bb5f19ce70115a245a17592ca5b02  ./binTools/e2fsck
 4273b5e836e83b9b0a2275bb04d494da  ./binTools/e2image
@@ -21,6 +23,7 @@ dc4bb5f19ce70115a245a17592ca5b02  ./binTools/fsck.ext2
 dc4bb5f19ce70115a245a17592ca5b02  ./binTools/fsck.ext3
 dc4bb5f19ce70115a245a17592ca5b02  ./binTools/fsck.ext4
 bd96ac752eb087e40214470b0d425fce  ./binTools/fsck.fat
+39765e591d7fc5a8f38f1cf37defad96  ./binTools/gdisk
 0d3f1844147342bf95e4e387b79a04f9  ./binTools/logsave
 7f7176aad87b2533b5495c839b31deb4  ./binTools/lsattr
 9cdc2a394d21e61586b4e105b6956ac2  ./binTools/mk_cmds
@@ -30,6 +33,7 @@ d276591d7a5a0fd43dfdc2c14af8064e  ./binTools/mkfs.ext2
 d276591d7a5a0fd43dfdc2c14af8064e  ./binTools/mkfs.ext3
 d276591d7a5a0fd43dfdc2c14af8064e  ./binTools/mkfs.ext4
 68996f5d08d25bbbcd1eb233ee5e85e1  ./binTools/mkfs.fat
+ea1486773c9b04d6c4640aec8a725f9a  ./binTools/mkimage
 bb3291056ad6e04adaa6244cac412c29  ./binTools/mklost+found
 c404535e7cc8a4fa1f64524e33211ff7  ./binTools/pigz
 6fb7cbf88f19f5dd2a4816a5d148461b  ./binTools/resize2fs
@@ -38,11 +42,7 @@ c404535e7cc8a4fa1f64524e33211ff7  ./binTools/pigz
 c404535e7cc8a4fa1f64524e33211ff7  ./binTools/unpigz
 7af141f019a16db2fd3a1d925b9e1a44  ./binTools/uuidd
 f2a59885f1550f3b0909176521f42ca6  ./binTools/uuidgen
-b0a0527f516529b20c94d667a9cfa443  ./binTools/dtc
-8620b74073ad2f449220fa872d647522  ./binTools/dumpimage
-ea1486773c9b04d6c4640aec8a725f9a  ./binTools/mkimage
-39765e591d7fc5a8f38f1cf37defad96  ./binTools/gdisk
 608ca6d0a3e1b5c55d67b5396617b698  ./script/bm1684/bm_make_package.sh
-b7976ce3c29844855a1a00a6b4d2d514  ./script/bm1688/bm_make_package.sh
+24dd21756fb680231e087305e006e2e5  ./script/bm1688/bm_make_package.sh
 7864745c1a0c7e0b72e2a6c68e7e78f9  ./script/bm1688/raw2cimg_edge.py
-8deec607fb2c9627b5e910d94bed5669  ./script/ota_update/ota_update.sh
+12710b5833813b255b8f45bfffb2df2c  ./script/ota_update/ota_update.sh


### PR DESCRIPTION
## 背景

MYS-761：psocbak（PR #100 适配的 CV84X2 整卡备份/OTA 打包）首次上真机（cv84x6 wevb，Ubuntu 22.04.5，eMMC 58G）完整验证。代码层适配的识别兜底在真机上不工作，另发现两处真机必现缺陷。

## 缺陷与修复

### 1. 芯片识别恒失败（致命，真机直接退出）
`/proc/device-tree` 是指向 `/sys/firmware/devicetree/base` 的**符号链接**，`find` 不加 `-L` 不遍历，PR #100 的 cv84x6 兜底识别恒返回空 → 真机 `ERROR: cannot get chip id!` 退出（实测复现）。

修复：与 get_info 一致的两级识别——首选 CPU part（MIDR `0xd05` = Cortex-A55，仅 cv84x6 独有，其余 SDK 芯片均为 A53/0xd03），兜底 `find -L`。`ota_update.sh` 同款兜底同步加 `-L`。

### 2. 备份被静默截断且报成功（致命）
`trap socbak_cleanup EXIT ERR ...` 挂了 ERR：tar 打包**运行中的**根文件系统时 `File removed before we read it` 等瞬态警告使 tar 以 1 退出（真机必现：dpkg/服务文件打包期间被删），ERR trap 触发 cleanup 提前退出且 `exit 0`——**产物不完整但进程返回成功**。

修复：移除 trap 中的 ERR（关键失败仍由脚本既有的显式 `"$?"` 检查处理）；rootfs 首次 tar 与各分区 tar 补 `--ignore-failed-read`（追加 pass 本就带该参数）。

### 3. data.tgz 自包含递归
外置存储缺省、产物直接落 `/data/socrepack` 时，data 分区 tar 会把正在生成的 `*.tgz` 打进包（实测 data.tgz 含 1.3G socrepack 内容）。`PART_EXCLUDE_FLAGS["data"]` 补 `--exclude=./socrepack`（rootfs 侧本就有同样排除）。

### 附带
- tgz-only 模式 `pushd output` 报 No such file（output 仅 all-in-one 模式创建），补 `mkdir -p`
- `socbak_md5.txt` 随 ota_update.sh 变更按脚本内置命令重新生成

## 真机验证结果（三轮）

- **备份（只读，`bash socbak.sh`）**：boot/data/recovery/rootfs 4 个 tgz + fip.bin + partition32G.xml 全部生成；gzip 完整性、md5、内容抽查（boot 含 boot.itb/boot.scr.emmc，rootfs 10 万条目且正确排除挂载点，data 已排除 socrepack）、fip.bin 与 `/dev/mmcblk0boot0` 前 2048 扇区逐字节一致（CVBL01 魔数）全部通过
- **OTA 打包（`SOC_BAK_ALL_IN_ONE=1`）**：output/sdcard 包 95 个文件（BOOT/boot.scr/boot_fip/boot_emmc-*.scr/每分区分片 *.N-of-M.gz/gpt.gz/fip.bin/ota_update.sh/md5.txt）；包内 md5 全检通过；mkimage 头正确；分区 mmc write 扇区偏移与 GPT 逐扇区吻合；新 GPT 布局与实机同构
- **OTA 保留 DATA 分区（`SOC_BAK_ALL_IN_ONE=1 SOC_BAK_FIXED_DATA_START=1`）**：ROOTFS 自动扩容 310272KB 由 ROOTFS_RW（9G→8.6G）补偿，`check last part start [NEW: 25427328] = [DEV: 25427328]` 精确一致——此包可走 ota_update 默认 LAST_PART_NOT_FLASH 模式；包内 md5 全检通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)