### PR TITLE
fix(memory_edit): CV84X6 -p 打印上限与校验不一致（多报 2M）

### DIFF
--- a/source/pmemory_edit/source/memory_edit/memory_edit.sh
+++ b/source/pmemory_edit/source/memory_edit/memory_edit.sh
@@ -548,7 +548,9 @@ fi
 echo "Info: =======================================================================" | tee -a $log_file_path
 echo "Info: get max memory size ..." | tee -a $log_file_path
 if [[ $runtime_info_target == "bm1688" || $runtime_info_target == "cv84x6" ]]; then
-	echo "Info: max npu+vpp size: $(printf "0x%x" $(($ddr_size - $npu_size_add))) [$(printf "%d MiB" "$(($(($ddr_size - $npu_size_add)) / $SIZE1M))")]" | tee -a $log_file_path
+	# npu+vpp 总量受 npu_size_add(底部 CMA+200M) 与 vpp_size_add(顶部 FREERTOS 预留) 共同约束，
+	# 必须都减去，否则 -p 报的总量比真实可配多 vpp_size_add（bm1688 该值为 0 不受影响）
+	echo "Info: max npu+vpp size: $(printf "0x%x" $(($ddr_size - $npu_size_add - $vpp_size_add))) [$(printf "%d MiB" "$(($(($ddr_size - $npu_size_add - $vpp_size_add)) / $SIZE1M))")]" | tee -a $log_file_path
 	echo "Info: max npu size: $(printf "0x%x" $(($ddr_size - $npu_size_add))) [$(printf "%d MiB" "$(($(($ddr_size - $npu_size_add)) / $SIZE1M))")]" | tee -a $log_file_path
 elif [[ $runtime_info_target == "bm1684" ]]; then
 	echo "Info: max npu size: $(printf "0x%x" $(($ddr1_size - $npu_size_add))) [$(printf "%d MiB" "$(($(($ddr1_size - $npu_size_add)) / $SIZE1M))")]" | tee -a $log_file_path
@@ -565,8 +567,11 @@ elif [[ $runtime_info_target == "bm1688" ]]; then
 		echo "Info: max vpp size: $(printf "0x%x" $(($size_4g - $vpp_size_add))) [$(printf "%d MiB" "$(($(($size_4g - $vpp_size_add)) / $SIZE1M))")]"| tee -a $log_file_path
 	fi
 elif [[ $runtime_info_target == "cv84x6" ]]; then
-	# MYSWY 决策：cv84x6 的 vpp 校验上限为 8GB，打印与校验保持一致
-	vpp_max_size=$(($size_4g * 2))
+	# MYSWY 决策：cv84x6 的 vpp 校验上限为 8GB（size_4g*2），顶部需预留
+	# vpp_size_add（FREERTOS 2M）。若校验用 vpp+vpp_size_add <= 8G 判定，
+	# 则实际可配上限 = 8G - vpp_size_add，打印必须与之保持一致，否则
+	# -p 报出的上限比真实可配多 2M（用户按打印值配置会被 -c 拒绝）。
+	vpp_max_size=$(($size_4g * 2 - $vpp_size_add))
 	echo "Info: max vpp size: $(printf "0x%x" $vpp_max_size) [$(printf "%d MiB" "$(($vpp_max_size / $SIZE1M))")]" | tee -a $log_file_path
 fi
 # 解析设备树，获取vpp和npu的ion内存空间的全局唯一索引

