### PR TITLE
fix(bmssm): reasonix 默认内嵌入 deb 包（2.3.5）

### DIFF
--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.4"
+DEFAULT_VERSION="2.3.5"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/pbmssm/release.sh
+++ b/source/pbmssm/release.sh
@@ -3,8 +3,9 @@
 # 用法: bash release.sh [ARCH] [VERSION] [REASONIX_BIN]
 #   ARCH:          arm64 | amd64 | all（默认 arm64）
 #   VERSION:       显式版本号（默认从 build/version.sh DEFAULT_VERSION 提取）
-#   REASONIX_BIN:  可选 reasonix arm64 二进制路径；与 build-deb-bmssm.sh 语义一致，
-#                  传入则把 Reasonix 一并打进 deb。
+#   REASONIX_BIN:  reasonix arm64 二进制路径。不传（或未设 env）时默认取
+#                  build/reasonix/bin/ 下的仓库内置版本（bmssm 包必须内置
+#                  reasonix——MYSWY 要求）；显式传第 3 个参数（含空串 ""）可跳过/覆盖。
 #   env OUTPUT_DIR: 产物目录（默认 <repo>/output/pbmssm/）
 set -euo pipefail
 
@@ -14,7 +15,18 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 ARCH="${1:-arm64}"
 # 版本默认值从 build/version.sh 的 DEFAULT_VERSION（唯一权威）提取，禁止在此硬编码
 VERSION="${2:-$(grep -oE '^DEFAULT_VERSION="[^"]+"' "$SCRIPT_DIR/build/version.sh" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')}"
-REASONIX_BIN="${3:-${REASONIX_BIN:-}}"
+# Reasonix 内嵌默认：仓库内置二进制（build/reasonix/bin/），存在即内嵌；
+# 第 3 个参数显式提供（含空串跳过）时不自动探测。此前默认不传导致 deb 无
+# reasonix 二进制，真机 Agent 服务开关报 "executable file not found in $PATH"
+# （2026-08-27 复现）。
+if [ $# -ge 3 ]; then
+  REASONIX_BIN="$3" # 显式传参（含空串 "" 跳过内嵌）优先
+elif [ -z "${REASONIX_BIN:-}" ]; then
+  for _f in "$SCRIPT_DIR"/build/reasonix/bin/reasonix-arm64*; do
+    [ -f "$_f" ] && REASONIX_BIN="$_f" && break
+  done
+fi
+unset _f
 OUTPUT_DIR="${OUTPUT_DIR:-$REPO_ROOT/output/pbmssm}"
 
 case "$ARCH" in


### PR DESCRIPTION
## 问题

真机（CV84X6/SE13，10.42.0.123）Web「Agent 服务管理」开启服务开关报错：

```
start reasonix acp: exec: 'reasonix': executable file not found in $PATH
```

## 根因

`release.sh` 的 `REASONIX_BIN` 是可选第 3 参数，默认不传 → 构建出的 deb 只包含
reasonix 配置目录（`/data/sophon/reasonix-home/`：config.toml / 技能 / se-rag），
不含二进制。bmssm 启动 agentproxy 时按 `binaryPath` 找不到可执行文件。

此前用户已要求 bmssm 包内置 reasonix，但构建入口未默认启用，历次
`bash release.sh arm64` 均产出无二进制的包。

## 修复

- `release.sh`：不传第 3 参数且未设 env 时，自动探测 `build/reasonix/bin/`
  下的仓库内置 arm64 二进制（`reasonix-arm64-v1.25.0-f32534ad`）打入 deb；
  显式传参（含空串 `""`）仍可跳过/覆盖。
- `build/version.sh`：`DEFAULT_VERSION` 2.3.4 → 2.3.5（版本号唯一权威在工具代码内，
  根 release 不传版本）。

## 验证（真机 10.42.0.123，bmssm 2.3.5）

1. `dpkg -i bmssm_2.3.5_arm64_se7.deb` 后：
   - `/opt/sophon/reasonix/bin/reasonix` 落位（37.5MB），`--version` 输出正常
   - `bmssm.yaml` `agentproxy.binaryPath` 指向该路径
   - `systemctl is-active bmssm` = active，`/healthz` 返回 SE13/CV84X6/2.3.5
2. Web「Agent 配置 → Agent 服务管理」开启服务开关：
   - `reasonix acp` 进程成功拉起（pgrep 确认）
   - journalctl：`agentproxy: initialize ok protocolVersion=1`
   - 页面状态由「已停止」变「运行中」，无报错
3. 单测：`go test ./...` 仅环境性失败（容器缺 `ip` 命令影响 compat/network 包）与
   一次偶发归档测试（复跑通过）；本 PR 不含 Go 代码改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
