### PR TITLE
fix(build): multica worktree 下容器构建 .git 引用无法解析（挂载主 git 目录）

### DIFF
--- a/docker/build-all.sh
+++ b/docker/build-all.sh
@@ -150,9 +150,31 @@ run_one() {
 
   local rc=0
   local extra_env="${EXTRA_ENV[$p]:-}"
+
+  # multica worktree 兼容（MYS-809/统一构建踩坑）：监控仓库以 git worktree 形式检出，
+  # 仓库根 .git 为 gitdir 引用文件（指向宿主绝对路径）。容器内 git 解析该引用失败
+  # （"not a git repository"），会打断 pnpm 安装 git 依赖（mpegts.js → webworkify-webpack）。
+  # 把 worktree 的主 git 目录按"同绝对路径"挂进容器，使 .git 引用在容器内可解析。
+  local git_mounts=()
+  if [ -f "${REPO_ROOT}/.git" ] && head -1 "${REPO_ROOT}/.git" 2>/dev/null | grep -q '^[[:space:]]*gitdir:'; then
+    local wt_gitdir main_common main_git_dir
+    wt_gitdir="$(sed -n 's/^[[:space:]]*gitdir:[[:space:]]*//p' "${REPO_ROOT}/.git" | sed 's/[[:space:]]*$//')"
+    if [ -n "$wt_gitdir" ] && [ -f "$wt_gitdir/commondir" ]; then
+      main_common="$(head -1 "$wt_gitdir/commondir" | sed 's/[[:space:]]*$//')"
+      case "$main_common" in
+        /*) main_git_dir="$main_common" ;;
+        *)  main_git_dir="$(cd "$wt_gitdir/$main_common" 2>/dev/null && pwd -P || true)" ;;
+      esac
+      if [ -n "$main_git_dir" ] && [ -d "$main_git_dir" ]; then
+        git_mounts=(-v "${main_git_dir}:${main_git_dir}:ro")
+      fi
+    fi
+  fi
+
   docker run --rm --privileged \
     -v /dev:/dev \
     -v "${REPO_ROOT}":/workspace/sophon-tools \
+    "${git_mounts[@]}" \
     -w "/workspace/sophon-tools/source/${p}" \
     -e OUTPUT_DIR="/workspace/sophon-tools/output/${p}" \
     "${IMAGE}" bash -c "


### PR DESCRIPTION
## 问题
sophon-tools 以 **git worktree** 形式检出时（multica 环境），仓库根 `.git` 是 `gitdir:` 引用文件，指向宿主绝对路径。统一构建容器内 git 解析该引用失败（`fatal: not a git repository`），psophliteos 前端 `pnpm install` 的 git 依赖（mpegts.js → webworkify-webpack）必挂——MYS-809 已记录、本次发版构建复现两次。

## 修复
`docker/build-all.sh`：`docker run` 前检测 `REPO_ROOT/.git` 是否为 gitdir 引用，若是则解析 worktree `commondir` 找到主 git 目录，将其按**同绝对路径只读挂载**进容器（`-v <main_git>:<main_git>:ro`），容器内 `.git` 引用即可解析。
- 普通 git 目录（`.git` 为目录）不受影响，不触发额外挂载。
- 只读挂载，容器无法污染 .repos 缓存。

## 实测
容器内 `git status` 仓库解析 OK；`git ls-remote https://github.com/xqq/webworkify-webpack.git` 成功。

## 验证
psophliteos 前端 `pnpm install` + 构建在挂载后通过。

## review+merge 提示
- 合入方式：squash merge（账号 zfsopv）