### PR TITLE
fix(bmssm): postinst 不再 apt-get（避免 dpkg 抢锁），iptables 依赖改 Recommends + bump 2.3.13

### DIFF
--- a/source/pbmssm/build/deb/bmssm.control
+++ b/source/pbmssm/build/deb/bmssm.control
@@ -5,6 +5,7 @@ Architecture: @ARCH@
 Maintainer: Sophgo <support@sophgo.com>
 Priority: optional
 Section: admin
+Recommends: iptables, iptables-persistent
 Description: bmssm - Sophon System Management
  Sophon 设备系统管理后端（bmssm 现代化重构）。
  提供 /api/v1/* REST API、WebSocket 实时终端、文件管理、OTA 升级工作流、

--- a/source/pbmssm/build/deb/postinst
+++ b/source/pbmssm/build/deb/postinst
@@ -11,14 +11,11 @@ mkdir -p /var/lib/bmssm /var/log/bmssm
 # DB 文件由 bmssm 启动时显式 chmod 0600（database.InitDB）
 chmod 0700 /var/lib/bmssm
 
-# 确保 iptables + iptables-persistent 已装（firewall 规则持久化依赖）
-if ! command -v iptables >/dev/null 2>&1; then
-    DEBIAN_FRONTEND=noninteractive apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables || true
-fi
-if ! dpkg -s iptables-persistent >/dev/null 2>&1; then
-    DEBIAN_FRONTEND=noninteractive apt-get update -qq
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq iptables-persistent || true
+# iptables/iptables-persistent 由 control Recommends 声明，apt 安装本包时自动满足；
+# 不在 postinst 内 apt-get：维护脚本在 dpkg 持锁阶段执行，apt 会与之抢
+# /var/lib/dpkg/lock-frontend 报 "Could not get lock"（发版实测）。缺失仅提示。
+if ! command -v iptables >/dev/null 2>&1 || ! dpkg -s iptables-persistent >/dev/null 2>&1; then
+    echo "WARN: firewall 依赖 iptables/iptables-persistent 未就绪，请手动执行: sudo apt-get install -y iptables iptables-persistent" >&2
 fi
 
 # 清理 ≤1.2.x 升级残留（MYS-824 实测踩坑）：旧包把 unit 装在 /etc/systemd/system 下，

--- a/source/pbmssm/build/version.sh
+++ b/source/pbmssm/build/version.sh
@@ -3,7 +3,7 @@
 # DEFAULT_VERSION 是 bmssm 版本号的唯一权威定义；release.sh / build-deb 从此处
 # 提取默认值（规范：版本号在工具代码中更新，仓库根 release 禁止传版本号进来）。
 set -e
-DEFAULT_VERSION="2.3.12"
+DEFAULT_VERSION="2.3.13"
 VERSION="${1:-$DEFAULT_VERSION}"
 COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
 BUILDTIME="$(date '+%Y-%m-%d_%H:%M:%S')"


### PR DESCRIPTION
## 问题
bmssm `postinst` 在 dpkg 持锁阶段调用 `apt-get install iptables-persistent`（重装系统缺该包时触发），apt 抢 `/var/lib/dpkg/lock-frontend` 报：
```
Setting up bmssm ... E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process ... (dpkg)
```
维护脚本内调用 apt/dpkg 是标准陷阱（dpkg 文档禁止）。`|| true` 兜底不阻断安装，但 iptables-persistent 未装上，防火墙规则无法持久化。

## 修复
- `postinst`：删除 apt-get 段，改为缺失时打印醒目提示（手动安装命令）。
- `bmssm.control`：新增 `Recommends: iptables, iptables-persistent`——用 apt 安装本包（`apt install ./bmssm.deb`）时自动满足依赖；`dpkg -i` 路径不再报锁错误。
- 版本 bump **2.3.13**（postinst 行为变更）。

## 验证
- 板实测：2.3.13 重装不再出现 `E: Could not get lock`；服务 active。
- bmssm `go test ./...` 34 包 PASS；postinst `bash -n` 通过。

## review+merge 提示
- squash merge（账号 zfsopv）
- 合入后重建 2.3.13 并替换 v26.08.31 资产