### PR TITLE
fix(packaging): deb 内置空 preinst，规避 dpkg obsolete-info 报错中断解包

### DIFF
--- a/source/pbmssm/build/build-deb-bmssm.sh
+++ b/source/pbmssm/build/build-deb-bmssm.sh
@@ -142,8 +142,11 @@ assemble_deb() {
   cp build/deb/postinst "$DEBROOT/DEBIAN/postinst"
   cp build/deb/prerm    "$DEBROOT/DEBIAN/prerm"
   cp build/deb/postrm   "$DEBROOT/DEBIAN/postrm"
+  # 空 preinst：新旧包都带同名维护脚本，避免 dpkg 升级时触发
+  # "unable to remove obsolete info file '...preinst'" 报错中断解包
+  cp build/deb/preinst  "$DEBROOT/DEBIAN/preinst"
   cp build/deb/conffiles "$DEBROOT/DEBIAN/conffiles"
-  chmod 0755 "$DEBROOT/DEBIAN/postinst" "$DEBROOT/DEBIAN/prerm" "$DEBROOT/DEBIAN/postrm"
+  chmod 0755 "$DEBROOT/DEBIAN/postinst" "$DEBROOT/DEBIAN/prerm" "$DEBROOT/DEBIAN/postrm" "$DEBROOT/DEBIAN/preinst"
   chmod 0644 "$DEBROOT/DEBIAN/control" "$DEBROOT/DEBIAN/conffiles"
 
   # md5sums

--- a/source/pbmssm/build/deb/preinst
+++ b/source/pbmssm/build/deb/preinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+# 空 preinst：新旧 deb 均携带同名维护脚本（exit 0），避免 dpkg 升级时在
+# "旧登记有 preinst 而磁盘无此文件"的环境（重装/中断/刷镜像）触发
+# "unable to remove obsolete info file '...preinst'" 报错中断解包（发版实测）。
+exit 0

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.10"
+DEFAULT_VERSION="2.3.11"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"

--- a/source/psophliteos/build/build-deb-sophliteos.sh
+++ b/source/psophliteos/build/build-deb-sophliteos.sh
@@ -98,10 +98,13 @@ cp "$SRC_DEBIAN/conffiles" "$STAGE/DEBIAN/conffiles"
 cp "$SRC_DEBIAN/postinst" "$STAGE/DEBIAN/postinst"
 cp "$SRC_DEBIAN/prerm"    "$STAGE/DEBIAN/prerm"
 cp "$SRC_DEBIAN/postrm"   "$STAGE/DEBIAN/postrm"
+# 空 preinst：新旧包都带同名维护脚本，避免 dpkg 升级时触发
+# "unable to remove obsolete info file '...preinst'" 报错中断解包
+cp "$SRC_DEBIAN/preinst"  "$STAGE/DEBIAN/preinst"
 # md5sums（仅数据文件，路径去前导 ./，对齐 deb policy）
 ( cd "$STAGE" && find . -type f ! -path './DEBIAN/*' -printf '%P\0' | sort -z | xargs -0 md5sum ) \
   > "$STAGE/DEBIAN/md5sums"
-chmod 0755 "$STAGE/DEBIAN/postinst" "$STAGE/DEBIAN/prerm" "$STAGE/DEBIAN/postrm"
+chmod 0755 "$STAGE/DEBIAN/postinst" "$STAGE/DEBIAN/prerm" "$STAGE/DEBIAN/postrm" "$STAGE/DEBIAN/preinst"
 chmod 0644 "$STAGE/DEBIAN/control" "$STAGE/DEBIAN/conffiles" "$STAGE/DEBIAN/md5sums"
 
 # 6. 打包（--root-owner-group 让数据树属主 root:root）

--- a/source/psophliteos/build/sophliteos/DEBIAN/preinst
+++ b/source/psophliteos/build/sophliteos/DEBIAN/preinst
@@ -1,0 +1,5 @@
+#!/bin/bash
+# 空 preinst：新旧 deb 均携带同名维护脚本（exit 0），避免 dpkg 升级时在
+# "旧登记有 preinst 而磁盘无此文件"的环境（重装/中断/刷镜像）触发
+# "unable to remove obsolete info file '...preinst'" 报错中断解包（发版实测）。
+exit 0

--- a/source/psophliteos/build/version.sh
+++ b/source/psophliteos/build/version.sh
@@ -2,7 +2,7 @@
 
 # DEFAULT_VERSION 是 sophliteos 版本号的唯一权威定义；release.sh / build-deb
 # 从此处提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
-DEFAULT_VERSION="2.2.9"
+DEFAULT_VERSION="2.2.10"
 
 # 生成 release_version.txt：module/commit/buildname/buildtime。
 # commit/branch 全部来自 git 实时读取，不再写入硬编码残留。


### PR DESCRIPTION
## 问题
bmssm 2.3.10 / sophliteos 2.2.9 的 deb 在**刚重装的系统**上安装报错（发版实测，10.42.0.123）：

```
dpkg: error processing archive xxx.deb (--install):
 unable to remove obsolete info file '/var/lib/dpkg/info/bmssm.preinst': No such file or directory
```

根因：deb 内不含 preinst；当 dpkg 数据库中登记有旧 preinst（重装/中断/刷镜像遗留）而磁盘无此文件时，dpkg 升级走"删除 obsolete info 文件"分支失败 → 中断解包（包停在 half-installed，**服务未完成配置**；事后需 touch 占位 + dpkg --configure -a 修复）。

## 修复
deb 显式携带**空 preinst**（`exit 0`）：
- 新旧包都带同名维护脚本 → dpkg 升级直接覆盖文件，不再进入"删除 obsolete info"分支
- 全新安装正常（preinst 为空操作，无行为影响）
- bmssm/sophliteos 双 deb 打包脚本同步加入（`build-deb-bmssm.sh` / `build-deb-sophliteos.sh`）
- 版本 bump：bmssm **2.3.11**、sophliteos **2.2.10**

## 验证方式
- 打包脚本 `bash -n` 通过
- 重建后真机验证：重装系统场景 dpkg -i 不再报 preinst 错误（板上回归）

## review+merge 提示
- squash merge（账号 zfsopv）
- 合入后：重建 2.3.11/2.2.10 → 更新 v26.08.31 release 资产 → 板上回归