### PR TITLE
fix(build): 版本号单一权威化——工具代码内定义，根 release 禁止传版本号

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -11,7 +11,6 @@
 # 统一接口 (M1 规范 v0.1):
 #   bash release.sh [ARCH] [VERSION]
 #     ARCH:    arm64 | amd64 | all（默认按子项目）
-#     VERSION: 显式版本号（缺省用子项目版本来源）
 #     env OUTPUT_DIR: 覆盖产物目录（默认 <repo>/output/<子项目>/）
 #
 # 范围: 16 个子项目（pmulti_video_qt 已按 MYSWY 决定排除）
@@ -21,7 +20,6 @@
 #   bash docker/build-all.sh --project pbmssm   # 只构建指定子项目
 #   bash docker/build-all.sh --arch arm64       # 只构建指定架构
 #   bash docker/build-all.sh --image sophon-tools-build:unified
-#   bash docker/build-all.sh --version 2.1.0    # 统一显式版本号（透传给所有 release.sh）
 #   bash docker/build-all.sh --list             # 列出子项目与平台
 #
 # 产物: 全部汇聚到仓库根 output/<子项目>/ (与根 release.sh 一致)
@@ -44,14 +42,12 @@ if [[ -z "${IMAGE:-}" ]]; then
 fi
 ONLY_PROJECT=""
 ONLY_ARCH=""
-BUILD_VERSION=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) ONLY_PROJECT="$2"; shift 2; continue ;;
     --arch) ONLY_ARCH="$2"; shift 2; continue ;;
     --image) IMAGE="$2"; shift 2; continue ;;
-    --version) BUILD_VERSION="$2"; shift 2; continue ;;
     --list) LIST_ONLY=1 ;;
     -h|--help) grep -E '^#' "$0" | sed 's/^# \{0,1\}//' | head -40; exit 0 ;;
     *) echo "未知参数: $1" >&2; exit 1 ;;
@@ -160,8 +156,10 @@ run_one() {
       git config --global --add safe.directory '*' 2>/dev/null || true
       git config --global --add safe.directory /workspace/sophon-tools 2>/dev/null || true
       ${extra_env}
-      echo '  >> bash release.sh ${arch} ${BUILD_VERSION}'
-      bash release.sh ${arch} ${BUILD_VERSION} 2>&1 | tail -20
+      # 版本号规范：各子项目 release.sh 自行从工具代码提取默认版本（build/version.sh
+#      的 DEFAULT_VERSION 等），统一入口禁止传版本号（MYSWY 规范 2026-08-27）。
+      echo '  >> bash release.sh ${arch}'
+      bash release.sh ${arch} 2>&1 | tail -20
     " 2>&1 | sed 's/^/    /'
   rc=${PIPESTATUS[0]}
   echo "  [${p}] 退出码: ${rc}"

--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@
 # sophon-tools 一键全量 release（M4 统一入口 / M5 单镜像；各子项目默认平台）
 #
 # 用法:
-#   bash release.sh [--project <子项目>] [--version <版本号>] [--no-image-check]
+#   bash release.sh [--project <子项目>] [--no-image-check]
 #
 # 行为:
 #   1. 检查统一构建镜像 sophon-tools-build:unified（M5 单镜像, ubuntu:20.04 基座）
@@ -41,7 +41,6 @@ ARGS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) ARGS+=(--project "$2"); shift 2; continue ;;
-    --version) ARGS+=(--version "$2"); shift 2; continue ;;
     --image) IMAGE="$2"; shift 2; continue ;;
     --no-image-check) NO_IMAGE_CHECK=1; shift ;;
     -h|--help)

--- a/source/pSophUI/release.sh
+++ b/source/pSophUI/release.sh
@@ -19,8 +19,11 @@ ARCH="${1:-arm64}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pSophUI}"
 
 # 版本号默认从 deb control 提取（sophgo-hdmi_1.6.8_arm64.deb）
