### PR TITLE
fix: P1/P2 安全加固（发版 review 落实）——temp token 注册、防火墙守卫、jwt fail-closed 等

### DIFF
--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.7"
+DEFAULT_VERSION="2.3.8"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/pbmssm/mvc/software/service.go
+++ b/source/pbmssm/mvc/software/service.go
@@ -508,6 +508,11 @@ func isValidPackageName(name string) bool {
 		}
 		return false
 	}
+	// 去掉扩展名后的包名不得为空或以 "." 开头（P2-2：如 "..tar.gz" 剥掉后缀得 ".."，
+	// filepath.Join 会落到父目录写文件）
+	if strings.HasPrefix(filepath.Base(packageName(base)), ".") {
+		return false
+	}
 	return true
 }
 

--- a/source/pbmssm/mvc/software/service_test.go
+++ b/source/pbmssm/mvc/software/service_test.go
@@ -789,6 +789,9 @@ func TestIsValidPackageName(t *testing.T) {
 		{"test$(whoami).deb", false}, // 命令注入
 		{"my_app_v1.0.tgz", true},
 		{"valid-name-v1.0.tar.gz", true},
+		{"..tar.gz", false},     // 剥掉后缀得 ".."，解包根逃逸父目录（P2-2）
+		{"..zip", false},        // 同上
+		{".hidden.deb", false},  // 隐藏点名前缀拒绝
 	}
 
 	for _, tt := range tests {

--- a/source/pbmssm/pkg/firewall/intent.go
+++ b/source/pbmssm/pkg/firewall/intent.go
@@ -226,16 +226,16 @@ func isBroadCidr(cidr string) bool { return isBroadMatch(cidr) }
 
 // CheckProtectDeny 拒绝屏蔽保护端口/全网段保护主机的意图。返回 ErrInvalidInput。
 // 覆盖三种绕过路径：
-//  1. port_deny + 全网段 src（空/0.0.0.0/0/0.0.0.0）且端口命中 protect → 拒绝
+//  1. port_deny 端口命中 protect → 一律拒绝（无论 src 宽窄）。管理机 IP 动态变化、
+//     窄段覆盖场景多，任何对管理端口（SSH/Web）的拒绝都有锁死管理通道风险
+//     （原仅拦全网段 src，窄段如 10/8、192.168/16 可绕过守卫——P1-2 收紧）。
 //  2. ip_blacklist + 全网段 cidr → 拒绝（黑名单无端口维度，全内网封禁即锁死保护主机）
 //  3. rate_limit 作用于保护端口 → 拒绝（recent+DROP 超限丢弃，等效拒绝）
 //
 // 与 Translate 语义对齐：src 缺省即匹配所有源，绝非"仅匹配自己"。
-//
-// 已知边界（S1/S2，前端已有提示）：特定源网段（如 10/8、172.16/12、192.168/16）的拒绝
-// 仍会合法通过守卫——企业内网管理机常落这些网段，可能锁死管理通道；且 protect 端口依赖
-// 实时探测（ss/netstat），探测不到时（如 sshd 以非标准进程名运行、systemd socket 激活）
-// 危险规则会被放行。Rebuild 不再有旧 Apply 的"临时放行 + 回滚计时器"兜底，配置需谨慎。
+// protect 端口依赖实时探测（ss/netstat）+ config 额外端口，探测不到的极端场景仍可能
+// 漏守卫——前端已加针对管理通道的强风险提示（建议 SSH 登录后由专业人士命令行操作）。
+// Rebuild 不再有旧 Apply 的"临时放行 + 回滚计时器"兜底，配置需谨慎。
 func CheckProtectDeny(it *Intent, protect []int) error {
 	if len(protect) == 0 {
 		return nil
@@ -249,11 +249,9 @@ func CheckProtectDeny(it *Intent, protect []int) error {
 		if err := json.Unmarshal([]byte(it.Params), &p); err != nil {
 			return nil // params 格式不匹配，由 Validate 负责报错
 		}
-		if isBroadMatch(p.Src) {
-			for _, port := range protect {
-				if p.Port == port {
-					return fmt.Errorf("%w: 不能拒绝保护端口 %d 的全网段流量", ErrInvalidInput, port)
-				}
+		for _, port := range protect {
+			if p.Port == port {
+				return fmt.Errorf("%w: 不能拒绝保护端口 %d（管理通道 SSH/Web，任何来源的拒绝都可能锁死设备管理，请 SSH 登录后由专业人士通过命令行操作）", ErrInvalidInput, port)
 			}
 		}
 	case IntentIPBlacklist:

--- a/source/pbmssm/pkg/firewall/intent_test.go
+++ b/source/pbmssm/pkg/firewall/intent_test.go
@@ -139,10 +139,10 @@ func TestCheckProtectDenyPortDenyEmptySrc(t *testing.T) {
 }
 
 func TestCheckProtectDenyPortDenySpecificSrc(t *testing.T) {
-	// 特定源 CIDR 允许拒绝
+	// 特定源 CIDR 拒绝保护端口也必须拦截（P1-2 收紧：窄段覆盖同样锁死管理通道）
 	it := Intent{ID: 10, Type: "port_deny", Params: mustParams(t, map[string]interface{}{"proto": "tcp", "port": 22, "src": "10.0.0.0/8"})}
-	if err := CheckProtectDeny(&it, []int{22}); err != nil {
-		t.Errorf("want allow for specific src, got %v", err)
+	if err := CheckProtectDeny(&it, []int{22}); err == nil {
+		t.Error("want block for specific src deny on protect port")
 	}
 }
 
@@ -219,10 +219,10 @@ func TestCheckProtectDenyPortDenySlash1Src(t *testing.T) {
 }
 
 func TestCheckProtectDenyPortDenySpecificSrcStillAllowed(t *testing.T) {
-	// 特定源 /8 deny 保护端口仍允许（合法运维场景）
+	// 任何来源拒绝保护端口一律拦截（P1-2 收紧：窄段覆盖同样锁死管理通道）
 	it := Intent{ID: 21, Type: "port_deny", Params: mustParams(t, map[string]interface{}{"proto": "tcp", "port": 22, "src": "10.0.0.0/8"})}
-	if err := CheckProtectDeny(&it, []int{22}); err != nil {
-		t.Errorf("want allow for specific /8 src, got %v", err)
+	if err := CheckProtectDeny(&it, []int{22}); err == nil {
+		t.Error("want block for specific /8 src deny on protect port")
 	}
 }
 

--- a/source/pota_update/get_network_info.sh
+++ b/source/pota_update/get_network_info.sh
@@ -24,6 +24,11 @@ declare -A CONFIG_NETMASK
 declare -A CONFIG_GATEWAY
 declare -A CONFIG_DNS
 
+# 单引号包裹安全转义：值内的 ' 转义为 '\''，拼入生成命令不破坏引号结构（P2-4）
+_q() {
+    printf "%s" "${1//\'/\'\\\'\'}"
+}
+
 # 函数：检测网络管理器类型
 detect_network_manager() {
     if systemctl is-active --quiet NetworkManager 2>/dev/null; then
@@ -373,18 +378,18 @@ generate_bm_set_ip_command() {
             return 1
         fi
 
-        cmd="$cmd '${CONFIG_IP[$iface]}' '${CONFIG_NETMASK[$iface]}'"
+        cmd="$cmd '$(_q "${CONFIG_IP[$iface]}")' '$(_q "${CONFIG_NETMASK[$iface]}")'"
 
         # 添加网关（如果存在）
         if [ -n "${CONFIG_GATEWAY[$iface]}" ]; then
-            cmd="$cmd '${CONFIG_GATEWAY[$iface]}'"
+            cmd="$cmd '$(_q "${CONFIG_GATEWAY[$iface]}")'"
         else
             cmd="$cmd ''"
         fi
 
         # 添加DNS（如果存在）
         if [ -n "${CONFIG_DNS[$iface]}" ]; then
-            cmd="$cmd '${CONFIG_DNS[$iface]}'"
+            cmd="$cmd '$(_q "${CONFIG_DNS[$iface]}")'"
         else
             cmd="$cmd ''"
         fi

--- a/source/pota_update/ota.sh
+++ b/source/pota_update/ota.sh
@@ -205,7 +205,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f "${LOGFILE}"*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "[INFO] ota update tool, version: v1.5.3"
+echo "[INFO] ota update tool, version: v1.5.4"
 
 WORK_DIR=""
 if [ ! -d "${RUN_WORK_DIR}/sdcard" ]; then

--- a/source/psocbak/socbak/socbak.sh
+++ b/source/psocbak/socbak/socbak.sh
@@ -11,7 +11,7 @@ LOGFILE="$(readlink -f "${BASH_SOURCE[0]}").log"
 rm -f $LOGFILE*
 exec > >(tee -a "$LOGFILE") 2>&1
 
-echo "VERSION: v1.3.0"
+echo "VERSION: v1.3.1"
 date '+%Y-%m-%d %H:%M:%S'
 
 export SOC_BAK_ALL_IN_ONE=${SOC_BAK_ALL_IN_ONE:-}
@@ -134,13 +134,15 @@ socbak_cleanup() {
 	echo -e "\nINFO: Received a kill signal. Cleaning up..."
 	systemctl disable resize-helper.service
 	umount ${TGZ_FILES_PATH}/sparse-path* &>/dev/null
-	exit 0
 }
 # 注意：不能挂 ERR。tar 打包运行中的根文件系统时，"File removed before we read it"
 # 等瞬态警告会使 tar 以 1 退出（属预期、可容忍，追加 pass 本就带 --ignore-failed-read），
 # ERR trap 会把这类警告当成致命错误：cleanup 提前退出且 exit 0，备份被静默截断还报成功
 # （CV84X2 真机实测踩坑）。关键步骤失败由各处的 "$?" 显式检查处理。
-trap socbak_cleanup EXIT SIGHUP SIGINT SIGQUIT SIGTERM
+# 退出码规范（P2-5）：cleanup 本身不 exit 0（原实现会吞掉脚本失败退出码）；
+# 信号 trap 单独显式 exit 130 结束，正常/失败路径退出码由 EXIT trap 原样保留。
+trap 'socbak_cleanup; exit 130' SIGHUP SIGINT SIGQUIT SIGTERM
+trap socbak_cleanup EXIT
 
 SOCBAK_GET_TAR_SIZE_KB=0
 socbak_get_tar_size() {

--- a/source/psophliteos/api/v1/system/sys_metrics_fwd.go
+++ b/source/psophliteos/api/v1/system/sys_metrics_fwd.go
@@ -151,7 +151,12 @@ func (a *MetricsFwdApi) SetEnabled(c *gin.Context) {
 	cfg := database.LoadMetricsForward()
 	cfg.Enabled = *req.Enabled
 	if cfg.Enabled && cfg.Token == "" {
-		cfg.Token = database.NewForwardToken()
+		tok, err := database.NewForwardToken()
+		if err != nil {
+			c.JSON(http.StatusOK, mvc.Fail(-1, "token generation failed: "+err.Error()))
+			return
+		}
+		cfg.Token = tok
 	}
 	if err := database.SaveMetricsForward(cfg); err != nil {
 		c.JSON(http.StatusOK, mvc.Fail(-1, "db error: "+err.Error()))
@@ -163,7 +168,12 @@ func (a *MetricsFwdApi) SetEnabled(c *gin.Context) {
 // RotateToken POST /api/device/metrics-forward/token —— 轮换 token（旧 token 立即失效）。
 func (a *MetricsFwdApi) RotateToken(c *gin.Context) {
 	cfg := database.LoadMetricsForward()
-	cfg.Token = database.NewForwardToken()
+	tok, err := database.NewForwardToken()
+	if err != nil {
+		c.JSON(http.StatusOK, mvc.Fail(-1, "token generation failed: "+err.Error()))
+		return
+	}
+	cfg.Token = tok
 	if err := database.SaveMetricsForward(cfg); err != nil {
 		c.JSON(http.StatusOK, mvc.Fail(-1, "db error: "+err.Error()))
 		return

--- a/source/psophliteos/api/v1/system/sys_metrics_fwd_test.go
+++ b/source/psophliteos/api/v1/system/sys_metrics_fwd_test.go
@@ -160,7 +160,10 @@ func TestForwardOK(t *testing.T) {
 
 // TestTokenGenerateFormat token 为 64 位 hex 且两次生成不同。
 func TestTokenGenerateFormat(t *testing.T) {
-	tok := database.NewForwardToken()
+	tok, err := database.NewForwardToken()
+	if err != nil {
+		t.Fatalf("generate token: %v", err)
+	}
 	if len(tok) != 64 {
 		t.Errorf("token len = %d, want 64", len(tok))
 	}
@@ -170,7 +173,11 @@ func TestTokenGenerateFormat(t *testing.T) {
 			break
 		}
 	}
-	if database.NewForwardToken() == tok {
+	tok2, err := database.NewForwardToken()
+	if err != nil {
+		t.Fatalf("generate second token: %v", err)
+	}
+	if tok2 == tok {
 		t.Error("two generated tokens must differ")
 	}
 }

--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.6"
+DEFAULT_VERSION="2.2.7"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/database/metrics_forward.go
+++ b/source/psophliteos/database/metrics_forward.go
@@ -3,6 +3,7 @@ package database
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"time"
 )
 
@@ -42,23 +43,25 @@ func SaveMetricsForward(m MetricsForward) error {
 }
 
 // NewForwardToken 生成抓取 token：crypto/rand 32 字节 → 64 位 hex。
-func NewForwardToken() string {
+// rand 失败（系统级异常）返回错误（P2-8 fail-closed），不再回退时间熵——
+// 时间派生的 token 可预测，用于指标抓取鉴权等价于无鉴权。
+func NewForwardToken() (string, error) {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
-		// crypto/rand 失败属系统级异常，fallback 到时间熵（极罕见路径）
-		now := time.Now().UnixNano()
-		for i := range b {
-			b[i] = byte(now >> (uint(i%8) * 8))
-		}
+		return "", fmt.Errorf("generate forward token: crypto/rand failed: %w", err)
 	}
-	return hex.EncodeToString(b)
+	return hex.EncodeToString(b), nil
 }
 
 // EnsureForwardToken 返回当前配置；若开启但无 token（如旧数据/首次开启）则自动生成并落库。
 func EnsureForwardToken() (MetricsForward, error) {
 	m := LoadMetricsForward()
 	if m.Enabled && m.Token == "" {
-		m.Token = NewForwardToken()
+		tok, err := NewForwardToken()
+		if err != nil {
+			return m, err
+		}
+		m.Token = tok
 		if err := SaveMetricsForward(m); err != nil {
 			return m, err
 		}

--- a/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
@@ -212,6 +212,7 @@ export default {
     portDeny: 'Port Deny',
     highRiskConfirmTitle: 'High-risk operation confirmation',
     highRiskConfirmContent: 'Confirmation code: {code} (valid for {secs}s). This high-risk operation takes effect immediately. Please confirm.',
+    highRiskWarn: '⚠️ Firewall changes may lock out the device management channel (SSH/Web) and are extremely dangerous! If the device becomes unreachable after applying, SSH into the device and have a professional restore it via command line.',
     challengeFail: 'Failed to fetch confirmation code',
     actionFail: 'Operation failed',
   },

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
@@ -217,6 +217,7 @@ export default {
     portDeny: '端口拒绝',
     highRiskConfirmTitle: '高危操作二次确认',
     highRiskConfirmContent: '二次确认码：{code}（{secs} 秒内有效）。高危操作将立即生效，请确认执行。',
+    highRiskWarn: '⚠️ 防火墙操作可能锁死设备管理通道（SSH/Web），此操作非常危险！若操作后设备失联，请通过 SSH 手动登录设备，由专业人士使用命令行操作恢复。',
     challengeFail: '获取二次确认码失败',
     actionFail: '操作失败',
   },

--- a/source/psophliteos/frontend/src/store/modules/user.ts
+++ b/source/psophliteos/frontend/src/store/modules/user.ts
@@ -132,15 +132,25 @@ export const useUserStore = defineStore({
         try {
           await ssoRegister(loginParams.username, token);
         } catch (regError) {
+          // 临时 token（默认密码首登，change_pass_required=true）被 register 拒绝：
+          // 属于"必须改密"而非登录失败——保留 token（改密接口 /api/v1/password 可用
+          // 临时 token 调用），转入改密引导表单；改密成功后重新登录即用正式 token。
+          const regStatus = (regError as any)?.response?.status;
+          const regData = (regError as any)?.response?.data;
+          if (regStatus === 403 && regData?.change_pass_required) {
+            this.setFirstLogin(true);
+            setLoginState(LoginStateEnum.CHANGE_PASSWORD);
+            return null;
+          }
           this.setToken(undefined);
           // 401/403（token 无效、bmssm 密钥不一致等）对用户都属于"建立会话失败"，
           // 直接给友好文案；网络异常等才透出具体错误。
-          const status = (regError as any)?.response?.status;
+          const status = regStatus;
           const regErrMsg =
             status === 401 || status === 403
               ? t('sys.login.registerFailed')
-              : (regError as any)?.response?.data?.error ||
-                (regError as any)?.response?.data?.error_message ||
+              : regData?.error ||
+                regData?.error_message ||
                 (regError as unknown as Error)?.message ||
                 t('sys.login.registerFailed');
           return Promise.reject(new Error(regErrMsg));

--- a/source/psophliteos/frontend/src/views/maintenance/firewall/Intent.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/firewall/Intent.vue
@@ -158,6 +158,11 @@
             h('p', { style: { 'font-weight': 550 } }, desc),
             h(
               'p',
+              { style: { color: '#ff4d4f', 'font-weight': 550, margin: '8px 0 4px', 'font-size': '13px' } },
+              t('maintenance.firewall.highRiskWarn'),
+            ),
+            h(
+              'p',
               { style: { color: '#fa8c16', margin: '8px 0 4px', 'font-size': '13px' } },
               t('maintenance.firewall.highRiskConfirmContent', {
                 code: ch.code,

--- a/source/psophliteos/initialization/register_test.go
+++ b/source/psophliteos/initialization/register_test.go
@@ -3,6 +3,8 @@ package initialization
 import (
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -58,10 +60,25 @@ func setProdTimeouts(t *testing.T) {
 	})
 }
 
+// setTestJWTSecret 写入临时持久化 bmssm JWT secret 并让 middleware 读取它
+// （P2-6 fail-closed 后，无 secret 时 register/本地路由全部 401，测试需显式
+// secret）；返回该 secret 供测试签发同格式 JWT。结束后恢复默认文件路径。
+func setTestJWTSecret(t *testing.T) string {
+	t.Helper()
+	const secret = "register-test-secret-0123456789abcdef"
+	path := filepath.Join(t.TempDir(), "jwt_secret")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	middleware.SetJWTSecretFilePath(path)
+	t.Cleanup(func() { middleware.SetJWTSecretFilePath("/var/lib/bmssm/jwt_secret") })
+	return secret
+}
+
 // TestSSORegisterRequiresValidJWT 验证 register 鉴权闭环：
 // 未携带有效 bmssm JWT 的请求不能自造活跃会话。
 func TestSSORegisterRequiresValidJWT(t *testing.T) {
-	middleware.SetJWTSecretFilePath("")
+	secret := setTestJWTSecret(t)
 	config.LoadConfig()
 	setProdTimeouts(t)
 	gin.SetMode(gin.TestMode)
@@ -77,7 +94,7 @@ func TestSSORegisterRequiresValidJWT(t *testing.T) {
 	}
 
 	// 2) 有效 JWT 但 username 不匹配 sub → 401，不建立会话
-	otherTok := issueBMSSMToken(t, "other", middleware.DefaultSecret, false)
+	otherTok := issueBMSSMToken(t, "other", secret, false)
 	w = registerJSON(t, router, `{"username":"admin","token":"`+otherTok+`"}`)
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("register with mismatched username: status=%d want 401 body=%s", w.Code, w.Body.String())
@@ -87,7 +104,7 @@ func TestSSORegisterRequiresValidJWT(t *testing.T) {
 	}
 
 	// 3) 有效 JWT + username 匹配 sub → 200，活跃会话建立
-	validTok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, false)
+	validTok := issueBMSSMToken(t, "admin", secret, false)
 	w = registerJSON(t, router, `{"username":"admin","token":"`+validTok+`"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("register with valid jwt: status=%d want 200 body=%s", w.Code, w.Body.String())
@@ -97,7 +114,18 @@ func TestSSORegisterRequiresValidJWT(t *testing.T) {
 	}
 	t.Cleanup(func() { middleware.SSOLogout(validTok) })
 
-	// 4) 畸形 body → 400
+	// 4) temp token（默认密码首登）→ 403 change_pass_required（P1-1）
+	tempTok := issueBMSSMToken(t, "admin", secret, true)
+	w = registerJSON(t, router, `{"username":"admin","token":"`+tempTok+`"}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("register with temp jwt: status=%d want 403 body=%s", w.Code, w.Body.String())
+	}
+	// 原活跃会话（validTok）保持不变：temp register 被拒即未顶号
+	if act, ok := middleware.SSOActiveToken(); !ok || act != validTok {
+		t.Fatalf("active session changed after rejected temp register: act=%q ok=%v", act, ok)
+	}
+
+	// 5) 畸形 body → 400
 	w = registerJSON(t, router, `{"username":"admin"}`)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("register with incomplete body: status=%d want 400", w.Code)
@@ -107,7 +135,7 @@ func TestSSORegisterRequiresValidJWT(t *testing.T) {
 // TestProtectedLocalRoutesUnifiedAuth 验证本地敏感路由统一鉴权口径：
 // 无活跃会话（或 token 无效）一律 401，登录注册后放行。
 func TestProtectedLocalRoutesUnifiedAuth(t *testing.T) {
-	middleware.SetJWTSecretFilePath("")
+	secret := setTestJWTSecret(t)
 	config.LoadConfig()
 	setProdTimeouts(t)
 	gin.SetMode(gin.TestMode)
@@ -135,7 +163,7 @@ func TestProtectedLocalRoutesUnifiedAuth(t *testing.T) {
 	}
 
 	// 已注册活跃会话 + 携带该 token → 放行
-	tok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, false)
+	tok := issueBMSSMToken(t, "admin", secret, false)
 	w = registerJSON(t, router, `{"username":"admin","token":"`+tok+`"}`)
 	if w.Code != http.StatusOK {
 		t.Fatalf("register failed: %d %s", w.Code, w.Body.String())
@@ -155,7 +183,7 @@ func TestProtectedLocalRoutesUnifiedAuth(t *testing.T) {
 	// 有效 JWT 但非活跃 token → 401（SSO 单会话比对）
 	// 注：JWT 的 iat 为秒级精度，同秒签发的同 sub token 字节相同（SSO 按字符串比对
 	// 视为同一会话），换一个 sub 保证是不同的 token。
-	otherTok := issueBMSSMToken(t, "admin2", middleware.DefaultSecret, false)
+	otherTok := issueBMSSMToken(t, "admin2", secret, false)
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/device/version", nil)
 	req.Header.Set("Authorization", "Bearer "+otherTok)
@@ -164,18 +192,18 @@ func TestProtectedLocalRoutesUnifiedAuth(t *testing.T) {
 		t.Fatalf("unregistered valid JWT: status=%d want 401 body=%s", w.Code, w.Body.String())
 	}
 
-	// 活跃 token 是临时 token（首次登录改密场景）→ 本地敏感路由 403，与 bmssm 口径一致
-	tempTok := issueBMSSMToken(t, "admin", middleware.DefaultSecret, true)
+	// 临时 token（默认密码首登）：register 一律 403、不建活跃会话（P1-1），
+	// 故携带临时 token 访问本地路由同样 401（无活跃会话）。
+	tempTok := issueBMSSMToken(t, "admin", secret, true)
 	w = registerJSON(t, router, `{"username":"admin","token":"`+tempTok+`"}`)
-	if w.Code != http.StatusOK {
-		t.Fatalf("register temp token failed: %d %s", w.Code, w.Body.String())
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("register temp token must be 403 (change pass required): %d %s", w.Code, w.Body.String())
 	}
-	defer middleware.SSOLogout(tempTok)
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/api/device/version", nil)
 	req.Header.Set("Authorization", "Bearer "+tempTok)
 	router.ServeHTTP(w, req)
-	if w.Code != http.StatusForbidden {
-		t.Fatalf("temp token on protected local route: status=%d want 403 body=%s", w.Code, w.Body.String())
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("temp token (no active session) on protected local route: status=%d want 401 body=%s", w.Code, w.Body.String())
 	}
 }

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -70,9 +70,17 @@ func Routers(webFS fs.FS) *gin.Engine {
 		// 鉴权：token 必须是 bmssm 签发的有效 JWT，且其 sub 与请求的 username 一致，
 		// 防止未认证请求用任意 username/token 自造活跃会话（伪造活跃会话可顶掉合法
 		// 用户 → 登录 DoS）。sub 取自 bmssm 登录签发，与前端登录输入一致。
-		sub, _, err := middleware.CheckBMSSMToken(req.Token)
+		sub, temp, err := middleware.CheckBMSSMToken(req.Token)
 		if err != nil || sub != req.Username {
 			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
+		}
+		// 临时 token（默认密码首登、待改密）不得建立活跃会话：临时 token 人人可取
+		// （默认凭据公开），放行会允许任意人顶掉已登录管理员（会话 DoS）。首登用户
+		// 必须先在 bmssm 完成改密、以正式 token 重新登录。前端收到 change_pass_required
+		// 后转入改密引导（temp token 可调 /api/v1/password 改密）。
+		if temp {
+			c.JSON(http.StatusForbidden, gin.H{"error": "temporary token, change password required", "change_pass_required": true})
 			return
 		}
 		middleware.SSORegister(req.Username, req.Token)
@@ -126,7 +134,14 @@ func Routers(webFS fs.FS) *gin.Engine {
 		}
 		Router.Any("/api/v1/*any",
 			middleware.SSO(),
-			middleware.DeadlineMiddleware(global.OtaTimeOut),
+			// P2-7：不再对全路由放大 deadline 到 OTA 超时（慢速连接可占连接 12 分钟），
+			// 仅长窗口路径（长文件下载、OTA 固件下载、LLM 配置/测试）命中前缀才延长；
+			// 其余保持服务器层 30s 读/写超时边界。LLM 流式走 /agent/ws（下挂
+			// DeadlineMiddleware），不依赖此处。
+			middleware.LongPathDeadline(
+				[]string{"/api/v1/files/download", "/api/v1/ota/download", "/api/v1/llm-proxy"},
+				global.OtaTimeOut,
+			),
 			func(c *gin.Context) {
 				proxy.ServeHTTP(c.Writer, c.Request)
 			})

--- a/source/psophliteos/middleware/deadline.go
+++ b/source/psophliteos/middleware/deadline.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"net/http"
 	"sophliteos/logger"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -23,6 +24,29 @@ func DeadlineMiddleware(d time.Duration) gin.HandlerFunc {
 		}
 		if err := rc.SetWriteDeadline(dl); err != nil {
 			logger.Debug("extend write deadline failed on %s: %v", c.Request.URL.Path, err)
+		}
+		c.Next()
+	}
+}
+
+// LongPathDeadline 仅对命中长窗口前缀的路径延长连接 deadline（P2-7）。
+// 常规 /api/v1/* 反代保持服务器层 30s 读/写超时边界，慢速连接占用时间有界，
+// 不会因全路由放大到 OTA 超时（12m）造成连接耗尽面；真正需要长窗口的路径
+// （长文件下载、OTA 固件下载、LLM 配置/测试等）单独命中前缀才延长。
+func LongPathDeadline(paths []string, d time.Duration) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		for _, prefix := range paths {
+			if strings.HasPrefix(c.Request.URL.Path, prefix) {
+				rc := http.NewResponseController(c.Writer)
+				dl := time.Now().Add(d)
+				if err := rc.SetReadDeadline(dl); err != nil {
+					logger.Debug("extend read deadline failed on %s: %v", c.Request.URL.Path, err)
+				}
+				if err := rc.SetWriteDeadline(dl); err != nil {
+					logger.Debug("extend write deadline failed on %s: %v", c.Request.URL.Path, err)
+				}
+				break
+			}
 		}
 		c.Next()
 	}

--- a/source/psophliteos/middleware/jwt.go
+++ b/source/psophliteos/middleware/jwt.go
@@ -40,8 +40,10 @@ func SetJWTSecretFilePath(p string) { jwtSecretFile = p }
 //     server.authSecret 时需要一并配置；默认部署 bmssm 生成随机 secret 持久化，
 //     无需设置。
 //  2. bmssm 持久化随机 secret（/var/lib/bmssm/jwt_secret，默认部署）。
-//  3. 开发默认值 ssm-dev-secret（bmssm EnsureSecret 失败时的回退，与之一致）。
-func bmssmJWTSecret() string {
+//  3. 两者皆不可得 → 返回错误（P2-6 fail-closed）。不再回退开发默认
+//     ssm-dev-secret：该值公开，回退时任意持有者可伪造 sub=admin 的 JWT 绕过
+//     本地敏感路由。正常部署 bmssm 启动即生成并持久化 secret，不受影响。
+func bmssmJWTSecret() (string, error) {
 	configured := ""
 	config.Conf.RLock()
 	if v := config.Conf.GetViper(); v != nil { // 配置未加载（如单测）视为无配置
@@ -49,24 +51,28 @@ func bmssmJWTSecret() string {
 	}
 	config.Conf.RUnlock()
 	if configured != "" && !devSecrets[configured] {
-		return configured
+		return configured, nil
 	}
 	if data, err := os.ReadFile(jwtSecretFile); err == nil {
 		if s := strings.TrimSpace(string(data)); s != "" {
-			return s
+			return s, nil
 		}
 	}
-	return DefaultSecret
+	return "", errors.New("bmssm jwt secret unavailable (no bmssm.authSecret and no " + jwtSecretFile + "); refusing to validate")
 }
 
 // CheckBMSSMToken 校验 token 是否为 bmssm 签发的有效 JWT（签名 + 有效期），
 // 成功返回 token 中的用户名（sub）与临时标志（temp，首次登录待改密）。
 func CheckBMSSMToken(tokenString string) (username string, temp bool, err error) {
+	secret, err := bmssmJWTSecret()
+	if err != nil {
+		return "", false, err
+	}
 	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
 		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, errors.New("unexpected signing method")
 		}
-		return []byte(bmssmJWTSecret()), nil
+		return []byte(secret), nil
 	})
 	if err != nil {
 		return "", false, err

--- a/source/psophliteos/middleware/jwt_test.go
+++ b/source/psophliteos/middleware/jwt_test.go
@@ -40,24 +40,16 @@ func resetJWTSecretFile(t *testing.T, path string) {
 	t.Cleanup(func() { jwtSecretFile = orig })
 }
 
-func TestCheckBMSSMTokenDefaultSecret(t *testing.T) {
-	// 无配置、无持久化文件 → 回退开发默认 secret（与 bmssm 空配置口径一致）
+func TestCheckBMSSMTokenFailClosedNoSecret(t *testing.T) {
+	// 无配置、无持久化文件 → fail-closed（P2-6）：不得回退开发默认 secret 校验，
+	// 否则持有公开默认值的任意人可伪造 sub=admin JWT 绕过本地敏感路由。
 	resetJWTSecretFile(t, "")
 
-	u, temp, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, false))
-	if err != nil || u != "admin" || temp {
-		t.Fatalf("valid token rejected: u=%q temp=%v err=%v", u, temp, err)
+	if _, _, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, false)); err == nil {
+		t.Fatal("default-secret token accepted without persisted secret (fail-closed violated)")
 	}
-
 	if _, _, err := CheckBMSSMToken("garbage-token"); err == nil {
 		t.Fatal("garbage token accepted")
-	}
-	if _, _, err := CheckBMSSMToken(issueToken(t, "admin", "wrong-secret", false)); err == nil {
-		t.Fatal("token signed with wrong secret accepted")
-	}
-	// 临时 token 标志透出
-	if _, temp, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, true)); err != nil || !temp {
-		t.Fatalf("temp flag not reported: temp=%v err=%v", temp, err)
 	}
 	// 缺 sub 的 token 拒绝
 	claims := jwt.MapClaims{"exp": time.Now().Add(time.Hour).Unix()}
@@ -67,19 +59,6 @@ func TestCheckBMSSMTokenDefaultSecret(t *testing.T) {
 	}
 	if _, _, err := CheckBMSSMToken(tok); err == nil {
 		t.Fatal("token without subject accepted")
-	}
-	// 已过期 token 拒绝
-	expired := jwt.MapClaims{
-		"sub": "admin",
-		"iat": time.Now().Add(-2 * time.Hour).Unix(),
-		"exp": time.Now().Add(-1 * time.Hour).Unix(),
-	}
-	exTok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, expired).SignedString([]byte(DefaultSecret))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, _, err := CheckBMSSMToken(exTok); err == nil {
-		t.Fatal("expired token accepted")
 	}
 }
 
@@ -98,10 +77,33 @@ func TestCheckBMSSMTokenPersistedSecret(t *testing.T) {
 	if _, _, err := CheckBMSSMToken(issueToken(t, "admin", DefaultSecret, false)); err == nil {
 		t.Fatal("default-secret token accepted while persisted secret active")
 	}
+	// 临时 token 标志透出（持久化 secret 路径）
+	if _, temp, err := CheckBMSSMToken(issueToken(t, "admin", secret, true)); err != nil || !temp {
+		t.Fatalf("temp flag not reported: temp=%v err=%v", temp, err)
+	}
+	// 已过期 token 拒绝
+	expired := jwt.MapClaims{
+		"sub": "admin",
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		"exp": time.Now().Add(-1 * time.Hour).Unix(),
+	}
+	exTok, err := jwt.NewWithClaims(jwt.SigningMethodHS256, expired).SignedString([]byte(secret))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := CheckBMSSMToken(exTok); err == nil {
+		t.Fatal("expired token accepted")
+	}
 }
 
 func TestRequireBMSSMTokenMiddleware(t *testing.T) {
-	resetJWTSecretFile(t, "")
+	// 设置有效持久化 secret（fail-closed 后无 secret 时全部 401，无法测到中间件语义）
+	secret := "middleware-test-secret"
+	path := filepath.Join(t.TempDir(), "jwt_secret")
+	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	resetJWTSecretFile(t, path)
 	gin.SetMode(gin.TestMode)
 	router := gin.New()
 	router.GET("/protected", RequireBMSSMToken(), func(c *gin.Context) {
@@ -127,7 +129,7 @@ func TestRequireBMSSMTokenMiddleware(t *testing.T) {
 	// 临时 token → 403（与 bmssm 口径一致：改密前无可用的受保护能力）
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
-	req.Header.Set("Authorization", "Bearer "+issueToken(t, "admin", DefaultSecret, true))
+	req.Header.Set("Authorization", "Bearer "+issueToken(t, "admin", secret, true))
 	router.ServeHTTP(w, req)
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("temp token: status=%d want 403", w.Code)
@@ -135,7 +137,7 @@ func TestRequireBMSSMTokenMiddleware(t *testing.T) {
 
 	// 有效 token（Authorization 头）→ 200 + user
 	w = httptest.NewRecorder()
-	tok := issueToken(t, "admin", DefaultSecret, false)
+	tok := issueToken(t, "admin", secret, false)
 	req = httptest.NewRequest(http.MethodGet, "/protected", nil)
 	req.Header.Set("Authorization", "Bearer "+tok)
 	router.ServeHTTP(w, req)


### PR DESCRIPTION
## Summary
按 MYS-809 发版 review 结论修复 P1 与指定 P2 项（用户确认修复清单），其余 P2 不修。版本随之 bump。

| 编号 | 工具（版本） | 改动 |
| --- | --- | --- |
| P1-1 | sophliteos 2.2.6→2.2.7 | `/api/sso/register` 拒绝临时 token（默认凭据不得顶掉管理员）；前端 403 `change_pass_required` 转入改密引导（临时 token 仍可调 `/api/v1/password` 改密） |
| P1-2 | bmssm 2.3.7→2.3.8 | 防火墙保护端口守卫收紧：拒绝保护端口（SSH/Web）的规则无论 src 宽窄一律拦截；前端二次确认框新增"可能锁死管理通道，建议 SSH 手动登录由专业人士命令行操作"强警示（中/英） |
| P1-3 | 核查 | 已确认修复（ota.sh/SophUI `find -L`，#160），无需再改 |
| P2-2 | bmssm | 软件上传包名拒绝空/`..`（`..tar.gz` 剥后缀得 `..` 可逃逸父目录） |
| P2-4 | pota_update 1.5.3→1.5.4 | get_network_info.sh 拼命令值单引号转义 |
| P2-5 | socbak 1.3.0→1.3.1 | cleanup 不吞退出码；信号与 EXIT trap 分离 |
| P2-6 | sophliteos | JWT secret fail-closed：无 authSecret 且无 jwt_secret 文件时拒绝校验，不再回退公开默认值 |
| P2-7 | sophliteos | LongPathDeadline 仅长窗口路径（文件/OTA 下载、llm-proxy）延长，常规 `/api/v1/*` 回落 30s 超时边界 |
| P2-8 | sophliteos | metrics_forward token 生成 crypto/rand 失败直接报错，不回退时间熵 |

## 测试
- bmssm `go test ./...` 全通过（firewall 守卫用例随新语义更新、service 包名用例新增）
- sophliteos `go test ./...` 全通过（register/jwt/metrics 用例适配 fail-closed 与 temp 拒绝语义）
- get_network_info.sh / socbak.sh `bash -n` 通过

## 行为变化提示
- 默认密码首登：Web 登录后将直接进入改密引导（register 拒绝临时 token），改密后重新登录；临时 token 改密接口不受影响
- 防火墙：所有"拒绝管理端口（SSH/Web）"的规则将被拦截并提示，无法再通过防火墙意图切断管理通道（防自锁死）
- 其余均为内部防御性收紧，正常使用无感