### PR TITLE
fix(sophliteos): agent 双回复——history 合并按 kind 归一化去重（v2.2.6）

### DIFF
--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.5"
+DEFAULT_VERSION="2.2.6"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -859,22 +859,18 @@
         open: false,
       });
     } else if (kind === 'thought') {
-      // 同一逻辑思考常被后端拆成多个 message.create（thought-1/thought-2）：
-      // 累积到当前打开的思考折叠块，避免同一段思考被拆成两个「思考过程」气泡。
+      // thought 分段独立成泡，不做跨 message_id 合并（MYS-774）：服务端
+      // RoundAssistants 落库时相邻 thought 不合并、按 message_id 各存一条；若前端
+      // 把 thought-2 续接到 thought-1 上，history 合并时本地合并版与落库的两条
+      // keyOf 均不匹配 → 该回合思考被重复渲染（合并泡 + 两泡落库版）。各自成泡后
+      // 本地与落库形态一致，mergeHistory 可正确去重（同一 message_id 的增量更新
+      // 走 handleUpdate 的 openThoughtKey 累积，不受影响）。
       const existing = messageId
         ? s.messages.find((m) => m.key === messageId && m.kind === 'thought')
         : null;
       if (existing) {
         existing.content = accumulate(existing.content, content);
         openThoughtKey = existing.key as string;
-      } else if (openThoughtKey) {
-        const target = s.messages.find((m) => m.key === openThoughtKey);
-        if (target && target.kind === 'thought') {
-          target.content += content;
-        } else {
-          openThoughtKey = null;
-          pushThought(messageId, content);
-        }
       } else {
         pushThought(messageId, content);
       }

--- a/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
+++ b/source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue
@@ -1086,7 +1086,16 @@
   // 重复存在），仅追加本地尚未被服务端覆盖的消息（在途流式内容、权限审批记录——
   // 服务端不回放 permission）。这样既不丢失历史，也不会因去重把不同轮次的相同内容合并掉。
   function mergeHistory(local: ChatMsg[], server: ChatMsg[]): ChatMsg[] {
-    const keyOf = (m: ChatMsg) => m.role + '|' + (m.kind || '') + '|' + (m.content || '');
+    // keyOf 对 assistant 纯文本做 kind 归一化（MYS-774）：本地流式 text 消息不存 kind
+    // （handleCreate 只记录 role/content），服务端 session.history 落库的 text 消息带
+    // kind='text'。若直接拼 kind，同一回复在「流式接收 + 回合结束 pullHistory 合并」时
+    // 会因 kind 不一致各保留一份 → 页面渲染出两条重复回复。归一化把 kind 为空或 text
+    // 的 assistant 消息视为同一类，新旧数据（含 localStorage 旧缓存）均可正确去重。
+    const keyOf = (m: ChatMsg) => {
+      let k = m.kind || '';
+      if (m.role === 'assistant' && (k === '' || k === 'text')) k = 'text';
+      return m.role + '|' + k + '|' + (m.content || '');
+    };
     const serverKeys = new Set(server.map(keyOf));
     return server.concat(local.filter((m) => !serverKeys.has(keyOf(m))));
   }


### PR DESCRIPTION
## 问题
sophliteos+bmssm 的 web agent 页面发送一条消息后出现**两个并行回答**（内容完全相同），后续每次提问都重复。

## 根因（两处数据形态不一致，均在 history 合并去重时暴露）

同一回复的流式接收形态与服务端落库形态不一致，`mergeHistory` 按 `role|kind|content` 做 key 去重时匹配不上，各保留一份 → 页面重复渲染：

1. **正式回复 text 重复**：本地流式 `text` 消息不含 `kind` 字段（`handleCreate` 只记 role/content），服务端 `session.history` 落库的 `text` 带 `kind='text'` → key 不匹配。
2. **思考过程重复（多一个合并块）**：前端 `handleCreate` 把不同 `message_id` 的 thought 段（thought-1/thought-2）续接到同一个折叠块；服务端 `RoundAssistants` 落库时相邻 thought 不合并、按 `message_id` 各存一条 → 本地「合并版」与落库几条均不匹配。

触发路径：回合结束 `session.busy=false`（wasBusy）→ 前端 `pullHistory` → `mergeHistory` 合并；或刷新页面后 localStorage 旧缓存 + 重连拉 history 同样触发。

## 修复
`WebChat.vue` 两处，均只改前端、不动服务端协议与历史数据结构：

1. `mergeHistory` 的 `keyOf` 对 assistant 纯文本做 kind 归一化（kind 为空或 `text` 视为同类），新旧数据（含 localStorage 旧缓存）均可正确去重；跨轮次同内容消息仍按原语义保留（server 自身不去重）。
2. `handleCreate` 的 thought 分支不再跨 `message_id` 合并（各自成泡）→ 本地与服务端落库形态一致，mergeHistory 去重生效；同一 `message_id` 的增量更新仍走 `handleUpdate` 的 openThoughtKey 累积，不受影响。

## 验证
- **真实浏览器闭环（10.42.0.123，bmssm 2.3.6 / sophliteos 2.2.6）**：修复前发「你好」→ 两份正文 + 三个思考折叠块；修复后 → 正文一份 + 思考过程两块（thought-1/thought-2 各自正常），连续提问第二轮同样无重复。截图对比见评论。
- **回归用例**（node 复现 mergeHistory）：流式+history 去重（双→单）、跨轮次同内容保留、旧缓存兼容、thought 分段不重复，全部通过。
- 服务端 WS 层单条 `message.send` 只产生一套流式帧（已排除前端重复发送 / 服务端双 turn / 反代双重路径）。

## 变更
- `source/psophliteos/frontend/src/views/ai-agent/agent/WebChat.vue`：mergeHistory keyOf 归一化 + thought 分段独立成泡
- `source/psophliteos/build/version.sh`：2.2.5 → 2.2.6

已在测试环境部署 2.2.6 验证通过，可合入。