### PR TITLE
fix(bmssm): OTA 升级/回滚首条 workflow 自锁误杀（MYS-451 竞态）+ bump 2.3.10

### DIFF
--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.9"
+DEFAULT_VERSION="2.3.10"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/pbmssm/mvc/compat/controller.go
+++ b/source/pbmssm/mvc/compat/controller.go
@@ -510,6 +510,13 @@ func (ctrl *Controller) ExecuteUpgrade(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// MYS-451 竞态（10.42.0.123 真机复现）：锁必须在 EnqueueFlow 前释放。worker 在
+	// flow 入队后立即获取刷机锁（ota.flash，覆盖整个刷机窗口）；若持锁到 handler
+	// 返回，worker 的第一把 acquire 会撞上本 handler 持有的 "ota.upgrade"，导致
+	// 首个提交的 workflow 被自身误标 Fail（"hazard lock: ota.upgrade is already
+	// in progress"）。并发防串由 worker 的 ota.flash 锁承担（刷机窗口内提交的
+	// 并发 upgrade 会在 worker 侧快速拒绝）。defer 保留作兜底（Release 幂等）。
+	guard.Release()
 	defer guard.Release()
 	// Product 为空时用设备实际型号兜底（global.DeviceTypeEx 形如 "SE7 V01"），
 	// 否则 productClass 识别不到会返回 "ota: path not implemented"。
@@ -550,6 +557,9 @@ func (ctrl *Controller) Rollback(c *gin.Context) {
 	if !ok {
 		return
 	}
+	// 同 ExecuteUpgrade（MYS-451 竞态）：入队前释放 handler 级锁，防 worker 抢
+	// ota.flash 时撞上本 handler 持有的 ota.rollback 锁。defer 兜底（幂等）。
+	guard.Release()
 	defer guard.Release()
 
 	product := req.Product

--- a/source/pbmssm/mvc/compat/controller_test.go
+++ b/source/pbmssm/mvc/compat/controller_test.go
@@ -1147,3 +1147,50 @@ func TestCompatEndpointsRequireAuth(t *testing.T) {
 		})
 	}
 }
+
+// TestCompatExecuteUpgradeNoSelfLock 回归：ExecuteUpgrade 入队后 worker 不应因
+// 自身 handler 仍持有 ota.upgrade 互斥锁而误判"hazard lock: already in progress"。
+// 此前 handler 全程持锁、worker 入队即抢 ota.flash 锁，二者冲突致首个 workflow
+// 必被误杀（MYS-451 引入，10.42.0.123 真机复现）。修复后 handler 入队前即释放锁，
+// flow 应正常到达终态 Success。
+func TestCompatExecuteUpgradeNoSelfLock(t *testing.T) {
+	r := setupCompatTest(t)
+	token := getNormalToken(t, r)
+
+	body, _ := json.Marshal(OtaVersion{
+		Product: "SE7", ModuleName: "soc", FileName: "soc_fw.tgz", Name: "race-test",
+		Version: "1.0.0", Confirm: hazard.NewConfirmCode(),
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/ota/upgrade", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	r.ServeHTTP(w, req)
+	assertSsmOK(t, w.Body.Bytes(), "upgrade enqueue")
+
+	// 等待 worker 消费到终态（dryRun flash → Success）
+	deadline := time.Now().Add(2 * time.Second)
+	var gotStatus int
+	var gotInfo string
+	for time.Now().Before(deadline) {
+		w2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest(http.MethodGet, "/api/v1/ota/workflow", nil)
+		req2.Header.Set("Authorization", "Bearer "+token)
+		r.ServeHTTP(w2, req2)
+		resp := assertSsmOK(t, w2.Body.Bytes(), "list")
+		if arr, ok := resp.Result.([]interface{}); ok && len(arr) > 0 {
+			if m, ok := arr[0].(map[string]interface{}); ok {
+				gotStatus = int(m["status"].(float64))
+				gotInfo, _ = m["info"].(string)
+				if gotStatus == ota.StatusSuccess || gotStatus == ota.StatusFail {
+					break
+				}
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if gotStatus != ota.StatusSuccess {
+		t.Errorf("workflow 终态 status=%d info=%q, want Success(%d)；首个 OTA 不应因自身 handler 锁被误杀",
+			gotStatus, gotInfo, ota.StatusSuccess)
+	}
+}


### PR DESCRIPTION
## 背景
10.42.0.123（bmssm 2.3.9）首次 OTA 升级即失败：workflow 状态 Fail 且 info = `hazard lock: hazardous operation blocked: ota.upgrade is already in progress`（唯一一条 workflow、无任何并发提交者，被**自身的 handler 锁误杀**）。

## 根因（MYS-451 引入刷机锁后的竞态）
- `ExecuteUpgrade`/`Rollback` 在 `requireHazardGuard` 获取 `"ota.upgrade"`/`"ota.rollback"` 锁后，**持有到 handler 函数返回**（`defer guard.Release()`）；
- 而 `otaEngine` worker 在 `EnqueueFlow`（非阻塞入队）后**立即**执行 `acquireFlashGuard` 获取刷机窗口锁 `"ota.flash"`；
- 两者竞态：worker 先于 handler 返回拿到 `ota.flash` 时，撞上 handler 持有的 `"ota.upgrade"` → `TryAcquire("ota.flash")` 失败 → workflow 标 Fail `hazard lock: ota.upgrade is already in progress`。首个升级必现（真机已复现）。

## 修复
handler 在 `EnqueueFlow` **之前**提前 `guard.Release()`（保留 `defer` 兜底，`Guard.Release` 幂等）。并发防串全部交由 worker 的 `ota.flash` 锁承担：刷机窗口内提交的并发 upgrade/rollback 仍会在 worker 侧快速拒绝（flow Fail），窗口外提交不再被自身干扰。
- `software` 路径为同步执行（解包+跑脚本，不经 worker），无此竞态，未改动。
- 版本 bump **2.3.9 → 2.3.10**（发布后 bug 修复，Z+1）。

## 测试
- 新增回归测试 `TestCompatExecuteUpgradeNoSelfLock`：提交 upgrade 后断言 workflow 到达终态 `Success`（dryRun 引擎），不再被自身锁误杀。
- `bmssm go test ./...` 全量 34 包 PASS；`go build ./...` 通过。

## review+merge 提示
- 合入方式：squash merge（账号 zfsopv）
- 合入后：重建 bmssm 2.3.10 → 更新 v26.08.31 release 资产（补丁小节）→ 部署 10.42.0.123 真机复验首次升级