### PR TITLE
feat(bmssm/sophliteos): CV84X6 官方规格落地——算力 64T/32/2、显示名 CV84X6、CPU 规格（bmssm 2.3.4 / sophliteos 2.2.3）

### DIFF
--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.3"
+DEFAULT_VERSION="2.3.4"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/pbmssm/mvc/compat/service.go
+++ b/source/pbmssm/mvc/compat/service.go
@@ -314,8 +314,10 @@ func (s *CompatService) BuildCtrlResource() []CtrlResource {
 							Memory:                  tpuMem,
 							CalculationCapacity:     calcCapacity,
 							CalculationCapacityInt8: calcCapacity,
-							CalculationCapacityFp16: calcCapacity / 4,
-							CalculationCapacityFp32: calcCapacity / 8,
+							// cv84x6 用官方规格（FP16/BF16 32 TFLOPS、FP32 2 TFLOPS）；
+							// 其余芯片沿用 /4 /8 派生（历史行为）
+							CalculationCapacityFp16: metrics.Fp16Capacity(global.ModuleType, calcCapacity),
+							CalculationCapacityFp32: metrics.Fp32Capacity(global.ModuleType, calcCapacity),
 							ChipType:                chipType,
 						},
 					},

--- a/source/pbmssm/pkg/device/devinfo.go
+++ b/source/pbmssm/pkg/device/devinfo.go
@@ -36,12 +36,12 @@ const (
 	CTRLShell2    = "/root/se_ctrl/sectr.sh"
 )
 
-// CV84X2 产品命名（一处定义，sophliteos 前端透传消费，不重复造映射）。
+// CV84X6 产品命名（一处定义，sophliteos 前端透传消费，不重复造映射）。
 // CV84X2 与 CV84X6 是同一芯片的不同称呼：SDK/内核侧标识为 cv84x6，
-// 对外产品命名（芯片名称/设备型号）统一显示 CV84X2 / SE13。
+// 对外芯片名称统一显示 CV84X6（2026-08-27 MYSWY 指示），设备型号默认 SE13。
 const (
 	CpuModelCv84x6  = "cv84x6" // SDK 标识（/proc/cpuinfo model name，经 CPU part 0xd05 修正）
-	ChipNameCv84x2  = "CV84X2" // 芯片对外显示名（cv84x6 → CV84X2）
+	ChipNameCv84x6  = "CV84X6" // 芯片对外显示名（cv84x6 → CV84X6，2026-08-27 统一用 CV84X6）
 	DeviceModelSE13 = "SE13"   // CV84X2 单板默认设备型号
 )
 
