### PR TITLE
fix(bmssm/sophliteos): postinst 清理旧 systemd unit + bump v2.3.9/v2.2.8（发版 v26.08.31 前置）

### DIFF
--- a/source/pbmssm/build/deb/postinst
+++ b/source/pbmssm/build/deb/postinst
@@ -21,6 +21,27 @@ if ! dpkg -s iptables-persistent >/dev/null 2>&1; then
     DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent || true
 fi
 
+# 清理 ≤1.2.x 升级残留（MYS-824 实测踩坑）：旧包把 unit 装在 /etc/systemd/system 下，
+# 且指向旧二进制 /bin/bmssm；systemd 中 /etc 优先级高于 /usr/lib，二者叠加会持续拉起
+# 旧版本。升级到本包时删除该残留（仅当指向旧路径，保留用户手动改过的 unit）。
+ETC_UNIT=/etc/systemd/system/bmssm.service
+if [ -f "$ETC_UNIT" ] && ! grep -q "^ExecStart=/opt/sophon/bmssm/bin/bmssm" "$ETC_UNIT"; then
+    echo "postinst: removing stale $ETC_UNIT (points to old path)" >&2
+    rm -f "$ETC_UNIT"
+fi
+
+# CV84X2 Ubuntu 22.04 rootfs（overlay）上 systemd 实测不识别 /usr/lib/systemd/system 下
+# 的新装 unit（unit-paths 含该路径但 cat/status 均报 not found，与 sophliteos 同现象），
+# 此处兜底：daemon-reload 后 unit 仍不可见则显式落到 /etc/systemd/system（优先级最高）。
+LIB_UNIT=/usr/lib/systemd/system/bmssm.service
+if [ -f "$LIB_UNIT" ]; then
+    systemctl daemon-reload
+    if ! systemctl cat bmssm >/dev/null 2>&1; then
+        echo "postinst: unit not visible from $LIB_UNIT, installing to $ETC_UNIT" >&2
+        cp "$LIB_UNIT" "$ETC_UNIT"
+    fi
+fi
+
 systemctl daemon-reload
 systemctl enable bmssm 2>/dev/null || true
 # 升级时重启新版本；首次安装时启动。失败不阻断 dpkg

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.8"
+DEFAULT_VERSION="2.3.9"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.7"
+DEFAULT_VERSION="2.2.8"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。


### PR DESCRIPTION
## 背景
发版 v26.08.31 前置（MYS-824 真机测试发现 + RELEASE.md §2 版本 bump 要求）。

## 改动

| 文件 | 内容 |
| --- | --- |
| `source/pbmssm/build/deb/postinst` | 修复：清理 `/etc/systemd/system/bmssm.service` 残留（旧包指向 `/bin/bmssm`，systemd /etc 优先导致升级后仍起旧 1.2.0）；CV84X2 overlay 下 unit 不可见时兜底落 `/etc/systemd/system`（与 sophliteos 同款逻辑） |
| `source/pbmssm/build/version.sh` | DEFAULT_VERSION 2.3.8 → **2.3.9**（日志下载修复/MYS-833、/agent/ws 修复、seskill 预载、postinst 修复） |
| `source/psophliteos/build/version.sh` | DEFAULT_VERSION 2.2.7 → **2.2.8**（日志下载修复/MYS-833、/agent/ws Host 修复） |

## 测试
- `go test ./...`：bmssm、sophliteos 全 PASS
- `bash -n`：postinst 通过

## review+merge 提示
- 合入方式：squash merge 到 main（账号 zfsopv）
- 合入后即进入 v26.08.31 发版流程（构建 → 删 v26.08.29 release 保留 tag → 发布）