### PR TITLE
fix: 发版前安全检查修复——/agent/ws 同源+限流加固、CV84X2 dts 兜底 find 补 -L

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 | [phytool](./source/psoph_phytool) | source/psoph_phytool | 网口 PHY 寄存器读写工具（纯脚本，无编译） |
 | [bmssm](./source/pbmssm) | source/pbmssm | 设备端后端（:9779）：鉴权/硬件指标/systemd/端口/网络/OTA/文件。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
 | [sophliteos](./source/psophliteos) | source/psophliteos | 算力设备管理 Web 平台（Go+Vue，:8080），反代 bmssm。见 [API.md](./API.md) / [USAGE.md](./USAGE.md) / [BUILD.md](./BUILD.md) |
+| [se-rag-core](./source/se-rag-core) | source/se-rag-core | SE 系列知识库 RAG 检索核心（Go，本地 FAISS/BM25 + 内置网关），供 SE7 skill 使用。见 [README](./source/se-rag-core/readme.md) |
 
 ## 编译方式
 

--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -13,7 +13,7 @@
 #     ARCH:    arm64 | amd64 | all（默认按子项目）
 #     env OUTPUT_DIR: 覆盖产物目录（默认 <repo>/output/<子项目>/）
 #
-# 范围: 16 个子项目（pmulti_video_qt 已按 MYSWY 决定排除）
+# 范围: 17 个子项目（pmulti_video_qt 已按 MYSWY 决定排除）
 #
 # 用法:
 #   bash docker/build-all.sh                    # 构建全部子项目(默认平台)
@@ -71,6 +71,7 @@ DEFAULT_ARCH[pdfss_cpp]=all
 DEFAULT_ARCH[pqt_batch_deployment]=all
 DEFAULT_ARCH[pqt_memory_edit]=all
 DEFAULT_ARCH[pSophUI]=arm64
+DEFAULT_ARCH[se-rag-core]=all
 # pmulti_video_qt: 按 MYSWY 决定（2026-08-08）不需要做，从统一构建范围排除
 DEFAULT_ARCH[psoph_phytool]=all
 DEFAULT_ARCH[pspacc_efuse_demo]=amd64
@@ -91,6 +92,7 @@ PLATFORMS[pdfss_cpp]="amd64/arm64/armbi/loongarch64/riscv64/sw_64/win-amd64/win-
 PLATFORMS[pqt_batch_deployment]="amd64(linux AppImage) + windows"
 PLATFORMS[pqt_memory_edit]="amd64(linux AppImage) + windows"
 PLATFORMS[pSophUI]="arm64(交叉Qt)"
+PLATFORMS[se-rag-core]="arm64/amd64(Go静态)"
 PLATFORMS[psoph_phytool]="通用脚本"
 PLATFORMS[pspacc_efuse_demo]="amd64/arm64"
 
@@ -118,7 +120,7 @@ declare -A DEPENDS
 DEPENDS[pbmsec]=psocbak
 
 if [[ "${LIST_ONLY:-0}" = "1" ]]; then
-  echo "=== sophon-tools 16 子项目构建清单（pmulti_video_qt 已排除，单镜像 ${IMAGE}） ==="
+  echo "=== sophon-tools 17 子项目构建清单（pmulti_video_qt 已排除，单镜像 ${IMAGE}） ==="
   for p in $(echo "${!DEFAULT_ARCH[@]}" | tr ' ' '\n' | sort); do
     printf "  %-22s 平台: %-40s 镜像: %s\n" "$p" "${PLATFORMS[$p]}" "${IMAGE}"
   done

--- a/source/pSophUI/SophUI/deb/DEBIAN/control
+++ b/source/pSophUI/SophUI/deb/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: sophgo-hdmi
 Source: sophgo-hdmi
-Version: 1.6.9
+Version: 1.6.10
 Architecture: arm64
 Maintainer: sophgo
 Priority: optional

--- a/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
+++ b/source/pSophUI/SophUI/deb/bm_services/SophonHDMI/run_hdmi_show.sh
@@ -47,7 +47,7 @@ CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
 # cv84x6 与 bm1688/cv186ah 同属 CV 家族，HDMI 走原生 DRM(card0) 通路，与 fl2000/USB 方案区分。
 if [ "$CPU_MODEL" != "bm1688" ] && [ "$CPU_MODEL" != "cv186ah" ] && [ "$CPU_MODEL" != "cv84x6" ] \
    && [ -d /proc/device-tree ]; then
