### PR TITLE
fix(bmssm): cv84x6 下 deviceTypeEx PCIE 兜底值须被 SE13 链覆盖（开机竞态）

### DIFF
--- a/source/pbmssm/pkg/device/devinfo.go
+++ b/source/pbmssm/pkg/device/devinfo.go
@@ -21,6 +21,10 @@ const (
 	SOC_DEV     = "soc"
 	UNKNOWN_DEV = "unknown"
 
+	// DeviceTypeExPCIEFallback：三段探测（i2c/OEM/SE6 裸板）皆无信息时的 deviceTypeEx
+	// 兜底猜测值，非设备侧事实；cv84x6 下应被 boot1/SE13 链覆盖（见 applyCv84x6Fallback）。
+	DeviceTypeExPCIEFallback = "PCIE"
+
 	SE5      = "SE"
 	SE6_CTRL = "SE-CTRL"
 	SE6_CORE = "SE-CORE" // 预留：SE6 核心板角色，后续硬件子项目启用。
@@ -270,7 +274,7 @@ func detectFromI2COrOEM(i2cPath, oemPath, boardIPPath string) {
 
 	// 3) 无 i2c 也无 OEM：可能是 SE6 控制器裸板
 	DeviceType = PCIE_DEV
-	DeviceTypeEx = "PCIE"
+	DeviceTypeEx = DeviceTypeExPCIEFallback
 	if ok1, _ := system.PathExists(CTRLShell); ok1 {
 		DeviceRole = SE6_CTRL
 		DeviceTypeEx = "SE8"
@@ -298,7 +302,10 @@ func applyCv84x6Fallback(cpuinfo, boot1 string) {
 	if DeviceRole == "" {
 		DeviceRole = SE5
 	}
-	if DeviceTypeEx == "" {
+	if DeviceTypeEx == "" || DeviceTypeEx == DeviceTypeExPCIEFallback {
+		// "PCIE" 是 detectFromI2COrOEM 三段探测皆无信息时的兜底猜测值（SE6 裸板路径），
+		// 非设备侧事实。cv84x6 下视为未定：开机竞态（bmssm 先于 /factory/OEMconfig.ini
+		// 转储启动，socbak 整卡恢复真机实测复现）会走到该分支，须被 boot1/SE13 链覆盖。
 		DeviceTypeEx = readFixedStringAt(boot1, Boot1ProductOffset, Boot1ProductLen)
 		if DeviceTypeEx == "" {
 			DeviceTypeEx = DeviceModelSE13

--- a/source/pbmssm/pkg/device/devinfo_test.go
+++ b/source/pbmssm/pkg/device/devinfo_test.go
@@ -621,3 +621,23 @@ func TestApplyCv84x6FallbackNonCv84x6(t *testing.T) {
 		t.Errorf("ModuleType=%q, want empty", ModuleType)
 	}
 }
+
+// TestApplyCv84x6FallbackOverridesPCIEFallback cv84x6 下 "PCIE" 兜底猜测值
+// 应被覆盖：开机竞态（bmssm 先于 /factory/OEMconfig.ini 转储启动，整卡恢复真机复现）
+// 走到 detectFromI2COrOEM 分支 3 时 deviceTypeEx="PCIE"，须回退 boot1/SE13 链。
+func TestApplyCv84x6FallbackOverridesPCIEFallback(t *testing.T) {
+	cpuinfo := writeCpuinfoFixture(t, "cv84x6", "0xd05")
+	boot1 := writeBoot1Fixture(t, "", "", "", "") // boot1 OEM 未烧写
+
+	resetGlobals()
+	DeviceType = PCIE_DEV
+	DeviceTypeEx = DeviceTypeExPCIEFallback
+	applyCv84x6Fallback(cpuinfo, boot1)
+
+	if DeviceTypeEx != DeviceModelSE13 {
+		t.Errorf("DeviceTypeEx=%q, want %q (PCIE 兜底值应被 SE13 覆盖)", DeviceTypeEx, DeviceModelSE13)
+	}
+	if DeviceType != SOC_DEV {
+		t.Errorf("DeviceType=%q, want soc", DeviceType)
+	}
+}


### PR DESCRIPTION
## 背景

socbak 整卡恢复刷机真机验证时发现：恢复后首次开机 healthz 的 `deviceTypeEx` 输出伪值 `PCIE`（应为 `SE13`），重启 bmssm 后恢复正常——启动时序竞态。

## 根因链

1. 开机时 `/factory/OEMconfig.ini` 由转储服务生成，bmssm 若先启动则文件尚缺
2. `detectFromI2COrOEM` 三段探测（i2c / OEM / SE6 裸板）皆无信息 → 分支 3 把 `deviceTypeEx` 设为兜底猜测值 `"PCIE"`
3. `applyCv84x6Fallback` 原判断 `DeviceTypeEx == ""` 过窄——`"PCIE"` 非空不被覆盖 → 伪值残留

## 修复

- 提取 `DeviceTypeExPCIEFallback` 常量（`devinfo.go:273` 同步引用）
- cv84x6 兜底把 `"PCIE"` 与空串同视为未定值，走 boot1 0xD0 → SE13 默认链；有明确 product 时设备侧优先语义不变
- 新增回归单测 `TestApplyCv84x6FallbackOverridesPCIEFallback`

## 验证（真机 10.42.0.123，bmssm 2.3.3）

- 整机重启后开机自启路径（uptime 1m27s）healthz 即正确输出 `deviceTypeEx=SE13`（修复前该时序下为 PCIE）
- go test 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)