### PR TITLE
fix(sophliteos): /agent/ws 反代保留浏览器原始 Host，修复 AI 对话 WS 403 重连 (MYS-833)

### DIFF
--- a/source/psophliteos/initialization/proxy_host_test.go
+++ b/source/psophliteos/initialization/proxy_host_test.go
@@ -1,0 +1,82 @@
+package initialization
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	"sophliteos/config"
+	"sophliteos/global"
+)
+
+// TestProxyHostPreservesAgentWSOriginHost 回归：/agent/ws 反代必须保留浏览器原始
+// Host（bmssm serveWS 的 CSWSH CheckOrigin 用 Origin.Host == r.Host 做同源校验，
+// 反代改写 Host 会把一切浏览器同源握手 403）；/api/v1/* 维持改写为上游 Host。
+//
+// 说明：ReverseProxy 依赖 CloseNotify，需用真实 server（httptest.NewServer）
+// 而非 ResponseRecorder 直调路由（httptest.ResponseRecorder 无 CloseNotify，
+// gin + ReverseProxy 会 panic）。
+func TestProxyHostPreservesAgentWSOriginHost(t *testing.T) {
+	config.LoadConfig()
+
+	// DeadlineMiddleware 使用 global.OtaTimeOut；测试环境未走 InitBase（0 值会
+	// 让 /agent/ws 的写超时即刻过期导致反代 copy 失败），固定为长窗口。
+	origOta := global.OtaTimeOut
+	global.OtaTimeOut = 12 * time.Minute
+	t.Cleanup(func() { global.OtaTimeOut = origOta })
+
+	// 假上游：原样回显收到的 Host 头。
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		fmt.Fprint(w, r.Host)
+	}))
+	defer upstream.Close()
+	upstreamHost := strings.TrimPrefix(upstream.URL, "http://")
+
+	conf := &config.Conf
+	conf.Lock()
+	conf.GetViper().Set("bmssm.server", upstreamHost)
+	conf.Unlock()
+	t.Cleanup(func() {
+		conf.Lock()
+		conf.GetViper().Set("bmssm.server", "127.0.0.1:9779")
+		conf.Unlock()
+	})
+
+	router := Routers(fstest.MapFS{"index.html": {Data: []byte("<html></html>")}})
+	front := httptest.NewServer(router)
+	defer front.Close()
+
+	// 浏览器视角：入口 Host 为前端 server 地址（模拟任意外部入口）。
+	clientHost := strings.TrimPrefix(front.URL, "http://")
+	client := &http.Client{}
+
+	get := func(t *testing.T, path string) string {
+		t.Helper()
+		resp, err := client.Get(front.URL + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return string(b)
+	}
+
+	t.Run("agent/ws 保留原始 Host", func(t *testing.T) {
+		// 假上游回显 r.Host：应等于浏览器入口 Host（而非上游 127.0.0.1:port）
+		if got := get(t, "/agent/ws"); got != clientHost {
+			t.Fatalf("upstream saw Host=%q, want %q (Host 被反代改写了)", got, clientHost)
+		}
+	})
+
+	t.Run("api/v1 维持改写为上游 Host", func(t *testing.T) {
+		if got := get(t, "/api/v1/login"); got != upstreamHost {
+			t.Fatalf("upstream saw Host=%q, want %q", got, upstreamHost)
+		}
+	})
+}

--- a/source/psophliteos/initialization/router.go
+++ b/source/psophliteos/initialization/router.go
@@ -125,8 +125,15 @@ func Routers(webFS fs.FS) *gin.Engine {
 		originalDirector := proxy.Director
 		proxy.Director = func(req *http.Request) {
 			originalDirector(req)
-			// 保留 Host 便于 bmssm 识别
-			req.Host = bmssmTarget.Host
+			// /api/v1/*：把 Host 指到 bmssm 上游，便于 bmssm 识别自身。
+			if req.URL.Path != "/agent/ws" {
+				req.Host = bmssmTarget.Host
+				return
+			}
+			// /agent/ws：必须保留浏览器原始 Host——bmssm serveWS 的 CSWSH CheckOrigin
+			// 用 Origin.Host == r.Host 做同源校验，反代一旦把 Host 改成 127.0.0.1:9779，
+			// 任何浏览器（含同源页面）都会被 403 拒于握手之前；保留原始 Host 后
+			// 同源页面通过、跨站 Origin 仍被拒（CSWSH 语义不变）。
 		}
 		proxy.Transport = &http.Transport{
 			// 长连接支持（含 WebSocket）


### PR DESCRIPTION
## Summary

修复 AI 智能体对话页：浏览器 `/agent/ws` WebSocket 握手一直 403 → 前端无限"重连中"。

**根因**（经 MYS-379 的 CSWSH 加固引入）：bmssm `serveWS` 的 `CheckOrigin` 用
`Origin.Host == r.Host` 做同源校验，而 sophliteos 反代把**所有**路径的 `Host` 头都
改写为上游 `127.0.0.1:9779`。因此任何浏览器（甚至是同源页面）发起的 `/agent/ws`
握手到达 bmssm 时 Host 都与 Origin 不匹配 → 403 → 连接建立失败。

影响面：设备直达和经外部转发（如 13.24:18080 → 10.42.0.123:8080）同样命中。
属预先存在缺陷（旧版本同样存在），不是本次日志下载修复引入的回归。

## Change

`sophliteos/initialization/router.go` — 反代 `Director`：
- `/agent/ws`：保留浏览器原始 `Host`（bmssm 的 CSWSH 校验依赖它做同源判断）
- `/api/v1/*`：维持原行为，Host 仍改写为上游，便于 bmssm 识别自身

CSWSH 防护语义保持不变：同源页面通过；跨站 Origin（恶意网站拉起 ws）仍被拒。

## Verification

- 新增回归测试 `proxy_host_test.go`：假上游回显 `r.Host`，断言 `/agent/ws` 保留
  原始 Host、`/api/v1/login` 仍为上游 Host；sophliteos `go test ./...` 全绿。
- 真机（10.42.0.123，sophliteos 含本修复）经 13.24:18080 socat 转发实测：
  - 同源握手 `Origin: http://172.26.13.24:18080` → **101 Switching Protocols**
  - 跨站握手 `Origin: http://evil.com` → **403**（CSWSH 未削弱）
- 修复已部署到 10.42.0.123，可在该设备访问 AI 对话页复核。

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>