+# 版本唯一来源：deb control（工具侧代码）。提取失败直接报错，不做硬编码兜底（防漂移）。
 VERSION="${2:-$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$SCRIPT_DIR/SophUI/deb/DEBIAN/control" 2>/dev/null | head -1)}"
-VERSION="${VERSION:-1.6.8}"
+if [ -z "$VERSION" ]; then
+  echo "ERROR: 无法从 SophUI/deb/DEBIAN/control 提取版本号" >&2; exit 1
+fi
 
 QT_CROSS_PREFIX="${QT_CROSS_PREFIX:-/env/qt_5.12.8_nosysroot}"
 # 交叉编译器: 默认用系统 aarch64-linux-gnu-gcc（apt, GCC 9.4），替代原 Linaro GCC 6.3

--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # bmssm .deb 打包：交叉编译 arm64 静态二进制 + 组装 deb 数据树 + dpkg-deb。
 # 用法: bash build/build-deb-bmssm.sh [VERSION] [ARCH] [REASONIX_BIN]
-#   VERSION      默认 2.3.3（与 build/version.sh 一致）
+#   VERSION      默认从 version.sh DEFAULT_VERSION 提取
 #   ARCH         默认 arm64（设备）；amd64 用于 PCIE/开发机
 #   REASONIX_BIN 可选：reasonix arm64 二进制路径。提供则把 Reasonix 一并嵌入 deb，
 #               安装到 /opt/sophon/reasonix/bin/reasonix，并在 bmssm.yaml 里把
@@ -16,7 +16,8 @@
 set -e
 
 cd "$(dirname "$0")/.."
-VERSION="${1:-2.3.3}"
+# 版本默认值从 version.sh 的 DEFAULT_VERSION（唯一权威）提取，禁止在此硬编码
+VERSION="${1:-$(grep -oE '^DEFAULT_VERSION="[^"]+"' "$(dirname "$0")/version.sh" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')}"
 VERSION="${VERSION//\//-}"
 ARCH="${2:-arm64}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 # 生成版本头信息，写入 build/version.txt 供 ldflags 读取
+# DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
+# 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-VERSION="${1:-2.3.1}"
+DEFAULT_VERSION="2.3.3"
+VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"
 cat > "$(dirname "$0")/version.txt" <<EOF

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -2,7 +2,7 @@
 # pbmssm 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION] [REASONIX_BIN]
 #   ARCH:          arm64 | amd64 | all（默认 arm64）
-#   VERSION:       显式版本号（默认 2.3.1，与 build/version.sh 一致）
+#   VERSION:       显式版本号（默认从 build/version.sh DEFAULT_VERSION 提取）
 #   REASONIX_BIN:  可选 reasonix arm64 二进制路径；与 build-deb-bmssm.sh 语义一致，
 #                  传入则把 Reasonix 一并打进 deb。
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbmssm/）
@@ -12,7 +12,8 @@ SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 cd "$SCRIPT_DIR"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-2.3.3}"
+# 版本默认值从 build/version.sh 的 DEFAULT_VERSION（唯一权威）提取，禁止在此硬编码
+VERSION="${2:-$(grep -oE '^DEFAULT_VERSION="[^"]+"' "$SCRIPT_DIR/build/version.sh" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')}"
 REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pbmssm}"
 

--- a/source/psophliteos/build/build-deb-sophliteos.sh
+++ b/source/psophliteos/build/build-deb-sophliteos.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # sophliteos .deb 打包（docker-free）：pnpm 前端 + go 交叉编译（前端 go:embed 内嵌）+ dpkg-deb。
 # 用法: bash build/build-deb-sophliteos.sh [VERSION] [soc|pcie]
-#   VERSION 默认 2.2.1
+#   VERSION 默认从 build/version.sh DEFAULT_VERSION 提取
 #   soc=arm64（设备，默认）；pcie=amd64（开发机）
 # 产物: release/sophliteos_<PRODUCT>_<VERSION>.deb（单文件二进制，前端内嵌）
 #