--- a/source/pmemory_edit/tests/check_max_size_consistency.sh
+++ b/source/pmemory_edit/tests/check_max_size_consistency.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# memory_edit -p 打印 vs 实际校验 一致性回归测试（CV84X6）
+#
+# 背景：CV84X6 环境下 -p 打印的 max vpp / max npu+vpp 比实际可配上限多 2M，
+# 根因是打印未减 vpp_size_add（FREERTOS 预留 2M），而 -c 校验减了。
+# 修复后打印与校验一致，-p 报出的上限即真实可配上限。
+#
+# 用法：
+#   MEMORY_EDIT_KIT=<kit 目录> \
+#     bash tests/check_max_size_consistency.sh
+#
+# kit 目录 = memory_edit 在目标机上解包后的工作目录，需含：
+#   <kit>/memory_edit.sh  <kit>/bintools/  <kit>/boot.itb
+#   <kit>/multi.its  <kit>/output/<dts>.dts
+# 可用真机 /data/.memedit/memory_edit 或 memory_edit.sh -d 生成的目录。
+#
+# 断言（无硬编码，全部由 -p 解析值推导，对不同 DDR 容量通用）：
+#   A. -c 用 max_vpp 提交必须通过（vpp 单项）
+#   B. -c 用 npu=max_npuvpp-4096, vpp=4096 提交必须通过（总量，vpp 在安全区）
+set -u
+
+KIT="${MEMORY_EDIT_KIT:-}"
+if [ -z "$KIT" ] || [ ! -f "$KIT/boot.itb" ] || [ ! -f "$KIT/multi.its" ]; then
+  echo "ERROR: 需要 MEMORY_EDIT_KIT=<kit 目录>（含 boot.itb + multi.its）" >&2
+  exit 2
+fi
+KIT=$(readlink -f "$KIT")
+
+# 在临时副本里跑，绝不污染真实 kit；memory_edit.sh 用本仓库源码覆盖 kit 自带版
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+cp -a "$KIT"/. "$TMP"/
+SRC=$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)
+cp -f "$SRC/source/memory_edit/memory_edit.sh" "$TMP/"
+cd "$TMP"
+
+# 记录 pristine dts（-c 会改写 output dts）
+PRISTINE=$(ls "$TMP"/output/*.dts 2>/dev/null | head -1)
+if [ -n "$PRISTINE" ]; then
+  cp -f "$PRISTINE" "$PRISTINE.pristine"
+fi
+restore_dts() {
+  if [ -n "$PRISTINE" ] && [ -f "$PRISTINE.pristine" ]; then
+    cp -f "$PRISTINE.pristine" "$PRISTINE"
+  fi
+}
+
+P_OUT=$(MEMORY_EDIT_ITB_FILE=./boot.itb MEMORY_EDIT_CHPI_TYPE=cv84x6 ./memory_edit.sh -p 2>&1)
+if ! echo "$P_OUT" | grep -q "max vpp size:"; then
+  echo "P 模式失败，输出尾部：" && echo "$P_OUT" | tail -15
+  exit 1
+fi
+MAX_VPP=$(echo "$P_OUT" | grep "Info: max vpp size:" | grep -oE "\[[0-9]+ MiB\]" | grep -oE "[0-9]+")
+MAX_NPUVPP=$(echo "$P_OUT" | grep "Info: max npu+vpp size:" | grep -oE "\[[0-9]+ MiB\]" | grep -oE "[0-9]+")
+echo "[-p 打印] max_vpp=$MAX_VPP MiB  max_npu+vpp=$MAX_NPUVPP MiB"
+
+# A. vpp 单项：用打印的 max_vpp 提交
+restore_dts
+echo "== A: vpp=$MAX_VPP MiB (npu=1024 MiB) =="
+A_OUT=$(MEMORY_EDIT_ITB_FILE=./boot.itb MEMORY_EDIT_CHPI_TYPE=cv84x6 ./memory_edit.sh -c -npu 1024 -vpu 0 -vpp "$MAX_VPP" 2>&1)
+if echo "$A_OUT" | grep -q "Error: vpp size"; then A=FAIL; else A=PASS; fi
+
+# B. 总量：npu=打印总量-4096, vpp=4096（vpp 远离单项上限，只测总量约束）
+restore_dts
+V_SUB=4096
+N_TOT=$((MAX_NPUVPP - V_SUB))
+echo "== B: npu=$N_TOT MiB vpp=$V_SUB MiB (npu+vpp = 打印总量) =="
+B_OUT=$(MEMORY_EDIT_ITB_FILE=./boot.itb MEMORY_EDIT_CHPI_TYPE=cv84x6 ./memory_edit.sh -c -npu "$N_TOT" -vpu 0 -vpp "$V_SUB" 2>&1)
+if echo "$B_OUT" | grep -q "Error:"; then B=FAIL; else B=PASS; fi
+
+echo "RESULT: A=[$A] B=[$B]"
+[ "$A" = PASS ] && [ "$B" = PASS ]


### PR DESCRIPTION
## 问题

CV84X6 (cv84x6) 环境下 `memory_edit -p` 打印的 max vpp / max npu+vpp 比实际可配置上限多 2M：

| 项 | -p 打印(修复前) | 实际校验上限 | 实测边界 |
|---|---|---|---|
| max vpp | 8192 MiB | 8190 MiB | 8190 过 / 8191 拒 |
| max npu+vpp | 30376 MiB | 30374 MiB | 30374 过 / 30375 拒 |

根因：`-p` 打印用的 `size_4g*2`（vpp）和 `ddr_size-npu_size_add`（总量）没有减掉 `vpp_size_add`（DDR 顶部预留 2M FREERTOS），而 `-c` 校验时是 `vpp+vpp_size_add<=8G` 与 `npu+vpp+vpp_size_add<=ddr_size`。bm1688 分支打印正确（已减 vpp_size_add），cv84x6 分支漏减。

效果：qt_memory_edit 与 memory_edit.sh 都按 `-p` 报 8192/30376，用户照此配置提交被 `-c` 拒绝。

## 修复

- `-p` 的 `max npu+vpp` 改为 `ddr_size - npu_size_add - vpp_size_add`（bm1688 的 vpp_size_add=0 不受影响）
- `-p` 的 cv84x6 `max vpp` 改为 `size_4g*2 - vpp_size_add`

修正后 `-p` 打印即真实可配上限，qt_memory_edit 因只解析 stdout 自动跟随修复。

## 验证

- 回归测试 `tests/check_max_size_consistency.sh`（TDD：先失败后通过，A/B 断言无硬编码、对不同 DDR 容量通用）
- 真机 CV84X6（SE13, 32G DDR）确认打印 8190/30374，边界 8190 过 / 8191 拒