-    if find /proc/device-tree -name compatible -type f -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null | grep -q .; then
+    if find -L /proc/device-tree -name compatible -type f -exec grep -laE "cvitek,cv84x6-" {} + 2>/dev/null | grep -q .; then
         CPU_MODEL="cv84x6"
     fi
 fi

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.6"
+DEFAULT_VERSION="2.3.7"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/pbmssm/mvc/agentproxy/ws.go
+++ b/source/pbmssm/mvc/agentproxy/ws.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -16,6 +17,9 @@ import (
 
 // wsPath WebSocket 端点路径（对齐设计文档 §6.3）。
 const wsPath = "/agent/ws"
+
+// maxWSConns 单个 Hub 允许的最大 WS 并发连接数（防资源耗尽）。
+const maxWSConns = 16
 
 // wsIdleTimeout 连接无任何消息(含客户端应用层 ping)即关闭。
 // MYS-632:原 30 分钟过长,半开连接最长假死 30 分钟;缩短到 3 分钟,
@@ -190,15 +194,38 @@ func (h *Hub) BroadcastSession(acpID string, frames ...WSFrame) {
 // Sec-WebSocket-Protocol，否则握手失败），前端 PicoWs 携带 token.<forward_key>
 // 的行为保持兼容。
 func (h *Hub) serveWS(w http.ResponseWriter, r *http.Request) {
+	// CSWSH 防护：拒绝跨源浏览器握手。非浏览器客户端（无 Origin 头）放行，
+	// 与 MYS-379 "免 key"裁定一致；同源页面（ws://<host>/agent/ws）不受影响。
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  4096,
 		WriteBufferSize: 4096,
-		CheckOrigin:     func(r *http.Request) bool { return true },
+		CheckOrigin: func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			if origin == "" {
+				return true
+			}
+			u, err := url.Parse(origin)
+			if err != nil {
+				return false
+			}
+			return strings.EqualFold(u.Host, r.Host)
+		},
 		// 回显客户端请求的子协议（token.<key>），浏览器强制要求服务端回显
 		// Sec-WebSocket-Protocol，否则握手失败。
 		// 子协议只用于回显，不再做 key 校验（见函数头注释）。
 		Subprotocols: websocket.Subprotocols(r),
 	}
+
+	// 并发连接数上限：未鉴权端点面对内部自用场景，防误配置/异常客户端打爆资源。
+	h.mu.Lock()
+	over := len(h.conns) >= maxWSConns
+	h.mu.Unlock()
+	if over {
+		logger.Warn("agentproxy: ws connection limit %d reached, reject %s", maxWSConns, r.RemoteAddr)
+		http.Error(w, "too many connections", http.StatusServiceUnavailable)
+		return
+	}
+
 	wsConn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return

--- a/source/pbmssm/mvc/agentproxy/ws_test.go
+++ b/source/pbmssm/mvc/agentproxy/ws_test.go
@@ -134,6 +134,76 @@ func TestWSAuthEmptyKeyAllowsAll(t *testing.T) {
 	conn.Close()
 }
 
+// TestWSCheckOrigin 验证同源校验：跨源浏览器 Origin 拒绝（CSWSH 防护），
+// 同源 Origin 与无 Origin（内部客户端）放行——不改 MYS-379 "免 key"裁定。
+func TestWSCheckOrigin(t *testing.T) {
+	mod := NewModule(DefaultConfig(), nil, nil)
+	h := newHub(mod, "")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	u := wsURL(srv.URL) + wsPath
+
+	// 无 Origin（Go 客户端/设备内部脚本）→ 放行
+	conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+	if err != nil {
+		t.Fatalf("no-origin dial failed: %v", err)
+	}
+	conn.Close()
+
+	// 同源 Origin（与请求 Host 一致）→ 放行
+	hdrs := map[string][]string{"Origin": {srv.URL}}
+	conn2, _, err := websocket.DefaultDialer.Dial(u, hdrs)
+	if err != nil {
+		t.Fatalf("same-origin dial failed: %v", err)
+	}
+	conn2.Close()
+
+	// 跨源 Origin → 拒绝握手（CSWSH）
+	evilHdrs := map[string][]string{"Origin": {"https://evil.example"}}
+	_, resp, err := websocket.DefaultDialer.Dial(u, evilHdrs)
+	if err == nil {
+		t.Fatalf("cross-origin dial must be rejected")
+	}
+	if resp != nil && resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin rejected with status %d, want 403", resp.StatusCode)
+	}
+	if resp == nil {
+		t.Fatalf("cross-origin dial should get an http response")
+	}
+}
+
+// TestWSConnLimit 验证并发连接上限：到达 maxWSConns 后新连接被 503 拒绝。
+func TestWSConnLimit(t *testing.T) {
+	mod := NewModule(DefaultConfig(), nil, nil)
+	h := newHub(mod, "")
+	srv := httptest.NewServer(http.HandlerFunc(h.serveWS))
+	t.Cleanup(srv.Close)
+	u := wsURL(srv.URL) + wsPath
+
+	opened := make([]*websocket.Conn, 0, maxWSConns)
+	t.Cleanup(func() {
+		for _, c := range opened {
+			c.Close()
+		}
+	})
+	for i := 0; i < maxWSConns; i++ {
+		conn, _, err := websocket.DefaultDialer.Dial(u, nil)
+		if err != nil {
+			t.Fatalf("dial %d/%d failed: %v", i+1, maxWSConns, err)
+		}
+		opened = append(opened, conn)
+	}
+
+	// 第 maxWSConns+1 个连接应被拒绝
+	_, resp, err := websocket.DefaultDialer.Dial(u, nil)
+	if err == nil {
+		t.Fatalf("connection beyond limit must be rejected")
+	}
+	if resp == nil || resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("limit rejection status = %v, want 503", resp)
+	}
+}
+
 // TestHubKeyRotation 验证 MYS-387 轮换同步：SetKey 后旧子协议立即失效（403），
 // 新子协议放行——无需重启 bmssm。
 // TestHubKeyRotation MYS-379 裁定后 key 不再参与 WS 鉴权：

