### PR TITLE
fix(sophliteos): 单板设备升级语义改为 soc（系统升级）+ bump 2.2.9

### DIFF
--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.8"
+DEFAULT_VERSION="2.2.9"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。

--- a/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/en/maintenance.ts
@@ -19,6 +19,7 @@ export default {
     selectUpgradeCoreBoard: 'Please Select Core Board',
     updateStatus: 'Upgrade Status',
     controlStartUpload: 'Start upgrding..., please wait five minites.',
+    socStartUpload: 'System upgrade started, about 5 minutes.',
     softwareUpdateStatus: 'Start upgrding..., please wait a minite！.',
     selectNeedFile: 'Please select file to upload',
     fileFormat: 'Only .tgz files are supported',

--- a/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
+++ b/source/psophliteos/frontend/src/locales/lang/zh-CN/maintenance.ts
@@ -20,6 +20,7 @@ export default {
     selectUpgradeCoreBoard: '请选择核心板',
     updateStatus: '升级状态',
     controlStartUpload: '控制板开始升级，预计需要5分钟',
+    socStartUpload: '系统升级已开始，预计需要5分钟',
     softwareUpdateStatus: '软件正在升级，请您耐心等待！',
     selectNeedFile: '请选择需要上传的文件',
     fileFormat: '请选择需要上传的.tgz格式文件',

--- a/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/controlForm.vue
+++ b/source/psophliteos/frontend/src/views/maintenance/sysSoft/components/controlForm.vue
@@ -515,7 +515,9 @@
           name: fileName,
           product,
           fileName,
-          moduleName: 'ctrl',
+          // 单板设备无"控制板/核心板"模块概念，模块语义为 soc（系统固件）；
+          // 多板（SE6/8）才是 ctrl（控制板）。执行仍按 product 分派到 SOC 路径。
+          moduleName: deviceInfoStore.isSingleBoard ? 'soc' : 'ctrl',
           cmdFlag: '',
           version: '',
           flashData: flashVal,
@@ -524,7 +526,12 @@
           // 高危操作二次确认（MYS-389）：executeHazard 自动取确认码携带 confirm，
           // 否则 bmssm 返回 403（confirmation required）。
           await executeHazard(executeUpgradeApi, execBody);
-          createMessage.success(t('maintenance.systemUpdate.controlStartUpload'), 4);
+          createMessage.success(
+            deviceInfoStore.isSingleBoard
+              ? t('maintenance.systemUpdate.socStartUpload')
+              : t('maintenance.systemUpdate.controlStartUpload'),
+            4,
+          );
         } catch (e) {
           const errMsg = (e as any)?.response?.data?.error_message || (e as any)?.message || '升级触发失败';
           createMessage.error(errMsg, 4);
@@ -577,7 +584,8 @@
           name: fileName,
           product,
           fileName,
-          moduleName: 'ctrl',
+          // 单板设备模块语义为 soc（系统固件），多板（SE6/8）才是 ctrl
+          moduleName: deviceInfoStore.isSingleBoard ? 'soc' : 'ctrl',
           cmdFlag: '',
           version: '',
           flashData: flashVal,
@@ -585,7 +593,12 @@
         try {
           // 高危操作二次确认（MYS-389）：executeHazard 自动取确认码携带 confirm
           await executeHazard(executeUpgradeApi, execBody);
-          createMessage.success(t('maintenance.systemUpdate.controlStartUpload'), 4);
+          createMessage.success(
+            deviceInfoStore.isSingleBoard
+              ? t('maintenance.systemUpdate.socStartUpload')
+              : t('maintenance.systemUpdate.controlStartUpload'),
+            4,
+          );
         } catch (e) {
           const errMsg = (e as any)?.response?.data?.error_message || (e as any)?.message || '升级触发失败';
           createMessage.error(errMsg, 4);


### PR DESCRIPTION
## 背景
SE7/9/13 等**单板**设备（`isSingleBoard=true`，singleBoardArr 含 se5/se7/se9/se13/cv84x6/cv84x2）的升级页沿用 **SE6/8 集群语义**：workflow/升级状态列表"模块名"显示 **ctrl**、成功提示"控制板开始升级"——单板设备没有"控制板"，属语义误导。
> 注：引擎执行按 **product** 分派（SE13→ClassSOC→runSOC 系统刷机），moduleName 不影响实际刷机路径（ctrl/soc 上传目录同为 /data/ota）；这是纯前端语义问题。

## 修复（单板时）
- `executeUpgradeApi` 的 `moduleName`：`ctrl` → **`soc`**（workflow 与"升级状态列表"模块名展示正确）
- 成功提示：`控制板开始升级` → **`系统升级已开始，预计需要5分钟`**（新增 i18n `socStartUpload`，zh/en）
- 本地分片上传保留 `ctrl`：sophliteos 本地 OTA（/api/device/ota/*）接口仅接受 ctrl/core 模块，且目录与 soc 相同（/data/ota），无实际影响
- 多板（SE6/8）行为不变
- 版本 bump **2.2.8 → 2.2.9**

## 验证
- sophliteos `go test ./...` 全 PASS；前端改动为简单三元/文案，构建阶段 `pnpm build` 验证
- 合入后：重建 2.2.9 → 更新 v26.08.31 release 资产 + notes 补丁 → 部署 10.42.0.123 验证 workflow 模块名显示 soc

## review+merge 提示
- 合入方式：squash merge（账号 zfsopv）