### PR TITLE
fix(get_info): dts 兜底 find 补 -L 跟随符号链接（v1.5.1）

### DIFF
--- a/source/pget_info/get_info.sh
+++ b/source/pget_info/get_info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-GET_INFO_VERSION="1.5.0"
+GET_INFO_VERSION="1.5.1"
 
 shopt -s compat31
 
@@ -485,7 +485,9 @@ case "${CPU_PART}" in
     *d05*|*D05*) CPU_MODEL="cv84x6" ;;
 esac
 if [[ "${CPU_MODEL}" != "cv84x6" ]] && [ -d /proc/device-tree ]; then
-    _cv_match=$(find /proc/device-tree -name compatible -type f \
+    # -L：/proc/device-tree 是指向 /sys/firmware/devicetree/base 的符号链接，
+    # 不跟随则恒返回空（真机实测 0 vs 147 条），兜底形同虚设（psocbak PR #146 同款问题）。
+    _cv_match=$(find -L /proc/device-tree -name compatible -type f \
         -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null)
     if [ -n "${_cv_match}" ]; then
         CPU_MODEL="cv84x6"


### PR DESCRIPTION
## 问题

`/proc/device-tree` 是指向 `/sys/firmware/devicetree/base` 的**符号链接**，`find` 不加 `-L` 恒返回空（真机实测 0 vs 147 条 compatible）——cv84x6 的 dts 兜底识别形同虚设。此前未暴露是因为 CPU part 0xd05 首选路径真机恒命中。

psocbak PR #146 已修同款问题（真机 socbak 曾因此"芯片识别恒失败"），本 PR 补齐 get_info 侧。

## 修复

`get_info.sh:488` find 补 `-L`（含注释说明），版本 1.5.0 → 1.5.1。

## 验证（真机 10.42.0.123）

| 路径 | 结果 |
|---|---|
| 正常路径（CPU part 0xd05 首选） | CPU_MODEL=cv84x6 不变 ✅ |
| 兜底路径（mount namespace 伪造 cpuinfo 为 cv186ah/0xd03） | 修复前恒不升级；修复后由 dts 特征正确升级 cv84x6 ✅ |
| 全量输出 | 57 字段无报错 ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)