--- a/source/pota_update/ota.sh
+++ b/source/pota_update/ota.sh
@@ -92,7 +92,7 @@ CPU_MODEL=$(awk -F': ' '/model name/{print $2; exit}' /proc/cpuinfo)
 case "${CPU_MODEL}" in
     ""|null|cv186ah)
         if [ -d /proc/device-tree ]; then
-            _cv_match=$(find /proc/device-tree -name compatible -type f \
+            _cv_match=$(find -L /proc/device-tree -name compatible -type f \
                 -exec grep -la "cv84x6" {} + 2>/dev/null)
             if [ -n "${_cv_match}" ]; then
                 CPU_MODEL="cv84x6"
@@ -205,7 +205,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f "${LOGFILE}"*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "[INFO] ota update tool, version: v1.5.2"
+echo "[INFO] ota update tool, version: v1.5.3"
 
 WORK_DIR=""
 if [ ! -d "${RUN_WORK_DIR}/sdcard" ]; then


### PR DESCRIPTION
## Summary
v26.07.13..HEAD 发版前安全/质量审查发现 3 处需处理项，随本次 release 一并发版：

1. **bmssm 2.3.6→2.3.7**（`source/pbmssm/...`）
   `/agent/ws` 为未鉴权端点（MYS-379 用户裁定"设备内部自用免 key"）,保持该裁定前提下补齐浏览器侧防线：
   - `CheckOrigin` 由恒 `true` 收紧为**同源校验** → 拒绝跨站 WebSocket 劫持（CSWSH）；无 Origin 的内部客户端（脚本/工具）保持放行。
   - 新增**并发连接上限 `maxWSConns=16`** → 防未鉴权端点被异常客户端耗尽资源。
   - 新增 `TestWSCheckOrigin` / `TestWSConnLimit`；`go test ./...` 全量通过。

2. **pota_update v1.5.2→v1.5.3**（`source/pota_update/ota.sh`）
   CV84X2 dts 兜底识别 `find /proc/device-tree` 补 `-L`：`/proc/device-tree` 是指向 `/sys/firmware/devicetree/base` 的符号链接，不加 `-L` 恒返回空，cv84x6 兜底识别形同虚设 → 真机 OTA 可能走错芯片刷机路径。与 get_info v1.5.1、psocbak #146 同类修复对齐。

3. **pSophUI 1.6.9→1.6.10**（`run_hdmi_show.sh` + `deb/DEBIAN/control`）
   同上 find 补 `-L`，CV84X2 HDMI 通路识别走对 DRM 原生通路。

## 测试
- `go test ./mvc/agentproxy/...` + 新增用例全过；`go test ./...`（bmssm 全量）通过
- 两个 shell 脚本 `bash -n` 语法通过
- 待发版构建验证（sophonliteos/ota/SophUI 重新出包）

## Notes
发版审查其余发现（firewall 窄段保护端口绕过、`/api/sso/register` 放行临时 token、jwt file 缺失 fail-open 等）已记录，作为下版本跟踪项，不阻塞本次发版。