### PR TITLE
fix(sophliteos): CPU 规格主频 2.5→2.6GHz（以官方规格表为准，v2.2.4）

### DIFF
--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.3"
+DEFAULT_VERSION="2.2.4"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/frontend/src/store/modules/overview.ts
+++ b/source/psophliteos/frontend/src/store/modules/overview.ts
@@ -162,11 +162,11 @@ export const useDeviceInfo = defineStore({
               desc: 'FP32',
             };
           } else if (key === 'cpuCount') {
-            // CV84X6 家族显示官方规格（Cortex-A55@2.5GHz），其余芯片保持原 desc
+            // CV84X6 家族显示官方规格（Cortex-A55@2.6GHz），其余芯片保持原 desc
             const cv84x6 = `${cpuInfo?.type || ''}`.toLowerCase().includes('84x6');
             this.deviceInfo[key] = {
               total: cpuInfo?.cores ?? 0,
-              desc: cv84x6 ? 'Cortex-A55@2.5GHz' : cpuInfo?.type ?? '',
+              desc: cv84x6 ? 'Cortex-A55@2.6GHz' : cpuInfo?.type ?? '',
             };
           } else if (key === 'memoryCount') {
             this.deviceInfo[key] = { total: memory?.total ?? 0, unit: 'MB' };

--- a/source/psophliteos/frontend/src/views/overview/detail-se5.vue
+++ b/source/psophliteos/frontend/src/views/overview/detail-se5.vue
@@ -161,10 +161,10 @@
 
   const cpuCard = computed(() => {
     const cpu = originData.value.cpu || {};
-    // CV84X6 家族显示官方规格（规格表：8核 Cortex-A55@2.5GHz）；EVB 实际运行
+    // CV84X6 家族显示官方规格（规格表：8核 Cortex-A55@2.6GHz）；EVB 实际运行
     // clk_ap_ca55=2GHz，规格与实测的差异属正常（规格为芯片能力标称值）
     const isCv84x6 = `${cpu.type || ''}`.toLowerCase().includes('84x6');
-    const specText = `${cpu.cores ?? 0}${t('overview.core')} Cortex-A55@2.5GHz`;
+    const specText = `${cpu.cores ?? 0}${t('overview.core')} Cortex-A55@2.6GHz`;
     return {
       usage: +(cpu.utilizationRate ?? cpu.usage ?? 0).toFixed(1),
       text: isCv84x6


### PR DESCRIPTION
MYSWY 确认规格表主频为 **2.6GHz**（PR #152 按指示文本暂用 2.5）。真机已部署验证：概览页 CPU 卡片显示 **8核 Cortex-A55@2.6GHz**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)