### PR TITLE
fix(sophliteos): OTA 升级执行补二次确认码（MYS-389），修复升级页 403

### DIFF
--- a/source/psophliteos/frontend/src/api/maintenance/index.ts
+++ b/source/psophliteos/frontend/src/api/maintenance/index.ts
@@ -235,9 +235,53 @@ export function modComIP(params: any) {
   return defHttp.post({ url: Api.modComIP, params });
 }
 
-// 执行 OTA 升级（ssm POST /ota/upgrade）
+// 执行 OTA 升级（ssm POST /ota/upgrade）。MYS-389：需带二次确认码 confirm，
+// 缺失/过期 bmssm 返回 403 confirmation required。错误交给调用方（executeHazard）统一处理，
+// 不触发 defHttp 默认 403 弹窗（避免误导性"访问被禁止"提示）。
 export function executeUpgradeApi(params: any) {
-  return defHttp.post({ url: '/v1/ota/upgrade', params });
+  return defHttp.post({ url: '/v1/ota/upgrade', params }, { errorMessageMode: 'none' });
+}
+
+export interface HazardChallenge {
+  code: string;
+  expiresInSecs: number;
+}
+
+// 高危操作二次确认码（GET /v1/hazard/challenge，经反代到 bmssm）。
+export function getHazardChallenge() {
+  return defHttp.get<HazardChallenge>({ url: '/v1/hazard/challenge' }, { errorMessageMode: 'none' });
+}
+
+// executeHazard MYS-389 高危操作二次确认执行：取一次性确认码 → 带 confirm 调用 apiFn。
+// 确认码过期（bmssm 403 confirmation required）时自动重新取码重试一次，保证与已确认的
+// 操作语义一致（对齐防火墙 rebuild 流程）；取码失败/重试仍 403 时抛出，由调用方提示。
+export async function executeHazard(
+  apiFn: (params: any) => Promise<any>,
+  execBody: Record<string, any>,
+): Promise<any> {
+  let retried = false;
+  for (;;) {
+    let code = '';
+    try {
+      const ch = await getHazardChallenge();
+      code = ch?.code || '';
+    } catch (e) {
+      throw e;
+    }
+    if (!code) {
+      throw new Error('获取二次确认码失败');
+    }
+    try {
+      return await apiFn({ ...execBody, confirm: code });
+    } catch (e: any) {
+      const msg = e?.response?.data?.error_message || e?.message || '';
+      if (!retried && msg.includes('confirmation required')) {
+        retried = true;
+        continue;
+      }
+      throw e;
+    }
+  }
 }
 
 // 远程单条命令执行（ssm POST /hardware/exec）

--- a/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/controlForm.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/controlForm.vue
@@ -156,6 +156,7 @@
     uploadPartFile,
     checkFileList,
     executeUpgradeApi,
+    executeHazard,
   } from '/@/api/maintenance/index';
   import { useDeviceInfo } from '/@/store/modules/overview';
   import { useMessage } from '/@/hooks/web/useMessage';
@@ -519,8 +520,17 @@
           version: '',
           flashData: flashVal,
         };
-        await executeUpgradeApi(execBody);
-        createMessage.success(t('maintenance.systemUpdate.controlStartUpload'), 4);
+        try {
+          // 高危操作二次确认（MYS-389）：executeHazard 自动取确认码携带 confirm，
+          // 否则 bmssm 返回 403（confirmation required）。
+          await executeHazard(executeUpgradeApi, execBody);
+          createMessage.success(t('maintenance.systemUpdate.controlStartUpload'), 4);
+        } catch (e) {
+          const errMsg = (e as any)?.response?.data?.error_message || (e as any)?.message || '升级触发失败';
+          createMessage.error(errMsg, 4);
+          item.status = 'error';
+          return { success: false, error: e };
+        }
         item.status = 'success';
         return { success: true, error: null };
       }