@@ -317,7 +317,7 @@ func applyCv84x6Fallback(cpuinfo, boot1 string) {
 		}
 	}
 	if ModuleType == "" {
-		ModuleType = ChipNameCv84x2
+		ModuleType = ChipNameCv84x6
 	}
 	if ChipSn == "" || DeviceSnEx == "" {
 		readSnFromRawWithPaths(cpuinfo, boot1, NvmemSnPath)

--- a/source/pbmssm/pkg/device/devinfo_test.go
+++ b/source/pbmssm/pkg/device/devinfo_test.go
@@ -543,7 +543,7 @@ func TestApplyCv84x6FallbackSE13Default(t *testing.T) {
 	if DeviceTypeEx != "SE13" {
 		t.Errorf("DeviceTypeEx=%q, want SE13", DeviceTypeEx)
 	}
-	if ModuleType != "CV84X2" {
+	if ModuleType != "CV84X6" {
 		t.Errorf("ModuleType=%q, want CV84X2", ModuleType)
 	}
 	if ModuleTypeEx != "" {

--- a/source/pbmssm/pkg/metrics/chip_capacity.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity.go
@@ -8,7 +8,7 @@ import "strings"
 //
 //	BM1684X (0x1686)      → 32 TOPS, chipType 2
 //	BM1688  (0x1688)      → 16 TOPS, chipType 3
-//	CV84X6/CV84X2 (0x1694) → 16 TOPS, chipType 3  (占位，对齐 BM1688 档位；真机确认后修正)
+//	CV84X6/CV84X2 (0x1694) → 64 TOPS, chipType 3  (官方规格表 2026-08-27：INT8/FP8 64 TOPS)
 //	BM1684  (non-X)       → 16 TOPS, chipType 1
 //	unknown / empty       → 16 TOPS, chipType 1  (bmssm default branch)
 //
@@ -17,8 +17,8 @@ func ChipCapacity(chipModel string) (calcCapacity float64, chipType int) {
 	upper := strings.ToUpper(chipModel)
 	switch {
 	case strings.Contains(upper, "84X6"), strings.Contains(upper, "84X2"):
-		// CV84X2 与 CV84X6 为同一芯片的不同称呼，同一档位
-		return 16, 3
+		// CV84X2 与 CV84X6 为同一芯片的不同称呼；官方规格：INT8/FP8 64 TOPS（此前 16 为占位值）
+		return 64, 3
 	case strings.Contains(upper, "1686") || strings.Contains(upper, "1684X"):
 		return 32, 2
 	case strings.Contains(upper, "1688"):
@@ -28,4 +28,24 @@ func ChipCapacity(chipModel string) (calcCapacity float64, chipType int) {
 	default:
 		return 16, 1
 	}
+}
+
+// Fp16Capacity FP16/BF16 算力（TFLOPS）。cv84x6 用官方规格 32；
+// 其余芯片沿用历史派生（INT8/4）。
+func Fp16Capacity(chipModel string, calcCapacity float64) float64 {
+	upper := strings.ToUpper(chipModel)
+	if strings.Contains(upper, "84X6") || strings.Contains(upper, "84X2") {
+		return 32
+	}
+	return calcCapacity / 4
+}
+
+// Fp32Capacity FP32 算力（TFLOPS）。cv84x6 用官方规格 2；
+// 其余芯片沿用历史派生（INT8/8）。
+func Fp32Capacity(chipModel string, calcCapacity float64) float64 {
+	upper := strings.ToUpper(chipModel)
+	if strings.Contains(upper, "84X6") || strings.Contains(upper, "84X2") {
+		return 2
+	}
+	return calcCapacity / 8
 }

--- a/source/pbmssm/pkg/metrics/chip_capacity_test.go
+++ b/source/pbmssm/pkg/metrics/chip_capacity_test.go
@@ -72,32 +72,32 @@ func TestChipCapacity(t *testing.T) {
 		{
 			name:             "CV84X6",
 			chipModel:        "CV84X6",
-			wantCalcCapacity: 16,
+			wantCalcCapacity: 64,
 			wantChipType:     3,
 		},
 		{
 			name:             "lowercase cv84x6",
 			chipModel:        "cv84x6",
-			wantCalcCapacity: 16,
+			wantCalcCapacity: 64,
 			wantChipType:     3,
 		},
 		{
 			name:             "84X6 substring",
 			chipModel:        "CV84X6-PROD",
-			wantCalcCapacity: 16,
+			wantCalcCapacity: 64,
 			wantChipType:     3,
 		},
 		{
 			// CV84X2 与 CV84X6 为同一芯片的不同称呼（设备侧命名链输出 CV84X2）
 			name:             "CV84X2 (display name)",
 			chipModel:        "CV84X2",
-			wantCalcCapacity: 16,
+			wantCalcCapacity: 64,
 			wantChipType:     3,
 		},
 		{
 			name:             "lowercase cv84x2",
 			chipModel:        "cv84x2",
-			wantCalcCapacity: 16,
+			wantCalcCapacity: 64,
 			wantChipType:     3,
 		},
 	}
@@ -112,5 +112,21 @@ func TestChipCapacity(t *testing.T) {
 				t.Errorf("ChipCapacity(%q) chipType = %d, want %d", tt.chipModel, gotType, tt.wantChipType)
 			}
 		})
+	}
+}
+
+// TestFpCapacityCv84x6 官方规格：cv84x6 FP16=32、FP32=2；其他芯片走 /4 /8 派生。
+func TestFpCapacityCv84x6(t *testing.T) {
+	if got := Fp16Capacity("cv84x6", 64); got != 32 {
+		t.Errorf("Fp16Capacity(cv84x6) = %v, want 32", got)
+	}
+	if got := Fp32Capacity("cv84x6", 64); got != 2 {
+		t.Errorf("Fp32Capacity(cv84x6) = %v, want 2", got)
+	}
+	if got := Fp16Capacity("BM1684X", 32); got != 8 {
+		t.Errorf("Fp16Capacity(BM1684X) = %v, want 8 (历史派生 /4)", got)
+	}
+	if got := Fp32Capacity("bm1688", 16); got != 2 {
+		t.Errorf("Fp32Capacity(bm1688) = %v, want 2 (历史派生 /8)", got)
 	}
 }

--- a/source/pbmssm/pkg/metrics/ion_memory_test.go
+++ b/source/pbmssm/pkg/metrics/ion_memory_test.go
@@ -97,7 +97,7 @@ func TestChipTypePartD05Override(t *testing.T) {
 // 其余芯片大写。空串保持空串（前端显示 '-'）。
 func TestChipDisplayName(t *testing.T) {
 	cases := []struct{ chip, want string }{
-		{"cv84x6", "CV84X2"},
+		{"cv84x6", "CV84X6"},
 		{"bm1684x", "BM1684X"},
 		{"bm1688", "BM1688"},
 		{"cv186ah", "CV186AH"},
@@ -330,7 +330,7 @@ func TestMemoryLayoutCv84x6(t *testing.T) {
 	c := NewCollector(fr, nil)
 	lay := c.MemoryLayout()
 
-	if lay.ChipType != "CV84X2" {
+	if lay.ChipType != "CV84X6" {
 		t.Fatalf("ChipType = %q, want CV84X2 (显示名)", lay.ChipType)
 	}
 	if !approxEqual(lay.TPU.TotalMB, 1536, 0.01) {

--- a/source/pbmssm/pkg/metrics/memory_layout.go
+++ b/source/pbmssm/pkg/metrics/memory_layout.go
@@ -2,13 +2,13 @@ package metrics
 
 import "strings"
 
-// ChipDisplayName 芯片对外显示名（SE13/CV84X2 产品命名，一处定义：
+// ChipDisplayName 芯片对外显示名（SE13 产品命名，一处定义：
 // sophliteos 前端透传 memoryLayout.chipType 显示"芯片名称"，不重复造映射）。
-// cv84x6（SDK/内核标识）对外显示 CV84X2——CV84X2 与 CV84X6 是同一芯片的不同称呼；
+// cv84x6（SDK/内核标识）对外显示 CV84X6（2026-08-27 MYSWY 指示：型号名称统一用 CV84X6）；
 // 其余芯片显示大写型号（bm1684x → BM1684X）。
 func ChipDisplayName(chip string) string {
 	if chip == "cv84x6" {
-		return "CV84X2"
+		return "CV84X6"
 	}
 	return strings.ToUpper(chip)
 }

--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.2"
+DEFAULT_VERSION="2.2.3"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/frontend/src/store/modules/overview.ts
+++ b/source/psophliteos/frontend/src/store/modules/overview.ts
@@ -162,7 +162,12 @@ export const useDeviceInfo = defineStore({
               desc: 'FP32',
             };
           } else if (key === 'cpuCount') {
-            this.deviceInfo[key] = { total: cpuInfo?.cores ?? 0, desc: cpuInfo?.type ?? '' };
+            // CV84X6 家族显示官方规格（Cortex-A55@2.5GHz），其余芯片保持原 desc
+            const cv84x6 = `${cpuInfo?.type || ''}`.toLowerCase().includes('84x6');
+            this.deviceInfo[key] = {
+              total: cpuInfo?.cores ?? 0,
+              desc: cv84x6 ? 'Cortex-A55@2.5GHz' : cpuInfo?.type ?? '',
+            };
           } else if (key === 'memoryCount') {
             this.deviceInfo[key] = { total: memory?.total ?? 0, unit: 'MB' };
           } else if (key === 'eMMCCount') {

--- a/source/psophliteos/frontend/src/views/maintenance/metricsForward/index.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/metricsForward/index.vue
@@ -154,7 +154,7 @@
 
   const promConfig = computed(
     () => `scrape_configs:
-  - job_name: "cv84x2-se13"
+  - job_name: "cv84x6-se13"
     metrics_path: /metrics
     authorization:
       credentials: ${token.value}

--- a/source/psophliteos/frontend/src/views/overview/detail-se5.vue
+++ b/source/psophliteos/frontend/src/views/overview/detail-se5.vue
@@ -161,11 +161,17 @@
 
   const cpuCard = computed(() => {
     const cpu = originData.value.cpu || {};
+    // CV84X6 家族显示官方规格（规格表：8核 Cortex-A55@2.5GHz）；EVB 实际运行
+    // clk_ap_ca55=2GHz，规格与实测的差异属正常（规格为芯片能力标称值）
+    const isCv84x6 = `${cpu.type || ''}`.toLowerCase().includes('84x6');
+    const specText = `${cpu.cores ?? 0}${t('overview.core')} Cortex-A55@2.5GHz`;
     return {
       usage: +(cpu.utilizationRate ?? cpu.usage ?? 0).toFixed(1),
-      text: `${cpu.cores ?? 0}${t('overview.core')}${
-        cpu.frequency ? (cpu.frequency / 1000).toFixed(1) : 0
-      }GHz`,
+      text: isCv84x6
+        ? specText
+        : `${cpu.cores ?? 0}${t('overview.core')}${
+            cpu.frequency ? (cpu.frequency / 1000).toFixed(1) : 0
+          }GHz`,
     };
   });
 
@@ -200,7 +206,7 @@
     return list.join('、');
   };
 
-  // 芯片名称：bmssm 侧命名链（cv84x6 → 展示名 CV84X2）在 memoryLayout.chipType 输出，
+  // 芯片名称：bmssm 侧命名链（cv84x6 → 展示名 CV84X6）在 memoryLayout.chipType 输出，
   // 前端透传显示；取不到时显示 '-'（空值容忍，不影响其它芯片展示）。
   const chipName = computed(
     () => originData.value?.memoryLayout?.chipType || '-',


### PR DESCRIPTION
## 依据

CV84X6 官方规格表（MYSWY 2026-08-27 提供）：**INT8/FP8 64 TOPS**、FP16/BF16 32 TFLOPS、FP32 2 TFLOPS、CPU 8核 Cortex-A55。

## bmssm 2.3.4

| 项 | 旧值 | 新值 |
|---|---|---|
| INT8 算力 | 16 TOPS（占位，对齐 BM1688） | **64 TOPS**（官方规格） |
| FP16 / FP32 | 4 / 2（/4 /8 派生） | **32 / 2**（官方规格，其余芯片保持派生） |
| 芯片显示名 | CV84X2 | **CV84X6**（ChipDisplayName 与 ChipNameCv84x6 两处权威定义） |

显示名变更同步生效于：healthz `moduleType`、API `memoryLayout.chipType`、Prometheus `chip_type` 标签。

## sophliteos 2.2.3

- 概览 CPU 卡片与 CPU 能力行：cv84x6 家族显示官方规格 **"8核 Cortex-A55@2.5GHz"**（EVB 实测 clk_ap_ca55=2GHz 为运行值，规格为标称值——前端注释已说明）
- 指标转发页 Prometheus 配置示例 job 名同步 `cv84x6-se13`

## 验证（真机 10.42.0.123，已部署）

- healthz：`moduleType=CV84X6`
- API：INT8=64 / FP16=32 / FP32=2，chipType=CV84X6
- Web 概览页：CPU 卡片"8核 Cortex-A55@2.5GHz"、TPU 卡片"INT8 64TOPS"、芯片名称 CV84X6（1080P 截图留档）
- 13.24 Prometheus `chip_type` 标签与 Grafana 仪表盘标题同步 CV84X6
- go test 全绿

⚠️ 待确认：CPU 主频规格表显示 **2.6GHz**，本次按指示文本采用 2.5GHz——如以规格表为准请告知，改一行即可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)