### PR TITLE
fix(ota): 预检拦截残缺刷机包，防止 OTA 死循环

### DIFF
--- a/source/pota_update/ota.sh
+++ b/source/pota_update/ota.sh
@@ -205,7 +205,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f "${LOGFILE}"*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "[INFO] ota update tool, version: v1.5.1"
+echo "[INFO] ota update tool, version: v1.5.2"
 
 WORK_DIR=""
 if [ ! -d "${RUN_WORK_DIR}/sdcard" ]; then
@@ -486,6 +486,37 @@ OTA_EMMC_UPDATE_CMD_FILE=$(grep -a "^${OTA_PACK_READ_FILE_CMD}" boot_emmc.cmd | 
 grep boot_emmc | awk -F' ' '{print $NF}' | awk -F'/' '{print $NF}')
 OTA_FIP_UPDATE_CMD_FILE=$(grep -a "^${OTA_PACK_READ_FILE_CMD}" boot.cmd | \
 head -n1 | awk -F' ' '{print $NF}' | awk -F'/' '{print $NF}')
+# 分区刷机段完整性校验（2026-08-28 OTA 死循环事故）：
+# 残缺包（构建时 mcopy 失败、分区 .gz 镜像缺失）的 boot_emmc.cmd 只剩 gpt 段，
+# 后续流程会静默生成仅含 fip+gpt 的刷机脚本，刷完无收尾（不恢复 /boot/boot.scr.emmc）
+# → 设备陷入 OTA 循环。这里在预检阶段拦截：
+# ① 每个 boot_emmc-*.cmd 引用的分区镜像 .gz 必须存在且非空；
+# ② boot_emmc.cmd 至少要含 4 个分区刷机段（gpt+boot+rootfs+data 是最小可用集）。
+if [[ -z "${OTA_EMMC_UPDATE_CMD_FILE// /}" ]]; then
+    panic "boot_emmc.cmd has no boot_emmc-*.cmd partition sections, package looks incomplete"
+fi
+OTA_EMMC_SECTION_COUNT=0
+for _sec in ${OTA_EMMC_UPDATE_CMD_FILE}; do
+    [[ -z "$_sec" ]] && continue
+    file_validate "${_sec}"
+    OTA_EMMC_SECTION_COUNT=$((OTA_EMMC_SECTION_COUNT + 1))
+    # 校验该段引用的每个分区镜像文件（.scr 是 mkimage 二进制，load 行可直接 grep -a）
+    for _img in $(grep -a "^${OTA_PACK_READ_FILE_CMD} " "${_sec}" | awk -F' ' '{print $NF}' \
+| awk -F'/' '{print $NF}'); do
+        [[ -z "$_img" ]] && continue
+        [[ "$_img" == *.cmd || "$_img" == *.scr ]] && continue
+        if [[ ! -s "$_img" ]]; then
+            panic "partition image $_img (referenced by ${_sec}) is missing or empty, \
+package looks incomplete (broken build?)"
+        fi
+    done
+done
+unset _sec _img
+if [[ "$OTA_EMMC_SECTION_COUNT" -lt 4 ]]; then
+    panic "boot_emmc.cmd only has ${OTA_EMMC_SECTION_COUNT} partition section(s), \
+expect at least 4 (gpt/boot/rootfs/data), package looks incomplete"
+fi
+echo "[INFO] boot_emmc.cmd partition sections: ${OTA_EMMC_SECTION_COUNT}, images all present"
 file_validate "${OTA_FIP_UPDATE_CMD_FILE}"
 OTA_FIP_FILE=$(grep -a "^${OTA_PACK_READ_FILE_CMD}" "$OTA_FIP_UPDATE_CMD_FILE" | \
 awk -F' ' '{print $NF}' | awk -F'/' '{print $NF}')


### PR DESCRIPTION
## 背景

2026-08-27 真机刷机事故：构建容器（bm1688_docker）缺 `mcopy`，`bm_make_package_sectors.sh` 生成分区 FAT 镜像时静默失败，产出的 sdcard 刷机包**只有 fip+gpt（34M，正常 1.1G）**。v1.5.1 ota.sh 静默接受该残缺包并生成仅含两步的刷机脚本；刷完后 OTA 收尾步骤（恢复 `/boot/boot.scr.emmc`）不会执行，设备陷入 OTA 循环重启（串口日志确认 4 轮 `OTA UPDATE START→DONE→reset` 无限循环）。

## 修复内容（v1.5.2）

在 fip 芯片类型检查之前新增刷机包完整性校验（`ota.sh:489-519`）：

1. **段存在性**：`boot_emmc.cmd` 引用的每个 `boot_emmc-*.scr` 分区段文件必须可读
2. **镜像非空**：每段引用的分区镜像 `.gz`（含分卷 `rootfs.N-of-31.gz` 等）必须存在且非空——`.scr` 是 mkimage 二进制，`grep -a` 直接提取 load 行
3. **段数下限**：分区段数 ≥ 4（gpt/boot/rootfs/data 最小可用集）

任一不满足即 `panic` 拒绝刷机，在预检阶段把残缺包挡下。

## 验证

| 用例 | 预期 | 实际 |
|---|---|---|
| 事故形态（仅 gpt 段） | 拦截 | ✅ PANIC "only has 1 partition section" |
| 段全但 rootfs 分卷缺失 | 拦截 | ✅ PANIC "rootfs.3-of-31.gz is missing" |
| 真实完整包（1.1G，7 段全分卷） | 放行 | ✅ "sections=7 images all present" |

`bash -n` 语法检查通过。

## 关联

- 根因分析：BSP-NOTES §31
- 构建侧修复（容器补 mtools）已另行处理，本 PR 是 OTA 工具侧的防御

🤖 Generated with [Claude Code](https://claude.com/claude-code)