### PR TITLE
feat(bmssm): reasonix 嵌入前自动 strip 去 debug 信息（2.3.6）

### DIFF
--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -4,7 +4,8 @@
 #   VERSION      默认从 version.sh DEFAULT_VERSION 提取
 #   ARCH         默认 arm64（设备）；amd64 用于 PCIE/开发机
 #   REASONIX_BIN 可选：reasonix arm64 二进制路径。提供则把 Reasonix 一并嵌入 deb，
-#               安装到 /opt/sophon/reasonix/bin/reasonix，并在 bmssm.yaml 里把
+#               安装到 /opt/sophon/reasonix/bin/reasonix（嵌入前自动 strip 去
+#               debug 信息减体积，MYSWY 要求 2026-08-27），并在 bmssm.yaml 里把
 #               agentproxy.binaryPath 指向它（出厂即带 AI Agent 后端）。
 #               省略则只打 bmssm（Reasonix 需后续单独部署）。
 #
@@ -63,6 +64,32 @@ assemble_deb() {
     mkdir -p "$DEBROOT/opt/sophon/reasonix/bin"
     cp "$REASONIX_BIN" "$DEBROOT/opt/sophon/reasonix/bin/reasonix"
     chmod 0755 "$DEBROOT/opt/sophon/reasonix/bin/reasonix"
+    # 去 debug 信息减体积（MYSWY 要求，2026-08-27）：对 deb 树内副本 strip，
+    # 不动源文件（可能是 git 跟踪的内置二进制）；已 stripped 的输入幂等无害。
+    # 与 build-bmssm-arm64.sh 同款风格：交叉 strip 优先，失败降级警告不阻断。
+    strip_reasonix() {
+      local dest="$DEBROOT/opt/sophon/reasonix/bin/reasonix"
+      case "$ARCH" in
+        arm64) for c in aarch64-linux-musl-strip aarch64-linux-gnu-strip; do
+                 command -v "$c" >/dev/null 2>&1 && "$c" --strip-unneeded \
+                   --remove-section=.comment --remove-section=.note.go.buildid "$dest" \
+                   && return 0
+               done ;;
+        amd64) for c in x86_64-linux-gnu-strip strip llvm-strip; do
+                 command -v "$c" >/dev/null 2>&1 && "$c" --strip-unneeded \
+                   --remove-section=.comment --remove-section=.note.go.buildid "$dest" \
+                   && return 0
+               done ;;
+      esac
+      return 1
+    }
+    if [ -n "$REASONIX_BIN" ]; then RX_BEFORE_MB=$(( $(stat -c%s "$DEBROOT/opt/sophon/reasonix/bin/reasonix") / 1024 / 1024 )); fi
+    if strip_reasonix; then
+      RX_AFTER_MB=$(( $(stat -c%s "$DEBROOT/opt/sophon/reasonix/bin/reasonix") / 1024 / 1024 ))
+      echo "  ✓ [$suffix] reasonix strip: ${RX_BEFORE_MB}MB → ${RX_AFTER_MB}MB"
+    else
+      echo "  WARN: [$suffix] reasonix strip 未执行（无可用 strip 工具），保留原样" >&2
+    fi
     sed -i \
       -e 's|^  enabled: false.*|  enabled: true|' \
       -e "s|^  binaryPath: \"\".*|  binaryPath: \"/opt/sophon/reasonix/bin/reasonix\"|" \

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.5"
+DEFAULT_VERSION="2.3.6"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"


### PR DESCRIPTION
## 目的

reasonix 自动打进 deb 包（PR #154）后，再 strip 掉 debug 信息减小体积（MYSWY 要求）。

## 改动

`build/build-deb-bmssm.sh` 嵌入 reasonix 时（cp 进 deb 数据树后）自动 strip：

- 工具按 ARCH 选择：arm64 用 `aarch64-linux-musl-strip`（优先）→ `aarch64-linux-gnu-strip`；amd64 用 `x86_64-linux-gnu-strip` → `strip`/`llvm-strip`
- 参数与 bmssm 主二进制同款：`--strip-unneeded --remove-section=.comment --remove-section=.note.go.buildid`
- 在 deb 树内副本上操作，**不动源文件**（可能是 git 跟踪的内置二进制）
- strip 失败降级警告，不阻断构建；已 stripped 的输入幂等无害
- 构建日志输出 strip 前后体积（`✓ [_se7] reasonix strip: 35MB → 35MB`）

`build/version.sh`：DEFAULT_VERSION 2.3.5 → 2.3.6。

## 验证

| 输入 | strip 前 | strip 后 | 说明 |
|---|---|---|---|
| 带 DWARF 的 Go arm64 二进制（模拟外部新版本 reasonix） | 2237KB | 1514KB | -32% |
| 仓库内置 v1.25.0（已 stripped） | 35MB | 35MB | 幂等无害 |

真机（10.42.0.123，bmssm 2.3.6）：
1. `reasonix --version` 正常输出（strip 未破坏可执行性）
2. Web「Agent 服务管理」开启开关 → `reasonix acp` 进程拉起、journalctl `agentproxy: initialize ok`、页面「已停止」→「运行中」

注：当前仓库内置二进制本就是 stripped（38M 为 Go 静态二进制固有体积），本改动主要保证未来传入未 strip 的 reasonix（自行编译/外部下载）时体积可控。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
