### PR TITLE
fix(sophliteos): agent WS 改同源寻址，不再硬编码 8080 端口（2.2.5）

### DIFF
--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.4"
+DEFAULT_VERSION="2.2.5"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/frontend/src/api/aiAgent/ws.ts
+++ b/source/psophliteos/frontend/src/api/aiAgent/ws.ts
@@ -2,8 +2,9 @@
  * Reasonix WebSocket 客户端（sophliteos 原生接入，PicoWS 的 TS 移植）。
  *
  * 职责：
- *   - 建立与 Reasonix agentproxy 的 WS 连接：ws://<host>:8080/agent/ws
- *     （端口 8080 为 sophliteos 同源入口，/agent/ws 由 sophliteos 反向代理转发到 bmssm 主服务）
+ *   - 建立与 Reasonix agentproxy 的 WS 连接：同源 ws(s)://<当前页面host>/agent/ws
+ *     （默认同源入口，/agent/ws 由 sophliteos 反向代理转发到 bmssm 主服务；
+ *     经端口转发/反代访问时自动跟随实际入口端口，不固定 8080）
  *   - 用子协议 token.<forward_key> 认证（浏览器无法设 Header，对齐 agentproxy ws.go）
  *   - 发送 message.send / session.list / session.history，接收 message.create /
  *     message.update / typing.* / session.create / error 等帧
@@ -241,7 +242,17 @@ export class PicoWs {
   }
 }
 
-export function defaultReasonixWsUrl(hostname: string, port?: number): string {
+/**
+ * 构造 agent WS 地址。
+ * 不传参数：同源模式——跟随当前页面的协议与 host（含端口），经端口转发/反向代理
+ * 访问（如 socat 18080 引出）时 WS 与页面走同一入口，不再固定 8080。
+ * 传 hostname（兼容旧调用）：默认 8080 端口，可由 port 覆盖。
+ */
+export function defaultReasonixWsUrl(hostname?: string, port?: number): string {
+  if (!hostname && !port) {
+    const proto = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    return `${proto}://${window.location.host}${REASONIX_WS_PATH}`;
+  }
   const p = port || REASONIX_DEFAULT_PORT;
   return `ws://${hostname}:${p}${REASONIX_WS_PATH}`;
 }

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -1350,7 +1350,10 @@
       ws.close();
       ws = null;
     }
-    const url = defaultReasonixWsUrl(window.location.hostname);
+    // 同源：跟随当前访问的协议/host（含端口），经 socat 等端口转发访问时
+    // WS 与页面同一入口，不再固定 8080（此前 18080 引出访问时 WS 连
+    // <host>:8080 失败，页面一直"重连中"）。
+    const url = defaultReasonixWsUrl();
     ws = new PicoWs({
       url,
       token: forwardKey,

--- a/source/psophliteos/frontend/src/views/maintenance/metricsForward/index.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/metricsForward/index.vue
@@ -149,8 +149,9 @@
     sinceStart: '',
   });
 
-  // 本机 IP（页面同源访问设备），用于生成可直接复制的抓取配置
-  const host = computed(() => window.location.hostname || '<device-ip>');
+  // 本机 host（含端口，页面同源访问设备），用于生成可直接复制的抓取配置——
+  // 经端口转发/反代访问时跟随实际入口，不固定 8080
+  const host = computed(() => window.location.host || '<device-ip>:8080');
 
   const promConfig = computed(
     () => `scrape_configs:
@@ -159,7 +160,7 @@
     authorization:
       credentials: ${token.value}
     static_configs:
-      - targets: ["${host.value}:8080"]`,
+      - targets: ["${host.value}"]`,
   );
 
   function fmtTime(v: string) {


### PR DESCRIPTION
## 问题

经端口转发访问 sophliteos（如 13.24 用 socat 将设备 8080 引出为 18080）时，Agent 对话页一直显示「重连中」，控制台报：

```
WebSocket connection to 'ws://172.26.13.24:8080/agent/ws' failed
```

## 根因

`WebChat.vue` 用 `defaultReasonixWsUrl(window.location.hostname)` 构造 WS 地址——hostname 动态但**端口硬编码 8080**。转发入口是 18080 时，页面 HTTP 正常（同源加载），WS 却连到 `<host>:8080`（无监听）→ 持续重连。

## 修复（2.2.5）

1. **`api/aiAgent/ws.ts`**：`defaultReasonixWsUrl()` 支持无参同源模式——协议跟随页面（https→wss）、host 用 `window.location.host`（含端口），WS 与页面走同一入口；传 hostname 的旧调用保持兼容
2. **`WebChat.vue`**：建连改无参同源调用（对齐 terminal 页已有的 `${location.host}` 范式）
3. **`metricsForward/index.vue`**（顺带同款问题）：Prometheus 抓取配置示例 `host:8080` 拼死端口 → 改 `window.location.host`

## 验证

- 转发入口 `http://172.26.13.24:18080/#/ai-agent/agent`：WS 状态「重连中」→**「已连接」**
- 设备直连 8080 路径不受影响（同源 = 同一端口）
- 真机已部署 sophliteos 2.2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
