### PR TITLE
chore: CV84X2 适配相关工具版本号补齐

### DIFF
--- a/source/pSophUI/SophUI/deb/DEBIAN/control
+++ b/source/pSophUI/SophUI/deb/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: sophgo-hdmi
 Source: sophgo-hdmi
-Version: 1.6.8
+Version: 1.6.9
 Architecture: arm64
 Maintainer: sophgo
 Priority: optional

--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # bmssm .deb 打包：交叉编译 arm64 静态二进制 + 组装 deb 数据树 + dpkg-deb。
 # 用法: bash build/build-deb-bmssm.sh [VERSION] [ARCH] [REASONIX_BIN]
-#   VERSION      默认 2.3.1（与 build/version.sh 一致）
+#   VERSION      默认 2.3.3（与 build/version.sh 一致）
 #   ARCH         默认 arm64（设备）；amd64 用于 PCIE/开发机
 #   REASONIX_BIN 可选：reasonix arm64 二进制路径。提供则把 Reasonix 一并嵌入 deb，
 #               安装到 /opt/sophon/reasonix/bin/reasonix，并在 bmssm.yaml 里把
@@ -16,7 +16,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
-VERSION="${1:-2.3.1}"
+VERSION="${1:-2.3.3}"
 VERSION="${VERSION//\//-}"
 ARCH="${2:-arm64}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-2.3.1}"
+VERSION="${2:-2.3.3}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pbmssm}"
 

--- a/source/psocbak/socbak/script/ota_update/ota_update.sh
+++ b/source/psocbak/socbak/script/ota_update/ota_update.sh
@@ -175,7 +175,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f $LOGFILE*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "[INFO] ota update tool, version: v1.3.3"
+echo "[INFO] ota update tool, version: v1.3.4"
 
 WORK_DIR=""
 if [ ! -d ${1}/sdcard ]; then

--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -11,7 +11,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f $LOGFILE*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "VERSION: v1.2.1"
+echo "VERSION: v1.3.0"
 date '+%Y-%m-%d %H:%M:%S'
 
 export SOC_BAK_ALL_IN_ONE=${SOC_BAK_ALL_IN_ONE:-}

--- a/source/psophliteos/build/build-deb-sophliteos.sh
+++ b/source/psophliteos/build/build-deb-sophliteos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # sophliteos .deb 打包（docker-free）：pnpm 前端 + go 交叉编译（前端 go:embed 内嵌）+ dpkg-deb。
 # 用法: bash build/build-deb-sophliteos.sh [VERSION] [soc|pcie]
-#   VERSION 默认 2.2.0
+#   VERSION 默认 2.2.1
 #   soc=arm64（设备，默认）；pcie=amd64（开发机）
 # 产物: release/sophliteos_<PRODUCT>_<VERSION>.deb（单文件二进制，前端内嵌）
 #
@@ -12,7 +12,7 @@
 set -e
 
 cd "$(dirname "$0")/.."
-VERSION="${1:-2.2.0}"
+VERSION="${1:-2.2.1}"
 PRODUCT="${2:-soc}"
 if [ "$PRODUCT" != "soc" ] && [ "$PRODUCT" != "pcie" ]; then
   echo "PRODUCT 必须是 soc 或 pcie" >&2; exit 1

--- a/source/psophliteos/release.sh
+++ b/source/psophliteos/release.sh
@@ -2,7 +2,7 @@
 # psophliteos 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION]
 #   ARCH:    arm64(soc) | amd64(pcie) | all（默认 arm64）
-#   VERSION: 显式版本号（默认 2.2.0，与 build/version.sh 一致）
+#   VERSION: 显式版本号（默认 2.2.1，与 build/version.sh 一致）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/psophliteos/）
 # 产物: sophliteos_soc_<ver>.deb + sophliteos_pcie_<ver>.deb（单文件二进制，前端 go:embed 内嵌）
 set -euo pipefail
@@ -10,7 +10,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-2.2.0}"
+VERSION="${2:-2.2.1}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/psophliteos}"
 
 case "$ARCH" in


### PR DESCRIPTION
## 背景

CV84X2 适配/验证期间部分工具功能已修复但版本号未同步，本 PR 统一补齐（仅版本号与注释，无逻辑改动）。

## 变更

| 工具 | 旧 → 新 | 对应功能改动 |
|---|---|---|
| psocbak socbak.sh | v1.2.1 → **v1.3.0** | PR #100 适配 + #146 三缺陷修复（识别/静默截断/递归） |
| psocbak 内嵌 ota_update.sh | v1.3.3 → **v1.3.4** | #146 find -L 修复 |
| bmssm release.sh / build-deb 默认 | 2.3.1 → **2.3.3** | #145/#147 已发布 2.3.2/2.3.3（手工传参构建），默认值未同步 |
| sophliteos | 2.2.0 → **2.2.1** | #144 修改 postinst 与构建脚本（deb 内容已变） |
| pSophUI deb | 1.6.8 → **1.6.9** | #130 review 修复 C++ 逻辑 |

## 已正确升版的（无需处理）

get_info 1.5.1（#124/#134/#141/#148）、pota_update ota.sh v1.5.1（#133/#143）、memory_edit 2.12.1 / pqt_memory_edit V2.12.2（#139）

## 说明

- psoph_phytool / pmem_aging_test 无版本号机制、pbm_set_ip 零改动——不适用
- 均通过 bash -n 语法检查

🤖 Generated with [Claude Code](https://claude.com/claude-code)