@@ -573,10 +583,12 @@
           flashData: flashVal,
         };
         try {
-          await executeUpgradeApi(execBody);
+          // 高危操作二次确认（MYS-389）：executeHazard 自动取确认码携带 confirm
+          await executeHazard(executeUpgradeApi, execBody);
           createMessage.success(t('maintenance.systemUpdate.controlStartUpload'), 4);
         } catch (e) {
-          // defHttp 已提示错误
+          const errMsg = (e as any)?.response?.data?.error_message || (e as any)?.message || '升级触发失败';
+          createMessage.error(errMsg, 4);
           item.status = 'error';
           return { success: false, error: e };
         }

--- a/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/coreForm.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/coreForm.vue
@@ -110,7 +110,7 @@
   import { Checkbox, CheckboxGroup, Upload, Input, InputPassword } from 'ant-design-vue';
   import { UploadOutlined } from '@ant-design/icons-vue';
   import { useMessage } from '/@/hooks/web/useMessage';
-  import { upgradeApi, executeUpgradeApi } from '/@/api/maintenance/index';
+  import { upgradeApi, executeUpgradeApi, executeHazard } from '/@/api/maintenance/index';
   import { storeToRefs } from 'pinia';
   import { useDeviceInfo } from '/@/store/modules/overview';
   import { buildUUID } from '/@/utils/uuid';
@@ -279,10 +279,14 @@
         flashData: false,
       };
       try {
-        await executeUpgradeApi(execBody);
+        // OTA 执行属高危操作（MYS-389）：executeHazard 自动取二次确认码携带 confirm，
+        // 否则 bmssm 返回 403（confirmation required）。
+        await executeHazard(executeUpgradeApi, execBody);
         item.responseData = data;
       } catch (e) {
         item.status = 'error';
+        const errMsg = (e as any)?.response?.data?.error_message || (e as any)?.message || '升级触发失败';
+        createMessage.error(errMsg, 4);
         return { success: false, error: e };
       }
       item.status = 'success';


### PR DESCRIPTION
## 背景
10.42.0.123 板（sophliteos 2.2.7 / bmssm 2.3.8）升级页点"开始升级"报 403："用户得到授权，但是访问是被禁止的!"。

## 根因
bmssm `ExecuteUpgrade`/`Rollback`（MYS-389 高危二次确认）强制要求请求体带 `confirm` 二次确认码，缺失/过期返回 403 `confirmation required`。sophliteos 2.2.7 前端升级页未实现挑战码流程：
- 只有防火墙页面（`firewall/Intent.vue`）实现了 `getHazardChallenge` + confirm 携带；
- `coreForm.vue` / `controlForm.vue` 的 `executeUpgradeApi` 调用**从未获取确认码** → bmssm 403 → axios 拦截器弹误导文案。

已实测复现：`POST /api/v1/ota/upgrade`（正式 token）→ 403 confirmation required（确认码缺失）。

## 修复
- `api/maintenance/index.ts`：新增 `executeHazard`（取 `/v1/hazard/challenge` 一次性确认码 → 携带 `confirm` 调用；确认码过期 403 时自动重新取码重试一次，对齐防火墙 rebuild 流程）；`executeUpgradeApi` 关闭默认 403 弹窗，错误由调用方按真实 `error_message` 提示。
- `coreForm.vue` / `controlForm.vue`：三处 `executeUpgradeApi` 调用改走 `executeHazard`，失败时显式提示真实原因（不再出现误导性"用户得到授权，但是访问是被禁止的!"）。

## 测试
- 待构建验证（`pnpm build` 类型检查 + 打包）；已核对 bmssm `OtaVersion.confirm` JSON tag 与前端 `{ confirm: code }` 匹配。
- 发版后真机回归：10.42.0.123 升级页执行 OTA 不再 403。

## review+merge 提示
- 合入方式：squash merge（账号 zfsopv）
- 归属：随 v26.08.31（sophliteos 2.2.8）发布