@@ -12,7 +12,8 @@
 set -e
 
 cd "$(dirname "$0")/.."
-VERSION="${1:-2.2.1}"
+# 版本默认值从 version.sh 的 DEFAULT_VERSION（唯一权威）提取，禁止在此硬编码
+VERSION="${1:-$(grep -oE '^DEFAULT_VERSION="[^"]+"' "$(dirname "$0")/version.sh" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')}"
 PRODUCT="${2:-soc}"
 if [ "$PRODUCT" != "soc" ] && [ "$PRODUCT" != "pcie" ]; then
   echo "PRODUCT 必须是 soc 或 pcie" >&2; exit 1

--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
+# 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
+DEFAULT_VERSION="2.2.1"
+
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。
 

--- a/source/psophliteos/release.sh
+++ b/source/psophliteos/release.sh
@@ -2,7 +2,7 @@
 # psophliteos 统一构建接口 (M1 规范 v0.1)
 # 用法: bash release.sh [ARCH] [VERSION]
 #   ARCH:    arm64(soc) | amd64(pcie) | all（默认 arm64）
-#   VERSION: 显式版本号（默认 2.2.1，与 build/version.sh 一致）
+#   VERSION: 显式版本号（默认从 build/version.sh DEFAULT_VERSION 提取）
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/psophliteos/）
 # 产物: sophliteos_soc_<ver>.deb + sophliteos_pcie_<ver>.deb（单文件二进制，前端 go:embed 内嵌）
 set -euo pipefail
@@ -10,7 +10,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
-VERSION="${2:-2.2.1}"
+# 版本默认值从 build/version.sh 的 DEFAULT_VERSION（唯一权威）提取，禁止在此硬编码
+VERSION="${2:-$(grep -oE '^DEFAULT_VERSION="[^"]+"' "$SCRIPT_DIR/build/version.sh" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')}"
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/psophliteos}"
 
 case "$ARCH" in


### PR DESCRIPTION
## 规范

版本号在工具自己的代码中更新；仓库根 `release.sh` 禁止把版本号传进构建链。

## 问题

bmssm / sophliteos 的版本默认值硬编码在各自 `release.sh` 参数里（`${2:-2.3.x}`），与代码侧 `build/version.sh` 的默认值**双份定义会漂移**——PR #149 审计时 bmssm 已漂移（release.sh 2.3.1 vs 实发 2.3.3 手工传参）。其余子项目（get_info/pota_update/psocbak/pqt_*/pSophUI 等）本就遵循"从工具代码提取默认值"模式。

## 变更

| 位置 | 改动 |
|---|---|
| `source/pbmssm/build/version.sh` | 新增 `DEFAULT_VERSION="2.3.3"` 唯一权威定义 |
| `source/pbmssm/{release.sh,build/build-deb-bmssm.sh}` | 默认值改为从 version.sh 提取（grep，与仓库既有模式一致） |
| `source/psophliteos/build/version.sh` | 新增 `DEFAULT_VERSION="2.2.1"` 唯一权威定义 |
| `source/psophliteos/{release.sh,build/build-deb-sophliteos.sh}` | 同上提取 |
| `source/pSophUI/release.sh` | 删除冗余硬编码兜底 `${VERSION:-1.6.8}`，control 提取失败直接报错 |
| 根 `release.sh` | 删除 `--version` 参数 |
| `docker/build-all.sh` | 删除 `--version`/`BUILD_VERSION` 透传，子项目调用改为 `bash release.sh <arch>` |

子项目 release.sh 的显式版本参数接口保留（本地调试可覆盖），但统一构建链不再传。

## 验证

- bmssm 无版本参数构建 → `bmssm_2.3.3_arm64_*.deb`（走 version.sh DEFAULT_VERSION）✅
- sophliteos 无版本参数构建 → `sophliteos_soc_2.2.1.deb` ✅
- 根入口 `bash release.sh --version 1.0.0` → `未知参数: --version` ✅
- 全部改动脚本 bash -n 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)