### PR TITLE
fix(psocbak): opt 分区排除外置数据盘挂载点 + 同步 ota_update md5

### DIFF
--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -60,6 +60,10 @@ PART_EXCLUDE_FLAGS["boot"]=' --exclude=./spi_flash.bin.socBakNew --exclude=./u-b
 # socrepack 为 socbak 自身产物目录：当外置存储缺省、产物直接落在 /data/socrepack 时，
 # 若不排除会把正在生成的 *.tgz 打进 data 包（自包含递归）。rootfs 侧已有同样排除。
 PART_EXCLUDE_FLAGS["data"]=' --exclude=./socrepack '
+# /opt/applications 常为外置数据盘(NVMe/SATA/USB)挂载点，不属于母盘环境。
+# 不排除时 tar 递归进入挂载点，会把数据盘内容打进 opt 分区镜像导致 sparse 空间写满
+# （与 rootfs 排除 ./media/* 同理）。
+PART_EXCLUDE_FLAGS["opt"]=' --exclude=./applications/* '
 
 # These parameters define several generated files and
 # their default sizes for repackaging. Users can modify

--- a/source/psocbak/socbak/socbak_md5.txt
+++ b/source/psocbak/socbak/socbak_md5.txt
@@ -45,4 +45,4 @@ f2a59885f1550f3b0909176521f42ca6  ./binTools/uuidgen
 608ca6d0a3e1b5c55d67b5396617b698  ./script/bm1684/bm_make_package.sh
 24dd21756fb680231e087305e006e2e5  ./script/bm1688/bm_make_package.sh
 7864745c1a0c7e0b72e2a6c68e7e78f9  ./script/bm1688/raw2cimg_edge.py
-12710b5833813b255b8f45bfffb2df2c  ./script/ota_update/ota_update.sh
+20601daa7642547eb31bfd71f703fb0e  ./script/ota_update/ota_update.sh


### PR DESCRIPTION
## 背景

MYS-795 用最新 socbak 脚本（v1.3.0，内置 ota_update v1.3.4）对 10.42.0.10 环境做 allinone 打包时发现两处问题，均为打包阻断级缺陷，已在本任务真机验证修复。

## 问题与修复

### 1. opt 分区打包时递归进入外置数据盘挂载点导致 sparse 空间写满

`/opt/applications` 常为外置数据盘（NVMe/SATA/USB）挂载点（本任务设备挂载 447G 数据盘、含 5.2G 业务数据）。socbak 打包 opt 分区时 `tar ./` 递归进入该挂载点，把数据盘内容打进仅约 2G 的 sparse 虚拟盘，导致 `No space left on device`，打包失败。

修复：新增 `PART_EXCLUDE_FLAGS["opt"]=' --exclude=./applications/* '`，与 rootfs 排除 `./media/*`、data 排除 `./socrepack` 同模式。

### 2. socbak_md5.txt 未随 ota_update.sh v1.3.4 同步

`3660368` 将 ota_update.sh 升级到 v1.3.4 但未同步 `socbak_md5.txt`，导致 socbak 启动时 `md5sum -c` 校验失败直接退出。

修复：更新 `socbak_md5.txt` 中 `ota_update.sh` 的哈希。

## 测试

- 在 10.42.0.10（BM1684X，/opt 下挂 447G 数据盘）执行 `bash socbak.sh SOC_BAK_ALL_IN_ONE=1` 成功：
  - `build success` / `INFO: pack success`
  - 日志 0 ERROR，7 个分区（boot/recovery/misc/rootfs/rootfs_rw/opt/data）全部生成
  - 刷机包产物 md5 校验全部通过
- 内置 ota_update 版本：v1.3.4